### PR TITLE
Add radiation to hubble flow

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -86,6 +86,7 @@ OPT	+=  -DBH_USE_GASVEL_IN_BONDI  # only when this is enabled, the surrounding g
 
 
 #-------------------------------------------- Things for special behaviour
+OPT	+=  -DINCLUDE_RADIATION		# Add radiation density to backround evolution. Only affects the Hubble flow.
 #OPT	+=  -DTRADITIONAL_SPH_FORMULATION
 OPT	+=  -DNOTEST_FOR_IDUNIQUENESS
 #OPT	+=  -DSNIA_HEATING

--- a/allvars.h
+++ b/allvars.h
@@ -184,9 +184,44 @@ typedef uint64_t peanokey;
 #define  LOG_LAMBDA      37.8	/* logarithmic Coulomb factor */
 #endif
 
-#if defined(CHEMISTRY) || defined(UM_CHEMISTRY)
-#define  T_CMB0      2.728	/* present-day CMB temperature */
+#if defined(CHEMISTRY) || defined(UM_CHEMISTRY) || defined(INCLUDE_RADIATION)
+#define  T_CMB0      2.7255	/* present-day CMB temperature, from Fixsen 2009. */
 #endif
+
+/*With slightly relativistic massive neutrinos, for consistency we need to include radiation.
+ * A note on normalisation (as of 08/02/2012):
+ * CAMB appears to set Omega_Lambda + Omega_Matter+Omega_K = 1,
+ * calculating Omega_K in the code and specifying Omega_Lambda and Omega_Matter in the paramfile.
+ * This means that Omega_tot = 1+ Omega_r + Omega_g, effectively
+ * making h0 (very) slightly larger than specified.
+ */
+#ifdef INCLUDE_RADIATION
+/*Stefan-Boltzmann constant in cgs units*/
+#define STEFAN_BOLTZMANN 5.670373e-5
+/* Omega_g = 4 \sigma_B T_{CMB}^4 8 \pi G / (3 c^3 H^2)*/
+#define OMEGAG (4*STEFAN_BOLTZMANN*8*M_PI*GRAVITY/(3*C*C*C*HUBBLE*HUBBLE)*pow(T_CMB0,4)/All.HubbleParam/All.HubbleParam)
+#if defined NEUTRINOS
+    /*Neutrinos are massive and included elsewhere*/
+    #define OMEGAR OMEGAG
+#else
+    /* Note there is a slight correction from 4/11
+     * due to the neutrinos being slightly coupled at e+- annihilation.
+     * See Mangano et al 2005 (hep-ph/0506164)
+     *The correction is (3.046/3)^(1/4), for N_eff = 3.046 */
+    #define TNU     (T_CMB0*pow(4/11.,1/3.)*1.00328)              /* Neutrino + antineutrino background temperature in Kelvin */
+    /*Neutrinos are included in the radiation*/
+    /*For massless neutrinos, rho_nu/rho_g = 7/8 (T_nu/T_cmb)^4 *N_eff, but we absorbed N_eff into T_nu above*/
+    #define OMEGANU (OMEGAG*7/8.*pow(TNU/T_CMB0,4)*3)
+    /*With massless neutrinos only, add the neutrinos to the radiation*/
+    #define OMEGAR (OMEGAG+OMEGANU)
+#endif
+#else
+        /*Default is no radiation*/
+        #define OMEGAR 0.
+#endif
+
+/* For convenience define OMEGAK*/
+#define OMEGAK (1-All.Omega0 - All.OmegaLambda)
 
 #define  SEC_PER_MEGAYEAR   3.155e13
 #define  SEC_PER_YEAR       3.155e7

--- a/begrun.c
+++ b/begrun.c
@@ -411,6 +411,9 @@ void set_units(void)
         printf("Annihilation radiation units:\n");
         printf("UnitDensity_in_Gev_per_cm3 = %g\n", All.UnitDensity_in_Gev_per_cm3);
 #endif
+#ifdef INCLUDE_RADIATION
+      printf("Radiation density Omega_R = %g\n",OMEGAR);
+#endif
 
         printf("\n");
     }

--- a/darkenergy.c
+++ b/darkenergy.c
@@ -411,7 +411,11 @@ double INLINE_FUNC hubble_function(double a)
 #ifdef EXTERNALHUBBLE
   hubble_a = hubble_function_external(a);
 #else
-  hubble_a = All.Omega0 / (a * a * a) + (1 - All.Omega0 - All.OmegaLambda) / (a * a)
+  hubble_a = All.Omega0 / (a * a * a) + OMEGAK / (a * a)
+#ifdef INCLUDE_RADIATION
+  /*Note OMEGAR is defined to be 0 if INCLUDE_RADIATION is not on*/
+   + OMEGAR/(a*a*a*a)
+#endif
 #ifdef DARKENERGY
     + DarkEnergy_a(a);
 #else


### PR DESCRIPTION
This adds a new option, INCLUDE_RADIATION.
This defines OMEGAR, the background radiation density (photons and
neutrinos if they are massless) in allvars.h.

Then the radiation density is added to the Hubble flow as OMEGAR/a^4 in
darkenergy.c
