### PR TITLE
Call the header block 'Header' for compatibility with P-Gadget3 HDF5 output

### DIFF
--- a/fofpetaio.c
+++ b/fofpetaio.c
@@ -234,7 +234,7 @@ static void build_buffer_fof(BigArray * array, IOTableEntry * ent) {
 
 static void fof_write_header(BigFile * bf) {
     BigBlock bh = {0};
-    if(0 != big_file_mpi_create_block(bf, &bh, "header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
+    if(0 != big_file_mpi_create_block(bf, &bh, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
         endrun(0, "Failed to create header\n");
     }
     int i;

--- a/genic-save.c
+++ b/genic-save.c
@@ -103,8 +103,8 @@ static void saveblock(BigFile * bf, void * baseptr, char * name, char * dtype, i
 
 void saveheader(BigFile * bf) {
     BigBlock bheader;
-    if(0 != big_file_mpi_create_block(bf, &bheader, "header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
-        endrun(0, "failed to create block %s:%s", "header",
+    if(0 != big_file_mpi_create_block(bf, &bheader, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
+        endrun(0, "failed to create block %s:%s", "Header",
                 big_file_get_error_message());
     }
 
@@ -135,7 +135,7 @@ void saveheader(BigFile * bf) {
     }
 
     if(0 != big_block_mpi_close(&bheader, MPI_COMM_WORLD)) {
-        endrun(0, "failed to close block %s:%s", "header",
+        endrun(0, "failed to close block %s:%s", "Header",
                     big_file_get_error_message());
     }
 }

--- a/petaio.c
+++ b/petaio.c
@@ -231,8 +231,8 @@ extern const char * GADGETVERSION;
 /* write a header block */
 static void petaio_write_header(BigFile * bf) {
     BigBlock bh = {0};
-    if(0 != big_file_mpi_create_block(bf, &bh, "header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to create block at %s:%s\n", "header",
+    if(0 != big_file_mpi_create_block(bf, &bh, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
+        endrun(0, "Failed to create block at %s:%s\n", "Header",
                 big_file_get_error_message());
     }
     int i;
@@ -275,8 +275,8 @@ static void petaio_write_header(BigFile * bf) {
 
 static void petaio_read_header(BigFile * bf) {
     BigBlock bh = {0};
-    if(0 != big_file_mpi_open_block(bf, &bh, "header", MPI_COMM_WORLD)) {
-        endrun(0, "Failed to create block at %s:%s\n", "header",
+    if(0 != big_file_mpi_open_block(bf, &bh, "Header", MPI_COMM_WORLD)) {
+        endrun(0, "Failed to create block at %s:%s\n", "Header",
                     big_file_get_error_message());
     }
     double Time;


### PR DESCRIPTION
Currently the header block is called 'header' but in P-Gadget3 it is called 'Header'. 

This is an unnecessary compatibility hurdle with P-Gadget3. If we fix it now (also in the public version), before too many people are using this code, we will save ourselves a lot of effort in the long run!

This changes the output format, but an advantage of bigfile is that old
snapshots (and there are not that many of them) can also easily be changed.
