### PR TITLE
Small fixes and a small script

### DIFF
--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -140,9 +140,8 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     {
         while(no >= 0)
         {
-            double mass, facpot, fac, r2, r, h;
+            double mass, r2, h;
             double dx, dy, dz;
-            int otherh;
             if(node_is_particle(no))
             {
                 /*Hybrid particle neutrinos do not gravitate at early times*/
@@ -161,7 +160,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 mass = P[no].Mass;
 
                 h = input->Soft;
-                otherh = FORCE_SOFTENING(no);
+                const double otherh = FORCE_SOFTENING(no);
                 if(h < otherh)
                     h = otherh;
                 no = Nextnode[no];
@@ -247,7 +246,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 }
 
                 h = input->Soft;
-                otherh = nop->u.d.MaxSoftening;
+                const double otherh = nop->u.d.MaxSoftening;
                 if(h < otherh)
                 {
                     h = otherh;
@@ -265,7 +264,9 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
             }
 
-            r = sqrt(r2);
+            double facpot, fac;
+
+            const double r = sqrt(r2);
 
             if(r >= h)
             {

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -190,40 +190,30 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                     }
                 }
 
-                mass = nop->u.d.mass;
-
                 dx = NEAREST(nop->u.d.s[0] - pos_x);
                 dy = NEAREST(nop->u.d.s[1] - pos_y);
                 dz = NEAREST(nop->u.d.s[2] - pos_z);
 
                 r2 = dx * dx + dy * dy + dz * dz;
 
+                /*This checks the distance from the node center of mass*/
                 if(r2 > rcut2)
                 {
                     /* check whether we can stop walking along this branch */
                     const double eff_dist = rcut + 0.5 * nop->len;
-                    double dist = NEAREST(nop->center[0] - pos_x);
 
-                    if(dist < -eff_dist || dist > eff_dist)
-                    {
-                        no = nop->u.d.sibling;
-                        continue;
-                    }
-                    dist = NEAREST(nop->center[1] - pos_y);
-
-                    if(dist < -eff_dist || dist > eff_dist)
-                    {
-                        no = nop->u.d.sibling;
-                        continue;
-                    }
-                    dist = NEAREST(nop->center[2] - pos_z);
-
-                    if(dist < -eff_dist || dist > eff_dist)
+                    /*This checks whether we are also outside this region of the oct-tree*/
+                    if(fabs(NEAREST(nop->center[0] - pos_x)) > eff_dist ||
+                        fabs(NEAREST(nop->center[1] - pos_y)) > eff_dist ||
+                            fabs(NEAREST(nop->center[2] - pos_z)) > eff_dist
+                      )
                     {
                         no = nop->u.d.sibling;
                         continue;
                     }
                 }
+
+                mass = nop->u.d.mass;
 
                 /* check relative opening criterion */
                 if(mass * nop->len * nop->len > r2 * r2 * aold)

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -145,9 +145,6 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             int otherh;
             if(node_is_particle(no))
             {
-                /* the index of the node is the index of the particle */
-                drift_particle(no, All.Ti_Current);
-
                 /*Hybrid particle neutrinos do not gravitate at early times*/
                 if(All.HybridNeutrinosOn && All.Time <= All.HybridNuPartTime && P[no].Type == All.FastParticleType)
                 {

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -121,6 +121,8 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     MyDouble acc_y = 0;
     MyDouble acc_z = 0;
 
+    /*Hybrid particle neutrinos do not gravitate at early times*/
+    const int NeutrinoTracer = All.HybridNeutrinosOn && (All.Time <= All.HybridNuPartTime);
     /*Tree-opening constants*/
     const double rcut = RCUT * All.Asmth * All.BoxSize / All.Nmesh;
     const double rcut2 = rcut * rcut;
@@ -144,11 +146,13 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             double dx, dy, dz;
             if(node_is_particle(no))
             {
-                /*Hybrid particle neutrinos do not gravitate at early times*/
-                if(All.HybridNeutrinosOn && All.Time <= All.HybridNuPartTime && P[no].Type == All.FastParticleType)
+                if(NeutrinoTracer)
                 {
-                    no = Nextnode[no];
-                    continue;
+                    if(P[no].Type == All.FastParticleType)
+                    {
+                        no = Nextnode[no];
+                        continue;
+                    }
                 }
 
                 dx = NEAREST(P[no].Pos[0] - pos_x);

--- a/tools/plot-structure.py
+++ b/tools/plot-structure.py
@@ -1,0 +1,35 @@
+"""Quick script to plot an image of structure."""
+
+import argparse
+import os.path
+import numpy as np
+from nbodykit.lab import BigFileCatalog
+import matplotlib
+matplotlib.use('PDF')
+import matplotlib.pyplot as plt
+
+def plot_image(snapshot, dataset=1, colorbar=True, Nmesh=None):
+    """Make a pretty picture of the mass distribution."""
+    cat = BigFileCatalog(snapshot, dataset=str(dataset)+'/', header='Header')
+    if Nmesh is None:
+        Nmesh = 2*int(np.round(np.cbrt(cat.attrs['TotNumPart'][dataset])))
+    box = cat.attrs['BoxSize']/1000
+    mesh = cat.to_mesh(Nmesh=Nmesh)
+    plt.clf()
+    plt.imshow(np.log10(mesh.preview(axes=(0, 1))/Nmesh), extent=(0,box,0,box))
+    if colorbar:
+        plt.colorbar()
+    plt.xlabel("x (Mpc/h)")
+    plt.ylabel("y (Mpc/h)")
+    plt.tight_layout()
+    snap = os.path.basename(os.path.normpath(snapshot))
+    plt.savefig("dens-plt-type"+str(dataset)+snap+".pdf")
+    plt.clf()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('snapshot', type=str, help='snapshot directory')
+    parser.add_argument('--type', type=int, default=1, help='type of particle to plot',required=False)
+    parser.add_argument('--nmesh', type=int, default=None, help='mesh size',required=False)
+    args = parser.parse_args()
+    plot_image(args.snapshot, dataset=args.type, Nmesh=args.nmesh)


### PR DESCRIPTION
This fixes a type definition in gravshort, which could have led the force softening to be truncated if we every used mixed softenings (but we don't).

It also removes the drift_particle from gravshort, which did nothing but was surprisingly hot in a profile.

Finally it adds a short script which uses nbodykit to plot the structure in a box. Just to have it handy.