### PR TITLE
Knlfix

### DIFF
--- a/depends/install_pfft.sh
+++ b/depends/install_pfft.sh
@@ -3,7 +3,7 @@
 PREFIX="$1"
 shift
 OPTIMIZE="$*"
-OPTIMIZE1=`echo "$*" | sed -s 's;enable-sse2;enable-sse;'`
+OPTIMIZE1="$*"
 echo "Optimization for double" ${OPTIMIZE}
 echo "Optimization for single" ${OPTIMIZE1}
 

--- a/examples/dm-only/paramfile.genic
+++ b/examples/dm-only/paramfile.genic
@@ -20,6 +20,8 @@ WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
 # the file 'FileWithInputSpectrum'
 # otherwise, Eisenstein & Hu parametrization is used
 
+DifferentTransferFunctions = 0
+ScaleDepVelocity = 0
 FileWithInputSpectrum = ../powerspectrum-wmap9.txt  # filename of tabulated input
 # spectrum (if used)
 InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated

--- a/genic/params.c
+++ b/genic/params.c
@@ -158,9 +158,9 @@ void read_parameterfile(char *fname)
     if(All2.PowerP.DifferentTransferFunctions && All2.PowerP.InputPowerRedshift != Redshift
         && (All2.ProduceGas || All.CP.MNu[0] + All.CP.MNu[1] + All.CP.MNu[2]))
         message(0, "WARNING: Using different transfer functions but also rescaling power to account for linear growth. NOT what you want!\n");
-    if((All.CP.MNu[0] + All.CP.MNu[1] + All.CP.MNu[2] > 0) || All2.PowerP.DifferentTransferFunctions)
+    if((All.CP.MNu[0] + All.CP.MNu[1] + All.CP.MNu[2] > 0) || All2.PowerP.DifferentTransferFunctions || All2.PowerP.ScaleDepVelocity)
         if(0 == strlen(All2.PowerP.FileWithTransferFunction))
-            endrun(0,"For massive neutrinos or different transfer functions you must specify a transfer function file\n");
+            endrun(0,"For massive neutrinos, different transfer functions, or scale dependent growth functions you must specify a transfer function file\n");
     if(!All.CP.RadiationOn && (All.CP.MNu[0] + All.CP.MNu[1] + All.CP.MNu[2] > 0))
         endrun(0,"You want massive neutrinos but no background radiation: this will give an inconsistent cosmology.\n");
 

--- a/platform-options/Options.mk.stampede2
+++ b/platform-options/Options.mk.stampede2
@@ -1,0 +1,30 @@
+#Uncomment below to specify default options
+
+MPICC       =   mpicc
+MPICXX       =   mpic++
+
+# Stampede 2 KNL nodes use icc.
+# TACC_VEC_FLAGS define: -xCORE-AVX2 -axMIC-AVX512,CORE-AVX512 
+# which means the base instruction set is CORE-AVX2, and 
+# alternate versions of some routines are generated for KNL and SKX nodes.
+OPTIMIZE =  -fopenmp -O3 -g -Wall ${TACC_VEC_FLAGS} -fp-model fast=1
+
+GSL_INCL = $(shell pkg-config --cflags gsl)
+GSL_LIBS = $(shell pkg-config --libs gsl)
+
+#--------------------------------------- Basic operation mode of code
+OPT += -DDENSITY_INDEPENDENT_SPH
+#OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
+#OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
+#OPT += -DDEBUG      # print a lot of debugging messages
+
+# flags shall that always be there they need to be cleaned up
+OPT += -DOPENMP_USE_SPINLOCK
+OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
+
+#--------------------------------------- SFR/feedback model
+# Star formation master switch. Also enables the Wind model
+OPT	+=  -DSFR
+
+#-------------------------------------- AGN stuff
+OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)


### PR DESCRIPTION
This fixes an error in the parameter files since the scaledepgrowth merge, removes a dependency on gnu sed which caused problems for mac, and adds a platform option for stampede2 (icc-driven knl/skylake nodes).