### PR TITLE
Spinlockfix

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -17,8 +17,9 @@ OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
+#Disable openmp locking. This means no threading.
+#OPT += -DNO_OPENMP_SPINLOCK
 
 #--------------------------------------- SFR/feedback model
 # Star formation master switch. Also enables the Wind model

--- a/Options.mk.example
+++ b/Options.mk.example
@@ -18,8 +18,6 @@ OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -57,7 +57,12 @@ int main(int argc, char **argv)
 
     message(0, "This is MP-Gadget, version %s.\n", GADGET_VERSION);
     message(0, "Running on %d MPI Ranks.\n", NTask);
+#ifdef NO_OPENMP_SPINLOCK
+    message(0,"Code compiled with NO_OPENMP_SPINLOCK (no locks), so no OpenMP threads.\n");
+    omp_set_num_threads(1);
+#else
     message(0, "           %d OpenMP Threads.\n", omp_get_max_threads());
+#endif
     message(0, "Code was compiled with settings:\n"
            "%s\n", GADGET_COMPILER_SETTINGS);
     message(0, "Size of particle structure       %td  [bytes]\n",sizeof(struct particle_data));

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -12,8 +12,6 @@
 #include "partmanager.h"
 #include "utils.h"
 
-static int drift_particle_full(int i, inttime_t ti1, int blocking);
-
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
 
 #ifdef OPENMP_USE_SPINLOCK
@@ -26,48 +24,16 @@ void unlock_particle(int i) {
 #endif
 
 void drift_particle(int i, inttime_t ti1) {
-    drift_particle_full(i, ti1, 1);
-}
-int drift_particle_full(int i, inttime_t ti1, int blocking) {
-    if(P[i].Ti_drift == ti1) return 0 ;
+    if(P[i].Ti_drift == ti1) return;
 
-#ifdef OPENMP_USE_SPINLOCK
-    int lockstate;
-    if (blocking) {
-        lockstate = pthread_spin_lock(&P[i].SpinLock);
-    } else {
-        lockstate = pthread_spin_trylock(&P[i].SpinLock);
-    }
-    if(0 == lockstate) {
-        inttime_t ti0 = P[i].Ti_drift;
-        if(ti0 != ti1) {
-            const double ddrift = get_drift_factor(ti0, ti1);
-            real_drift_particle(i, ti1, ddrift);
+    lock_particle(i);
+    inttime_t ti0 = P[i].Ti_drift;
+    if(ti0 != ti1) {
+        const double ddrift = get_drift_factor(ti0, ti1);
+        real_drift_particle(i, ti1, ddrift);
 #pragma omp flush
-        }
-        pthread_spin_unlock(&P[i].SpinLock);
-        return 0;
-    } else {
-        if(blocking) {
-            endrun(99999, "This shall not happen. Why?");
-            return -1;
-        } else {
-            return -1;
-        }
     }
-
-#else
-    /* do not use SpinLock */
-#pragma omp critical (_driftparticle_)
-    {
-        inttime_t ti0 = P[i].Ti_drift;
-        if(ti0 != ti1) {
-            const double ddrift = get_drift_factor(ti0, ti1);
-            real_drift_particle(i, ti1, ddrift);
-        }
-    }
-    return 0;
-#endif
+    unlock_particle(i);
 }
 
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift)

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -14,14 +14,16 @@
 
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
 
-#ifdef OPENMP_USE_SPINLOCK
 void lock_particle(int i) {
+#ifndef NO_OPENMP_SPINLOCK
     pthread_spin_lock(&P[i].SpinLock);
+#endif
 }
 void unlock_particle(int i) {
+#ifndef NO_OPENMP_SPINLOCK
     pthread_spin_unlock(&P[i].SpinLock);
-}
 #endif
+}
 
 void drift_particle(int i, inttime_t ti1) {
     if(P[i].Ti_drift == ti1) return;

--- a/libgadget/partmanager.c
+++ b/libgadget/partmanager.c
@@ -28,7 +28,7 @@ particle_alloc_memory(int MaxPart)
      * (memory lock etc?)
      * */
     memset(P, 0, sizeof(struct particle_data) * MaxPart);
-#ifdef OPENMP_USE_SPINLOCK
+#ifndef NO_OPENMP_SPINLOCK
     {
         int i;
         for(i = 0; i < MaxPart; i ++) {

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -10,7 +10,7 @@
  */
 struct particle_data
 {
-#ifdef OPENMP_USE_SPINLOCK
+#ifndef NO_OPENMP_SPINLOCK
     pthread_spinlock_t SpinLock;
 #endif
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -810,9 +810,6 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
             if(lv->tw->type == TREEWALK_SPLIT && !(BINMASK(P[other].TimeBin) & lv->tw->bgmask))
                 continue;
 
-            if(lv->tw->type != TREEWALK_SPLIT) /* FIXME: get rid of this entirely */
-                drift_particle(other, All.Ti_Current);
-
             double dist;
 
             if(iter->symmetric == NGB_TREEFIND_SYMMETRIC) {

--- a/libgadget/utils/openmpsort.c
+++ b/libgadget/utils/openmpsort.c
@@ -34,6 +34,9 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
+/*Define for convenience*/
+typedef int(*__compar_fn_t)(const void *, const void *);
+
 struct msort_param
 {
   size_t s;

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -49,44 +49,20 @@ size_t sizemax(size_t a, size_t b);
 
 static inline int atomic_fetch_and_add(int * ptr, int value) {
     int k;
-#if _OPENMP >= 201107
 #pragma omp atomic capture
     {
       k = (*ptr);
       (*ptr)+=value;
     }
-#else
-#if defined(OPENMP_USE_SPINLOCK) && !defined(__INTEL_COMPILER)
-    k = __sync_fetch_and_add(ptr, value);
-#else /* non spinlock*/
-#pragma omp critical
-    {
-      k = (*ptr);
-      (*ptr)+=value;
-    }
-#endif
-#endif
     return k;
 }
 static inline int atomic_add_and_fetch(int * ptr, int value) {
     int k;
-#if _OPENMP >= 201107
 #pragma omp atomic capture
     {
       (*ptr)+=value;
       k = (*ptr);
     }
-#else
-#ifdef OPENMP_USE_SPINLOCK
-    k = __sync_add_and_fetch(ptr, value);
-#else /* non spinlock */
-#pragma omp critical
-    {
-      (*ptr)+=value;
-      k = (*ptr);
-    }
-#endif
-#endif
     return k;
 }
 

--- a/platform-options/Options.mk.BlueTides
+++ b/platform-options/Options.mk.BlueTides
@@ -19,9 +19,6 @@ GSL_LIBS = -L$(GSL_DIR)/lib -lgsl -lgslcblas
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/platform-options/Options.mk.cori
+++ b/platform-options/Options.mk.cori
@@ -18,31 +18,14 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #--------------------------------------- Basic operation mode of code
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-OPT += -DPETAPM_ORDER=1  # order of finite differentiation kernel 1 is same as gadget
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#--------------------------------------- Multi-Domain and Top-Level Tree options
-OPT	+=  -DTOPNODEFACTOR=5.0
-
-
-#--------------------------------------- Things that are always recommended
-#OPT	+=  -DCPUSPEEDADJUSTMENT
-#OPT	+=  -DHYDRO_COST_FACTOR=1000
-
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV
-OPT	+=  -DINHOMOG_GASDISTR_HINT         # if the gas is distributed very different from collisionless particles, this can helps to avoid problems in the domain decomposition -- increase All.MaxPartSph

--- a/platform-options/Options.mk.coriknl
+++ b/platform-options/Options.mk.coriknl
@@ -18,31 +18,16 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #--------------------------------------- Basic operation mode of code
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-OPT += -DPETAPM_ORDER=1  # order of finite differentiation kernel 1 is same as gadget
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
-#--------------------------------------- Multi-Domain and Top-Level Tree options
-OPT	+=  -DTOPNODEFACTOR=5.0
-
-
-#--------------------------------------- Things that are always recommended
-#OPT	+=  -DCPUSPEEDADJUSTMENT
-#OPT	+=  -DHYDRO_COST_FACTOR=1000
 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV
-OPT	+=  -DINHOMOG_GASDISTR_HINT         # if the gas is distributed very different from collisionless particles, this can helps to avoid problems in the domain decomposition -- increase All.MaxPartSph

--- a/platform-options/Options.mk.edison
+++ b/platform-options/Options.mk.edison
@@ -18,31 +18,16 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #--------------------------------------- Basic operation mode of code
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-OPT += -DPETAPM_ORDER=1  # order of finite differentiation kernel 1 is same as gadget
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
-#--------------------------------------- Multi-Domain and Top-Level Tree options
-OPT	+=  -DTOPNODEFACTOR=5.0
-
-
-#--------------------------------------- Things that are always recommended
-#OPT	+=  -DCPUSPEEDADJUSTMENT
-#OPT	+=  -DHYDRO_COST_FACTOR=1000
 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV
-OPT	+=  -DINHOMOG_GASDISTR_HINT         # if the gas is distributed very different from collisionless particles, this can helps to avoid problems in the domain decomposition -- increase All.MaxPartSph

--- a/platform-options/Options.mk.example.coma
+++ b/platform-options/Options.mk.example.coma
@@ -7,11 +7,8 @@ GSL_LIBS = -L/opt/gsl/impi/lib64 -lgsl -lgslcblas
 #--------------------------------------- Basic operation mode of code
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-OPT += -DPETAPM_ORDER=1  # order of finite differentiation kernel 1 is same as gadget
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/platform-options/Options.mk.example.icc
+++ b/platform-options/Options.mk.example.icc
@@ -17,8 +17,6 @@ OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/platform-options/Options.mk.pfe
+++ b/platform-options/Options.mk.pfe
@@ -9,11 +9,8 @@ GSL_LIBS = $(HOME)/anaconda3/envs/3.5/lib/libgsl.a $(HOME)/anaconda3/envs/3.5/li
 #--------------------------------------- Basic operation mode of code
 #OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-#OPT += -DPETAPM_ORDER=1  # order of finite differentiation kernel 1 is same as gadget
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 #OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/platform-options/Options.mk.stampede2
+++ b/platform-options/Options.mk.stampede2
@@ -18,8 +18,6 @@ OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -13,8 +13,6 @@ OPT += -DDEBUG
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 
-# flags shall that always be there they need to be cleaned up
-OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
@@ -25,5 +23,4 @@ OPT	+=  -DSFR
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 
 #-------------------------------------------- Things for special behaviour
-OPT	+=  -DINCLUDE_RADIATION		# Add radiation density to backround evolution. Only affects the Hubble flow.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV
+#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
This commit fixes #217 and should fix compilation on mac. OPENMP_USE_SPINLOCK is replaced by NO_OPENMP_SPINLOCK, which compiles and enforces that the code runs in single-threaded mode. Most of the diff is actually cleanups.