### PR TITLE
Fix the linear response neutrino code for class formatted transfer functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "radixsort"]
 	path = depends/mpsort
 	url = https://github.com/rainwoodman/MP-sort
-[submodule "kspace-neutrinos"]
-	path = libgadget/kspace-neutrinos
-	url = https://github.com/sbird/kspace-neutrinos

--- a/benchmarks/dm-50-512/paramfile.genic
+++ b/benchmarks/dm-50-512/paramfile.genic
@@ -15,16 +15,7 @@ Redshift = 99        # Starting redshift
 
 Sigma8 = 0.810      # power spectrum normalization
 
-WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
-# "2" selects a tabulated power spectrum in
-# the file 'FileWithInputSpectrum'
-# otherwise, Eisenstein & Hu parametrization is used
-
-FileWithInputSpectrum = @PREFIX@/powerspectrum-wmap9.txt  # filename of tabulated input
-# spectrum (if used)
-InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated
-# input spectrum in cm/h. 
-# Note: This can be chosen different from UnitLength_in_cm
+FileWithInputSpectrum = @PREFIX@/powerspectrum-wmap9.txt
 
 Seed = 181170    #  seed for IC-generator
 

--- a/examples/dm-only/paramfile.genic
+++ b/examples/dm-only/paramfile.genic
@@ -16,15 +16,12 @@ Redshift = 49        # Starting redshift
 Sigma8 = 0.810      # power spectrum normalization
 
 WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
-# "2" selects a tabulated power spectrum in
+# "2" selects a tabulated power spectrum (in Mpc/h units) in
 # the file 'FileWithInputSpectrum'
 # otherwise, Eisenstein & Hu parametrization is used
 
 FileWithInputSpectrum = ../powerspectrum-wmap9.txt  # filename of tabulated input
 # spectrum (if used)
-InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated
-# input spectrum in cm/h. 
-# Note: This can be chosen different from UnitLength_in_cm
 
 PrimordialIndex = 0.971 # may be used to tilt the primordial index
 

--- a/examples/fastpm-compat/paramfile.genic
+++ b/examples/fastpm-compat/paramfile.genic
@@ -15,9 +15,8 @@ Redshift = 9        # Starting redshift
 
 UsePeculiarVelocity = 1
 
-
-FileWithInputSpectrum = planck_camb_56106182_matterpower_z0.dat  # filename of tabulated input
-InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated
+ # filename of tabulated input in Mpc/h units
+FileWithInputSpectrum = planck_camb_56106182_matterpower_z0.dat
 
 Seed = 181170    #  seed for IC-generator
 

--- a/examples/hydro/paramfile.genic
+++ b/examples/hydro/paramfile.genic
@@ -24,11 +24,10 @@ WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
 
 
 DifferentTransferFunctions = 1
+#Tabulated output in Mpc/h units.
 FileWithInputSpectrum = ../class_pk_99.dat  # filename of tabulated input spectrum (if used)
 FileWithTransferFunction = ../class_tk_99.dat  # filename of transfer functions for different species
 
-InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated
-                                                                   # input spectrum in cm/h. 
                                     # Note: This can be chosen different from UnitLength_in_cm
 # Only used by the CLASS script.
 PrimordialAmp = 2.215e-9

--- a/examples/linear_growth/paramfile.genic
+++ b/examples/linear_growth/paramfile.genic
@@ -25,6 +25,7 @@ PrimordialAmp = 2.142e-11
 
 DifferentTransferFunctions = 1
 ScaleDepVelocity = 1
+# tabulated input spectrum in Mpc/h units 
 FileWithInputSpectrum = linear_growth_matterpow.dat
 FileWithTransferFunction = linear_growth_transfer.dat
 UnitaryAmplitude = 1
@@ -34,8 +35,6 @@ MNue = 0.0
 MNum = 0.0
 MNut = 0.0
 
-# defines length unit of tabulated input spectrum in cm/h. 
-InputSpectrum_UnitLength_in_cm  = 3.085678e24 
 UnitLength_in_cm = 3.085678e21   # defines length unit of output (in cm/h) 
 UnitMass_in_g = 1.989e43      # defines mass unit of output (in g/cm)
 UnitVelocity_in_cm_per_s = 1e5 # defines velocity unit of output (in cm/sec)

--- a/examples/lya/paramfile.genic
+++ b/examples/lya/paramfile.genic
@@ -24,13 +24,9 @@ WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
 		                   # "2" selects a tabulated power spectrum in
                            # the file 'FileWithInputSpectrum'
                            # otherwise, Efstathiou parametrization is used
-
-FileWithInputSpectrum = ../class_pk_99.dat  # filename of tabulated input
-                                                                   # spectrum (if used)
+ # filename of tabulated input spectrum in Mpc/h units
+FileWithInputSpectrum = ../class_pk_99.dat 
 FileWithTransferFunction = ../class_tk_99.dat
-InputSpectrum_UnitLength_in_cm  = 3.085678e24 # defines length unit of tabulated
-                                                                   # input spectrum in cm/h. 
-                                                # Note: This can be chosen different from UnitLength_in_cm
 
 PrimordialIndex = 0.971
 PrimordialAmp = 2.215e-9

--- a/examples/neutrinos/paramfile.gadget
+++ b/examples/neutrinos/paramfile.gadget
@@ -34,7 +34,7 @@ BufferSize = 100          # in MByte
 
 #Massive neutrinos
 MassiveNuLinRespOn = 1
-LinearTransferFunction = camb_transfer_nu_99.dat
+LinearTransferFunction = class_tk_nu_99.dat
 
 MNue = 0.133333333333
 MNum = 0.133333333333

--- a/examples/neutrinos/paramfile.genic
+++ b/examples/neutrinos/paramfile.genic
@@ -22,12 +22,9 @@ WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
 # otherwise, Eisenstein & Hu parametrization is used
 
 DifferentTransferFunctions = 1
+#Power spectra in Mpc/h units
 FileWithTransferFunction = class_tk_nu_99.dat
-FileWithInputSpectrum = class_pk_nu_99.dat      # filename of tabulated input
-# spectrum (if used)
-InputSpectrum_UnitLength_in_cm = 3.085678e24 # defines length unit of tabulated
-# input spectrum in cm/h. 
-# Note: This can be chosen different from UnitLength_in_cm
+FileWithInputSpectrum = class_pk_nu_99.dat
 
 PrimordialIndex = 1. # may be used to tilt the primordial index
 

--- a/examples/small/paramfile.genic
+++ b/examples/small/paramfile.genic
@@ -26,13 +26,8 @@ WhichSpectrum = 2         # "1" selects Eisenstein & Hu spectrum,
                            # the file 'FileWithInputSpectrum'
                            # otherwise, Efstathiou parametrization is used
 
-
-FileWithInputSpectrum = ../powerspectrum-wmap9.txt  # filename of tabulated input
-                                                                   # spectrum (if used)
-InputSpectrum_UnitLength_in_cm = 3.085678e24                     # defines length unit of tabulated
-                                                                   # input spectrum in cm/h. 
-                                                # Note: This can be chosen different from UnitLength_in_cm
-    
+# filename of tabulated input in Mpc/h
+FileWithInputSpectrum = ../powerspectrum-wmap9.txt
 
 PrimordialIndex = 0.971      # may be used to tilt the primordial index
 

--- a/examples/travis/paramfile.genic
+++ b/examples/travis/paramfile.genic
@@ -16,14 +16,10 @@ HubbleParam = 0.7      # Hubble paramater (may be used for power spec parameteri
 
 Redshift = 99        # Starting redshift
 
-FileWithInputSpectrum = class_pk_99.dat   # filename of tabulated input
-                                       # spectrum (if used)
+# filename of tabulated input in Mpc/h
+FileWithInputSpectrum = class_pk_99.dat
 FileWithTransferFunction = class_tk_99.dat
 DifferentTransferFunctions = 1
-
-InputSpectrum_UnitLength_in_cm = 3.085678e24                     # defines length unit of tabulated
-                                                                   # input spectrum in cm/h. 
-                                                # Note: This can be chosen different from UnitLength_in_cm
 
 UsePeculiarVelocity = 1  # Use peculiar velocity like FastPM
 

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -20,6 +20,11 @@
 
 #include "params.h"
 
+void gsl_handler (const char * reason, const char * file, int line, int gsl_errno)
+{
+    endrun(2001,"GSL_ERROR in file: %s, line %d, errno:%d, error: %s\n",file, line, gsl_errno, reason);
+}
+
 /*! \file main.c
  *  \brief start of the program
  */
@@ -92,6 +97,9 @@ int main(int argc, char **argv)
         RestartSnapNum = find_last_snapnum();
         message(1, "Last Snapshot number is %d.\n", RestartSnapNum);
     }
+
+    /*Set up GSL so it gives a proper MPI termination*/
+    gsl_set_error_handler(gsl_handler);
 
     mymalloc_init(All.MaxMemSizePerNode);
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -490,7 +490,6 @@ void read_parameter_file(char *fname)
         /*Massive neutrino parameters*/
         All.MassiveNuLinRespOn = param_get_int(ps, "MassiveNuLinRespOn");
         All.HybridNeutrinosOn = param_get_int(ps, "HybridNeutrinosOn");
-        All.CAMBInputSpectrum_UnitLength_in_cm = param_get_double(ps, "InputSpectrum_UnitLength_in_cm");
         All.CP.MNu[0] = param_get_double(ps, "MNue");
         All.CP.MNu[1] = param_get_double(ps, "MNum");
         All.CP.MNu[2] = param_get_double(ps, "MNut");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -300,7 +300,7 @@ create_gadget_parameter_set()
     param_declare_int(ps, "MassiveNuLinRespOn", REQUIRED, 0, "Enables linear response massive neutrinos of 1209.0461. Make sure you enable radiation too.");
     param_declare_int(ps, "HybridNeutrinosOn", OPTIONAL, 0, "Enables hybrid massive neutrinos, where some density is followed analytically, and some with particles. Requires MassivenuLinRespOn");
     param_declare_string(ps, "LinearTransferFunction", OPTIONAL, "camb_transfer_99.dat", "File containing linear transfer function in CAMB format. Used for massive neutrinos.");
-    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", OPTIONAL, 3.085678e24, "Units of the CAMB transfer function in cm. By default Mpc.");
+    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", OPTIONAL, CM_PER_MPC, "Units of the CAMB transfer function in cm. By default Mpc.");
     param_declare_double(ps, "MNue", OPTIONAL, 0, "First neutrino mass in eV.");
     param_declare_double(ps, "MNum", OPTIONAL, 0, "Second neutrino mass in eV.");
     param_declare_double(ps, "MNut", OPTIONAL, 0, "Third neutrino mass in eV.");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -300,7 +300,7 @@ create_gadget_parameter_set()
     param_declare_int(ps, "MassiveNuLinRespOn", REQUIRED, 0, "Enables linear response massive neutrinos of 1209.0461. Make sure you enable radiation too.");
     param_declare_int(ps, "HybridNeutrinosOn", OPTIONAL, 0, "Enables hybrid massive neutrinos, where some density is followed analytically, and some with particles. Requires MassivenuLinRespOn");
     param_declare_string(ps, "LinearTransferFunction", OPTIONAL, "camb_transfer_99.dat", "File containing linear transfer function in CAMB format. Used for massive neutrinos.");
-    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", OPTIONAL, CM_PER_MPC, "Units of the CAMB transfer function in cm. By default Mpc.");
+    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", OPTIONAL, CM_PER_MPC, "Units of the CAMB transfer function in cm/h. By default Mpc/h.");
     param_declare_double(ps, "MNue", OPTIONAL, 0, "First neutrino mass in eV.");
     param_declare_double(ps, "MNum", OPTIONAL, 0, "Second neutrino mass in eV.");
     param_declare_double(ps, "MNut", OPTIONAL, 0, "Third neutrino mass in eV.");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -490,7 +490,6 @@ void read_parameter_file(char *fname)
         /*Massive neutrino parameters*/
         All.MassiveNuLinRespOn = param_get_int(ps, "MassiveNuLinRespOn");
         All.HybridNeutrinosOn = param_get_int(ps, "HybridNeutrinosOn");
-        param_get_string2(ps, "LinearTransferFunction", All.CAMBTransferFunction);
         All.CAMBInputSpectrum_UnitLength_in_cm = param_get_double(ps, "InputSpectrum_UnitLength_in_cm");
         All.CP.MNu[0] = param_get_double(ps, "MNue");
         All.CP.MNu[1] = param_get_double(ps, "MNum");

--- a/genic/main.c
+++ b/genic/main.c
@@ -181,8 +181,8 @@ void print_spec(void)
 
       fprintf(fd, "# %12g %12g\n", 1/All.TimeIC-1, DDD);
       /* print actual starting redshift and linear growth factor for this cosmology */
-      kstart = 2 * M_PI / (2*All.BoxSize * (3.085678e24 / All.UnitLength_in_cm));	/* 2x box size Mpc/h */
-      kend = 2 * M_PI / (All.BoxSize/(8*All2.Ngrid) * (3.085678e24 / All.UnitLength_in_cm));	/* 1/8 mean spacing Mpc/h */
+      kstart = 2 * M_PI / (2*All.BoxSize * (CM_PER_MPC / All.UnitLength_in_cm));	/* 2x box size Mpc/h */
+      kend = 2 * M_PI / (All.BoxSize/(8*All2.Ngrid) * (CM_PER_MPC / All.UnitLength_in_cm));	/* 1/8 mean spacing Mpc/h */
 
       message(1,"kstart=%lg kend=%lg\n",kstart,kend);
 

--- a/genic/main.c
+++ b/genic/main.c
@@ -78,10 +78,10 @@ int main(int argc, char **argv)
   /*Use 'total' (CDM + baryon) transfer function
    * unless DifferentTransferFunctions are on.
    */
-  int DMType = 3, GasType = 3, NuType = 2;
+  enum TransferType DMType = DELTA_CB, GasType = DELTA_CB, NuType = DELTA_NU;
   if(All2.ProduceGas && All2.PowerP.DifferentTransferFunctions) {
-      DMType = 1;
-      GasType = 0;
+      DMType = DELTA_CDM;
+      GasType = DELTA_BAR;
   }
 
   /*First compute and write CDM*/
@@ -188,7 +188,7 @@ void print_spec(void)
 
       for(k = kstart; k < kend; k *= 1.025)
 	  {
-	    double po = pow(DeltaSpec(k, -1),2);
+	    double po = pow(DeltaSpec(k, DELTA_TOT),2);
 	    fprintf(fd, "%12g %12g\n", k, po);
 	  }
       fclose(fd);

--- a/genic/main.c
+++ b/genic/main.c
@@ -71,6 +71,10 @@ int main(int argc, char **argv)
     message(0,"F-D velocity scale: %g. Max particle vel: %g. Fraction of mass in particles: %g\n",v_th*sqrt(All.TimeIC), All2.Max_nuvel*sqrt(All.TimeIC), total_nufrac);
   }
   saveheader(&bf, TotNumPart, TotNu, total_nufrac);
+
+  /*Save the transfer functions*/
+  save_all_transfer_tables(&bf, ThisTask);
+
   /*Use 'total' (CDM + baryon) transfer function
    * unless DifferentTransferFunctions are on.
    */

--- a/genic/params.c
+++ b/genic/params.c
@@ -58,9 +58,9 @@ create_parameters()
     param_declare_double(ps, "PrimordialIndex", OPTIONAL, 0.971, "Tilting power, ignored for tabulated input.");
 
     param_declare_double(ps, "UnitVelocity_in_cm_per_s", OPTIONAL, 1e5, "Velocity unit in cm/sec. Default is 1 km/s");
-    param_declare_double(ps, "UnitLength_in_cm", OPTIONAL, 3.085678e21, "Length unit in cm. Default is 1 kpc");
+    param_declare_double(ps, "UnitLength_in_cm", OPTIONAL, CM_PER_MPC/1000, "Length unit in cm. Default is 1 kpc");
     param_declare_double(ps, "UnitMass_in_g", OPTIONAL, 1.989e43, "Mass unit in g. Default is 10^10 M_sun.");
-    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", REQUIRED, 3.085678e24, "Length unit of input power spectrum file in cm. Default is 1 Mpc");
+    param_declare_double(ps, "InputSpectrum_UnitLength_in_cm", OPTIONAL, CM_PER_MPC, "Length unit of input power spectrum file in cm. Default is 1 Mpc");
 
     param_declare_int(ps, "NumPartPerFile", OPTIONAL, 1024 * 1024 * 128, "");
     param_declare_int(ps, "NumWriters", OPTIONAL, 0, "");

--- a/genic/params.c
+++ b/genic/params.c
@@ -132,7 +132,7 @@ void read_parameterfile(char *fname)
     All2.PowerP.DifferentTransferFunctions = param_get_int(ps, "DifferentTransferFunctions");
     All2.PowerP.ScaleDepVelocity = param_get_int(ps, "ScaleDepVelocity");
     All2.PowerP.WhichSpectrum = param_get_int(ps, "WhichSpectrum");
-    All2.PowerP.SpectrumLengthScale = param_get_double(ps, "InputSpectrum_UnitLength_in_cm") / All.UnitLength_in_cm;
+    All2.PowerP.SpectrumLengthScale = CM_PER_MPC / All.UnitLength_in_cm;
     All2.PowerP.PrimordialIndex = param_get_double(ps, "PrimordialIndex");
 
     /*Simulation parameters*/

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -34,7 +34,6 @@ INCL = config.h densitykernel.h \
 	walltime.h \
 	neutrinos_lra.h \
 	kspace-neutrinos/omega_nu_single.h \
-	kspace-neutrinos/delta_tot_table.h \
 utils/peano.h \
 utils/interp.h \
 utils/paramset.h \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -33,7 +33,7 @@ INCL = config.h densitykernel.h \
 	timestep.h  \
 	walltime.h \
 	neutrinos_lra.h \
-	kspace-neutrinos/omega_nu_single.h \
+	omega_nu_single.h \
 utils/peano.h \
 utils/interp.h \
 utils/paramset.h \
@@ -54,6 +54,7 @@ TESTED = hci \
 	forcetree \
 	timefac \
 	timebinmgr \
+	omega_nu_single \
 	exchange
 
 MPI_TESTED = exchange
@@ -92,7 +93,7 @@ GADGET_OBJS =  \
 	 densitykernel.o lightcone.o walltime.o\
 	 runtests.o \
 	 neutrinos_lra.o \
-     kspace-neutrinos/omega_nu_single.o \
+     omega_nu_single.o \
 
 GADGET_UTILS_OBJS= \
 utils/endrun.o \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -93,7 +93,6 @@ GADGET_OBJS =  \
 	 runtests.o \
      kspace-neutrinos/omega_nu_single.o \
      kspace-neutrinos/delta_tot_table.o \
-     kspace-neutrinos/transfer_init.o
 
 GADGET_UTILS_OBJS= \
 utils/endrun.o \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -32,6 +32,7 @@ INCL = config.h densitykernel.h \
 	powerspectrum.h  \
 	timestep.h  \
 	walltime.h \
+	neutrinos_lra.h \
 	kspace-neutrinos/omega_nu_single.h \
 	kspace-neutrinos/delta_tot_table.h \
 utils/peano.h \
@@ -91,6 +92,7 @@ GADGET_OBJS =  \
 	 petapm.o gravity.o \
 	 densitykernel.o lightcone.o walltime.o\
 	 runtests.o \
+	 neutrinos_lra.o \
      kspace-neutrinos/omega_nu_single.o \
      kspace-neutrinos/delta_tot_table.o \
 

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -54,6 +54,7 @@ TESTED = hci \
 	forcetree \
 	timefac \
 	timebinmgr \
+	neutrinos_lra \
 	omega_nu_single \
 	exchange
 
@@ -119,6 +120,9 @@ all: libgadget.a libgadget-utils.a
 	$(MPICC) $(CFLAGS) -I../tests/ $^ $(LIBS) -o $@
 
 .objs/test_%: tests/test_%.c .objs/%.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
+	$(MPICC) $(CFLAGS) -I../tests/ $^ $(LIBS) -o $@
+
+.objs/test_neutrinos_lra: tests/test_neutrinos_lra.c .objs/neutrinos_lra.o .objs/cosmology.o .objs/omega_nu_single.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(CFLAGS) -I../tests/ $^ $(LIBS) -o $@
 
 build-tests: $(TESTBIN)

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -94,7 +94,6 @@ GADGET_OBJS =  \
 	 runtests.o \
 	 neutrinos_lra.o \
      kspace-neutrinos/omega_nu_single.o \
-     kspace-neutrinos/delta_tot_table.o \
 
 GADGET_UTILS_OBJS= \
 utils/endrun.o \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -92,7 +92,7 @@ GADGET_OBJS =  \
 	 densitykernel.o lightcone.o walltime.o\
 	 runtests.o \
      kspace-neutrinos/omega_nu_single.o \
-     kspace-neutrinos/delta_pow.o kspace-neutrinos/delta_tot_table.o \
+     kspace-neutrinos/delta_tot_table.o \
      kspace-neutrinos/transfer_init.o
 
 GADGET_UTILS_OBJS= \

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -248,7 +248,6 @@ extern struct global_data_all_processes
     double HybridVcrit; /*!< Critical velocity switching between particle
                           and analytic solvers when hybrid neutrinos are on*/
     double HybridNuPartTime; /*!< Redshift at which hybrid neutrinos switch on*/
-    char CAMBTransferFunction[512]; /*!< CAMB transfer function for initial neutrino power*/
     double CAMBInputSpectrum_UnitLength_in_cm; /*!< Units of CAMB transfer function*/
 
     enum StarformationCriterion StarformationCriterion;  /*!< flags that star formation is enabled */

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -248,7 +248,6 @@ extern struct global_data_all_processes
     double HybridVcrit; /*!< Critical velocity switching between particle
                           and analytic solvers when hybrid neutrinos are on*/
     double HybridNuPartTime; /*!< Redshift at which hybrid neutrinos switch on*/
-    double CAMBInputSpectrum_UnitLength_in_cm; /*!< Units of CAMB transfer function*/
 
     enum StarformationCriterion StarformationCriterion;  /*!< flags that star formation is enabled */
     enum WindModel WindModel;  /*!< flags that star formation is enabled */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -219,8 +219,8 @@ void blackhole(void)
         double mdot_in_msun_per_year =
             total_mdot * (All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR);
 
-        total_mdoteddington *= 1.0 / ((4 * M_PI * GRAVITY * C * PROTONMASS /
-                    (0.1 * C * C * THOMPSON)) * All.UnitTime_in_s);
+        total_mdoteddington *= 1.0 / ((4 * M_PI * GRAVITY * LIGHTCGS * PROTONMASS /
+                    (0.1 * LIGHTCGS * LIGHTCGS * THOMPSON)) * All.UnitTime_in_s);
 
         fprintf(FdBlackHoles, "%g %d %g %g %g %g\n",
                 All.Time, SlotsManager->info[5].size, total_mass_holes, total_mdot, mdot_in_msun_per_year, total_mdoteddington);
@@ -264,7 +264,7 @@ blackhole_accretion_postprocess(int i, TreeWalk * tw)
     double soundspeed = blackhole_soundspeed(BHP(i).Entropy, BHP(i).Pressure, rho);
 
     /* Note: we take here a radiative efficiency of 0.1 for Eddington accretion */
-    double meddington = (4 * M_PI * GRAVITY * C * PROTONMASS / (0.1 * C * C * THOMPSON)) * BHP(i).Mass
+    double meddington = (4 * M_PI * GRAVITY * LIGHTCGS * PROTONMASS / (0.1 * LIGHTCGS * LIGHTCGS * THOMPSON)) * BHP(i).Mass
         * All.UnitTime_in_s;
 
     double norm = pow((pow(soundspeed, 2) + pow(bhvel, 2)), 1.5);
@@ -685,7 +685,7 @@ blackhole_feedback_copy(int i, TreeWalkQueryBHFeedback * I, TreeWalk * tw)
     double dtime = get_dloga_for_bin(P[i].TimeBin) / All.cf.hubble;
 
     I->FeedbackEnergy = All.BlackHoleFeedbackFactor * 0.1 * BHP(i).Mdot * dtime *
-                pow(C / All.UnitVelocity_in_cm_per_s, 2);
+                pow(LIGHTCGS / All.UnitVelocity_in_cm_per_s, 2);
 }
 
 static void

--- a/libgadget/cosmology.c
+++ b/libgadget/cosmology.c
@@ -31,7 +31,7 @@ void init_cosmology(Cosmology * CP_in, const double TimeBegin)
     CP->OmegaG = 4 * STEFAN_BOLTZMANN
                   * pow(CP->CMBTemperature, 4)
                   * (8 * M_PI * GRAVITY)
-                  / (3*C*C*C*HUBBLE*HUBBLE)
+                  / (3*pow(LIGHTCGS, 3)*HUBBLE*HUBBLE)
                   / (CP->HubbleParam*CP->HubbleParam);
 
     init_omega_nu(&CP->ONu, CP->MNu, TimeBegin, CP->HubbleParam, CP->CMBTemperature);

--- a/libgadget/cosmology.h
+++ b/libgadget/cosmology.h
@@ -2,7 +2,7 @@
 #define COSMOLOGY_H
 
 #include <stddef.h>
-#include "kspace-neutrinos/omega_nu_single.h"
+#include "omega_nu_single.h"
 
 typedef struct {
     double CMBTemperature;

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -13,14 +13,10 @@
 #include "domain.h"
 
 #include "cosmology.h"
-#include "kspace-neutrinos/delta_tot_table.h"
+#include "neutrinos_lra.h"
 
 /*Global variable to store power spectrum*/
 struct _powerspectrum PowerSpectrum;
-
-/*Structure which holds the neutrino state*/
-_delta_tot_table delta_tot_table;
-_transfer_init_table t_init;
 
 static int pm_mark_region_for_node(int startno, int rid);
 static void convert_node_to_region(PetaPMRegion * r);
@@ -292,68 +288,6 @@ static double sinc_unnormed(double x) {
     }
 }
 
-/* Constructor for delta_tot. Does some sanity checks and initialises delta_nu_last.*/
-static void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[])
-{
-    int ik;
-    if(nk_in > d_tot->nk_allocated){
-           endrun(2011,"input power of %d is longer than memory of %d\n",nk_in,d_tot->nk_allocated);
-    }
-    if(d_tot->nk != nk_in)
-        endrun(201, "Number of neutrino bins %d != stored value %d\n",nk_in, d_tot->nk);
-
-    /*Set the wave number*/
-    for(ik=0;ik<d_tot->nk;ik++){
-        d_tot->wavenum[ik] = wavenum[ik];
-    }
-    /*Initialise delta_nu_last*/
-    get_delta_nu_combined(d_tot, exp(d_tot->scalefact[d_tot->ia-1]), wavenum, d_tot->delta_nu_last);
-    d_tot->delta_tot_init_done=1;
-    return;
-}
-
-/* Constructor. transfer_init_tabulate must be called before this function.
- * Initialises delta_tot (including from a file) and delta_nu_init from the transfer functions.
- * read_all_nu_state must be called before this if you want reloading from a snapshot to work
- * Note delta_cdm_curr includes baryons, and is only used if not resuming.*/
-static void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const _transfer_init_table * const t_init)
-{
-    int ik;
-    if(nk_in > d_tot->nk_allocated){
-           endrun(2011,"input power of %d is longer than memory of %d\n",nk_in,d_tot->nk_allocated);
-    }
-    d_tot->nk=nk_in;
-    const double OmegaNua3=get_omega_nu_nopart(d_tot->omnu, d_tot->TimeTransfer)*pow(d_tot->TimeTransfer,3);
-    const double OmegaNu1 = get_omega_nu(d_tot->omnu, 1);
-    gsl_interp_accel *acc = gsl_interp_accel_alloc();
-    gsl_interp * spline=gsl_interp_alloc(gsl_interp_cspline,t_init->NPowerTable);
-    gsl_interp_init(spline,t_init->logk,t_init->T_nu,t_init->NPowerTable);
-    /*Check we have a long enough power table*/
-    if(log(wavenum[d_tot->nk-1]) > t_init->logk[t_init->NPowerTable-1])
-        endrun(2,"Want k = %g but maximum in CAMB table is %g\n",wavenum[d_tot->nk-1], exp(t_init->logk[t_init->NPowerTable-1]));
-    for(ik=0;ik<d_tot->nk;ik++) {
-            /* T_nu contains T_nu / T_cdm.*/
-            double T_nubyT_nonu = gsl_interp_eval(spline,t_init->logk,t_init->T_nu,log(wavenum[ik]),acc);
-            /*Initialise delta_nu_init to use the first timestep's delta_cdm_curr
-             * so that it includes potential Rayleigh scattering. */
-            d_tot->delta_nu_init[ik] = delta_cdm_curr[ik]*T_nubyT_nonu;
-            const double partnu = particle_nu_fraction(&d_tot->omnu->hybnu, All.TimeIC, 0);
-            /*Initialise the first delta_tot*/
-            d_tot->delta_tot[ik][0] = get_delta_tot(d_tot->delta_nu_init[ik], delta_cdm_curr[ik], OmegaNua3, d_tot->Omeganonu, OmegaNu1, partnu);
-            d_tot->wavenum[ik] = wavenum[ik];
-    }
-    gsl_interp_accel_free(acc);
-    gsl_interp_free(spline);
-
-    /*If we are not restarting, make sure we set the scale factor*/
-    d_tot->scalefact[0]=log(All.TimeIC);
-    d_tot->ia=1;
-    /*Initialise delta_nu_last*/
-    get_delta_nu_combined(d_tot, exp(d_tot->scalefact[0]), wavenum, d_tot->delta_nu_last);
-    d_tot->delta_tot_init_done=1;
-    return;
-}
-
 /* Compute neutrino power spectrum.
  * This should happen after the CFT is computed,
  * and after powerspectrum_add_mode() has been called,
@@ -377,7 +311,7 @@ static void compute_neutrino_power() {
         if(delta_tot_table.ia > 0)
             delta_tot_resume(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk);
         else
-            delta_tot_first_init(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Power, &t_init);
+            delta_tot_first_init(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Power, &t_init, All.TimeIC);
     }
     const double partnu = particle_nu_fraction(&All.CP.ONu.hybnu, All.Time, 0);
     if(1 - partnu > 1e-3) {

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -306,7 +306,7 @@ static void compute_neutrino_power() {
     /*Initialize the interpolation for the neutrinos*/
     PowerSpectrum.nu_spline = gsl_interp_alloc(gsl_interp_linear,PowerSpectrum.nonzero);
     PowerSpectrum.nu_acc = gsl_interp_accel_alloc();
-    gsl_interp_init(PowerSpectrum.nu_spline,PowerSpectrum.logknu,PowerSpectrum.Pnuratio,PowerSpectrum.nonzero);
+    gsl_interp_init(PowerSpectrum.nu_spline,PowerSpectrum.logknu,PowerSpectrum.delta_nu_ratio,PowerSpectrum.nonzero);
     /*Zero power spectrum, which is stored with the neutrinos*/
     powerspectrum_zero(&PowerSpectrum);
 }
@@ -407,7 +407,7 @@ static void potential_transfer(int64_t k2, int kpos[3], pfft_complex *value) {
          * This is correct for the forces, and gives the right power spectrum,
          * once we multiply PowerSpectrum.Norm by (Omega0 / (Omega0 - OmegaNu))**2 */
         const double nufac = 1 + PowerSpectrum.nu_prefac * gsl_interp_eval(PowerSpectrum.nu_spline,PowerSpectrum.logknu,
-                                                                       PowerSpectrum.Pnuratio,logk2,PowerSpectrum.nu_acc);
+                                                                       PowerSpectrum.delta_nu_ratio,logk2,PowerSpectrum.nu_acc);
         value[0][0] *= nufac;
         value[0][1] *= nufac;
     }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -308,16 +308,11 @@ static void compute_neutrino_power() {
     powerspectrum_sum(&PowerSpectrum, All.BoxSize*All.UnitLength_in_cm);
     int i;
     /*Get delta_cdm_curr , which is P(k)^1/2, and skip bins with zero modes:*/
-    int nk_nonzero = 0;
-    for(i=0;i<PowerSpectrum.size;i++){
-        if (PowerSpectrum.Nmodes[i] == 0)
-            continue;
-        PowerSpectrum.Pnuratio[nk_nonzero] = sqrt(PowerSpectrum.Power[i]);
-        PowerSpectrum.kk[nk_nonzero] = PowerSpectrum.kk[i];
-        nk_nonzero++;
+    for(i=0; i<PowerSpectrum.nonzero; i++) {
+        PowerSpectrum.Pnuratio[i] = sqrt(PowerSpectrum.Power[i]);
     }
-    double Pnu[nk_nonzero];
-    memset(Pnu,0, nk_nonzero*sizeof(double));
+    double Pnu[PowerSpectrum.nonzero];
+    memset(Pnu,0, PowerSpectrum.nonzero*sizeof(double));
     /*This sets up P_nu_curr.*/
     /*This is done on the first timestep: we need nk_nonzero for it to work.*/
     if(!delta_tot_table.delta_tot_init_done) {
@@ -334,14 +329,14 @@ static void compute_neutrino_power() {
         /*Broadcast the transfer table*/
         MPI_Bcast(transfer_init.logk,2*transfer_init.NPowerTable,MPI_DOUBLE,0,MPI_COMM_WORLD);
         /*Initialise delta_tot*/
-        delta_tot_init(&delta_tot_table, nk_nonzero, PowerSpectrum.kk, PowerSpectrum.Power, &transfer_init, All.Time);
+        delta_tot_init(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Power, &transfer_init, All.Time);
         free_transfer_init_table(&transfer_init);
     }
     const double partnu = particle_nu_fraction(&All.CP.ONu.hybnu, All.Time, 0);
     double kspace_prefac = 0;
     if(1 - partnu > 1e-3) {
-        get_delta_nu_update(&delta_tot_table, All.Time, nk_nonzero, PowerSpectrum.kk, PowerSpectrum.Pnuratio, Pnu, NULL);
-        message(0,"Done getting neutrino power: nk= %d, k = %g, delta_nu = %g, delta_cdm = %g,\n",nk_nonzero, PowerSpectrum.kk[1],Pnu[1],PowerSpectrum.Pnuratio[1]);
+        get_delta_nu_update(&delta_tot_table, All.Time, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Pnuratio, Pnu, NULL);
+        message(0,"Done getting neutrino power: nk= %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum.nonzero, PowerSpectrum.kk[1], Pnu[1], PowerSpectrum.Pnuratio[1]);
         /*kspace_prefac = M_nu (analytic) / M_particles */
         const double OmegaNu_nop = get_omega_nu_nopart(&All.CP.ONu, All.Time);
         const double omega_hybrid = get_omega_nu(&All.CP.ONu, 1) * partnu / pow(All.Time, 3);
@@ -349,11 +344,11 @@ static void compute_neutrino_power() {
         kspace_prefac = OmegaNu_nop/(delta_tot_table.Omeganonu/pow(All.Time,3) + omega_hybrid);
     }
     /*We want to interpolate in log space*/
-    for(i=0;i<nk_nonzero;i++){
+    for(i=0; i < PowerSpectrum.nonzero; i++) {
         PowerSpectrum.logknu[i] = log(PowerSpectrum.kk[i]);
         PowerSpectrum.Pnuratio[i] = Pnu[i]/PowerSpectrum.Pnuratio[i];
     }
-    init_delta_pow(&nu_pow, PowerSpectrum.logknu, PowerSpectrum.Pnuratio, nk_nonzero, kspace_prefac);
+    init_delta_pow(&nu_pow, PowerSpectrum.logknu, PowerSpectrum.Pnuratio, PowerSpectrum.nonzero, kspace_prefac);
     /*Zero power spectrum, which is stored with the neutrinos*/
     powerspectrum_zero(&PowerSpectrum);
 }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -51,7 +51,7 @@ void gravpm_init_periodic() {
     /*Initialise the kspace neutrino code if it is enabled.
      * Mpc units are used to match power spectrum code.*/
     if(All.MassiveNuLinRespOn) {
-        init_neutrinos_lra(All.Nmesh, All.TimeIC, All.TimeMax, All.CP.Omega0, &All.CP.ONu, All.UnitTime_in_s, 3.085678e24);
+        init_neutrinos_lra(All.Nmesh, All.TimeIC, All.TimeMax, All.CP.Omega0, &All.CP.ONu, All.UnitTime_in_s, CM_PER_MPC);
         global_functions.global_readout = measure_power_spectrum;
         global_functions.global_analysis = compute_neutrino_power;
     }
@@ -392,7 +392,7 @@ static void potential_transfer(int64_t k2, int kpos[3], pfft_complex *value) {
     /*Add neutrino power if desired*/
     if(All.MassiveNuLinRespOn && k2 > 0) {
         /* Change the units of k to match those of logkk*/
-        double logk2 = log(sqrt(k2) * 2 * M_PI / (All.BoxSize * All.UnitLength_in_cm/ 3.085678e24 ));
+        double logk2 = log(sqrt(k2) * 2 * M_PI / (All.BoxSize * All.UnitLength_in_cm/ CM_PER_MPC ));
         /* Floating point roundoff and the binning means there may be a mode just beyond the box size.*/
         if(logk2 < PowerSpectrum.logknu[0] && logk2 > PowerSpectrum.logknu[0]-log(2) )
             logk2 = PowerSpectrum.logknu[0];

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -296,9 +296,9 @@ static void compute_neutrino_power() {
     /*Note the power spectrum is now in Mpc units*/
     powerspectrum_sum(&PowerSpectrum, All.BoxSize*All.UnitLength_in_cm);
     int i;
-    /*Get delta_cdm_curr , which is P(k)^1/2, and skip bins with zero modes:*/
+    /*Get delta_cdm_curr , which is P(k)^1/2.*/
     for(i=0; i<PowerSpectrum.nonzero; i++) {
-        PowerSpectrum.Pnuratio[i] = sqrt(PowerSpectrum.Power[i]);
+        PowerSpectrum.Power[i] = sqrt(PowerSpectrum.Power[i]);
     }
     /*Get the neutrino power.*/
     delta_nu_from_power(&PowerSpectrum, &All.CP, All.Time, All.TimeIC);

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -311,7 +311,7 @@ static void compute_neutrino_power() {
         if(delta_tot_table.ia > 0)
             delta_tot_resume(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk);
         else
-            delta_tot_first_init(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Power, &t_init, All.TimeIC);
+            delta_tot_first_init(&delta_tot_table, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Power, All.TimeIC);
     }
     const double partnu = particle_nu_fraction(&All.CP.ONu.hybnu, All.Time, 0);
     if(1 - partnu > 1e-3) {

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -13,19 +13,13 @@
 #include "domain.h"
 
 #include "cosmology.h"
-#include "kspace-neutrinos/delta_pow.h"
 #include "kspace-neutrinos/delta_tot_table.h"
 
 /*Global variable to store power spectrum*/
 struct _powerspectrum PowerSpectrum;
 
-/* Structure which holds pointers to the stored
- * neutrino power spectrum*/
-_delta_pow nu_pow;
 /*Structure which holds the neutrino state*/
 _delta_tot_table delta_tot_table;
-
-void powerspectrum_nu_save(struct _delta_pow *nu_pow, const char * OutputDir, const double Time);
 
 static int pm_mark_region_for_node(int startno, int rid);
 static void convert_node_to_region(PetaPMRegion * r);
@@ -99,7 +93,7 @@ void gravpm_force(void) {
     if(ThisTask == 0)
         powerspectrum_save(&PowerSpectrum, All.OutputDir, All.Time, GrowthFactor(All.Time, 1.0));
     if(ThisTask == 0 && All.MassiveNuLinRespOn)
-        powerspectrum_nu_save(&nu_pow, All.OutputDir, All.Time);
+        powerspectrum_nu_save(&PowerSpectrum, All.OutputDir, All.Time);
     walltime_measure("/LongRange");
     /*Rebuild the force tree we freed in _prepare to save memory*/
     force_tree_rebuild();
@@ -333,43 +327,26 @@ static void compute_neutrino_power() {
         free_transfer_init_table(&transfer_init);
     }
     const double partnu = particle_nu_fraction(&All.CP.ONu.hybnu, All.Time, 0);
-    double kspace_prefac = 0;
     if(1 - partnu > 1e-3) {
         get_delta_nu_update(&delta_tot_table, All.Time, PowerSpectrum.nonzero, PowerSpectrum.kk, PowerSpectrum.Pnuratio, Pnu, NULL);
-        message(0,"Done getting neutrino power: nk= %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum.nonzero, PowerSpectrum.kk[1], Pnu[1], PowerSpectrum.Pnuratio[1]);
+        message(0,"Done getting neutrino power: nk = %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum.nonzero, PowerSpectrum.kk[1], Pnu[1], PowerSpectrum.Pnuratio[1]);
         /*kspace_prefac = M_nu (analytic) / M_particles */
         const double OmegaNu_nop = get_omega_nu_nopart(&All.CP.ONu, All.Time);
         const double omega_hybrid = get_omega_nu(&All.CP.ONu, 1) * partnu / pow(All.Time, 3);
         /* Omega0 - Omega in neutrinos + Omega in particle neutrinos = Omega in particles*/
-        kspace_prefac = OmegaNu_nop/(delta_tot_table.Omeganonu/pow(All.Time,3) + omega_hybrid);
+        PowerSpectrum.nu_prefac = OmegaNu_nop/(delta_tot_table.Omeganonu/pow(All.Time,3) + omega_hybrid);
     }
     /*We want to interpolate in log space*/
     for(i=0; i < PowerSpectrum.nonzero; i++) {
         PowerSpectrum.logknu[i] = log(PowerSpectrum.kk[i]);
         PowerSpectrum.Pnuratio[i] = Pnu[i]/PowerSpectrum.Pnuratio[i];
     }
-    init_delta_pow(&nu_pow, PowerSpectrum.logknu, PowerSpectrum.Pnuratio, PowerSpectrum.nonzero, kspace_prefac);
+    /*Initialize the interpolation for the neutrinos*/
+    PowerSpectrum.nu_spline = gsl_interp_alloc(gsl_interp_linear,PowerSpectrum.nonzero);
+    PowerSpectrum.nu_acc = gsl_interp_accel_alloc();
+    gsl_interp_init(PowerSpectrum.nu_spline,PowerSpectrum.logknu,PowerSpectrum.Pnuratio,PowerSpectrum.nonzero);
     /*Zero power spectrum, which is stored with the neutrinos*/
     powerspectrum_zero(&PowerSpectrum);
-}
-
-void powerspectrum_nu_save(struct _delta_pow *nu_pow, const char * OutputDir, const double Time)
-{
-    int i;
-    char fname[1024];
-    /* Now save the neutrino power spectrum*/
-    snprintf(fname, 1024,"%s/powerspectrum-nu-%0.4f.txt", OutputDir, Time);
-    FILE * fp = fopen(fname, "w");
-    fprintf(fp, "# in Mpc/h Units \n");
-    fprintf(fp, "# (k P_nu(k))\n");
-    fprintf(fp, "# a= %g\n", Time);
-    fprintf(fp, "# nk = %d\n", delta_tot_table.nk);
-    for(i = 0; i < delta_tot_table.nk; i++){
-        fprintf(fp, "%g %g\n", exp(nu_pow->logkk[i]), pow(delta_tot_table.delta_nu_last[i],2));
-    }
-    fclose(fp);
-    /*Clean up the neutrino memory now we saved the power spectrum.*/
-    free_d_pow(nu_pow);
 }
 
 /* Compute the power spectrum of the fourier transformed grid in value.
@@ -452,8 +429,13 @@ static void potential_transfer(int64_t k2, int kpos[3], pfft_complex *value) {
 
     /*Add neutrino power if desired*/
     if(All.MassiveNuLinRespOn && k2 > 0) {
-        /*Change the units of k to match those of logkk*/
+        /* Change the units of k to match those of logkk*/
         double logk2 = log(sqrt(k2) * 2 * M_PI / (All.BoxSize * All.UnitLength_in_cm/ 3.085678e24 ));
+        /* Floating point roundoff and the binning means there may be a mode just beyond the box size.*/
+        if(logk2 < PowerSpectrum.logknu[0] && logk2 > PowerSpectrum.logknu[0]-log(2) )
+            logk2 = PowerSpectrum.logknu[0];
+        else if( logk2 > PowerSpectrum.logknu[PowerSpectrum.nonzero-1])
+            logk2 = PowerSpectrum.logknu[PowerSpectrum.nonzero-1];
         /* Note get_neutrino_powerspec returns Omega_nu / (Omega0 -OmegaNu) * delta_nu / P_cdm^1/2, which is dimensionless.
          * So below is: M_cdm * delta_cdm (1 + Omega_nu/(Omega0-OmegaNu) (delta_nu / delta_cdm))
          *            = M_cdm * (delta_cdm (Omega0 - OmegaNu)/Omega0 + Omega_nu/Omega0 delta_nu) * Omega0 / (Omega0-OmegaNu)
@@ -462,7 +444,8 @@ static void potential_transfer(int64_t k2, int kpos[3], pfft_complex *value) {
          *            = (M_cdm + M_nu) * delta_t
          * This is correct for the forces, and gives the right power spectrum,
          * once we multiply PowerSpectrum.Norm by (Omega0 / (Omega0 - OmegaNu))**2 */
-        const double nufac = 1 + get_dnudcdm_powerspec(&nu_pow, logk2);
+        const double nufac = 1 + PowerSpectrum.nu_prefac * gsl_interp_eval(PowerSpectrum.nu_spline,PowerSpectrum.logknu,
+                                                                       PowerSpectrum.Pnuratio,logk2,PowerSpectrum.nu_acc);
         value[0][0] *= nufac;
         value[0][1] *= nufac;
     }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -47,7 +47,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions);
 
 void gravpm_init_periodic() {
     petapm_init(All.BoxSize, All.Nmesh, All.NumThreads);
-    powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads);
+    powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads, All.MassiveNuLinRespOn);
     /*Initialise the kspace neutrino code if it is enabled.
      * Mpc units are used to match power spectrum code.*/
     if(All.MassiveNuLinRespOn) {

--- a/libgadget/lightcone.c
+++ b/libgadget/lightcone.c
@@ -73,7 +73,7 @@ static void lightcone_init_entry(int i) {
 
     /* result is in DH, hubble distance */
     /* convert to cm / h */
-    result *= C / HUBBLE;
+    result *= LIGHTCGS / HUBBLE;
     /* convert to Kpc/h or internal units */
     result /= All.UnitLength_in_cm;
 

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -149,6 +149,7 @@ static void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in
             d_tot->delta_tot[ik][0] = get_delta_tot(d_tot->delta_nu_init[ik], delta_cdm_curr[ik], OmegaNua3, d_tot->Omeganonu, OmegaNu1, partnu);
             d_tot->wavenum[ik] = wavenum[ik];
     }
+    ta_free(t_init->logk);
     gsl_interp_accel_free(acc);
     gsl_interp_free(spline);
 
@@ -157,7 +158,6 @@ static void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in
     d_tot->ia=1;
     /*Initialise delta_nu_last*/
     get_delta_nu_combined(d_tot, exp(d_tot->scalefact[0]), wavenum, d_tot->delta_nu_last);
-    myfree(t_init->logk);
     d_tot->delta_tot_init_done=1;
     return;
 }
@@ -262,7 +262,7 @@ void petaio_read_icnutransfer(BigFile * bf, int ThisTask)
             endrun(0, "Failed to close block %s\n",big_file_get_error_message());
     }
     message(0,"Found transfer function, using %d rows.\n", t_init->NPowerTable);
-    t_init->logk = (double *) mymalloc2("Transfer_functions", 2*t_init->NPowerTable* sizeof(double));
+    t_init->logk = ta_malloc("Transfer_functions", double, 2*t_init->NPowerTable);
     t_init->T_nu=t_init->logk+t_init->NPowerTable;
 
     /*Defaults: zero*/

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -1,10 +1,16 @@
 #include <math.h>
+#include <bigfile-mpi.h>
+
 #include "neutrinos_lra.h"
+
 #include "utils/endrun.h"
+#include "utils/mymalloc.h"
+#include "petaio.h"
 
 /*Structure which holds the neutrino state*/
 _delta_tot_table delta_tot_table;
-_transfer_init_table t_init;
+static _transfer_init_table t_init_data;
+static _transfer_init_table * t_init = &t_init_data;
 
 /* Constructor for delta_tot. Does some sanity checks and initialises delta_nu_last.*/
 void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[])
@@ -30,7 +36,7 @@ void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const dou
  * Initialises delta_tot (including from a file) and delta_nu_init from the transfer functions.
  * read_all_nu_state must be called before this if you want reloading from a snapshot to work
  * Note delta_cdm_curr includes baryons, and is only used if not resuming.*/
-void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const _transfer_init_table * const t_init, const double TimeIC)
+void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const double TimeIC)
 {
     int ik;
     if(nk_in > d_tot->nk_allocated){
@@ -64,7 +70,185 @@ void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const
     d_tot->ia=1;
     /*Initialise delta_nu_last*/
     get_delta_nu_combined(d_tot, exp(d_tot->scalefact[0]), wavenum, d_tot->delta_nu_last);
+    myfree(t_init->logk);
     d_tot->delta_tot_init_done=1;
     return;
 }
 
+void petaio_save_neutrinos(BigFile * bf, int ThisTask)
+{
+#pragma omp master
+    {
+    double * scalefact = delta_tot_table.scalefact;
+    size_t nk = delta_tot_table.nk, ia = delta_tot_table.ia;
+    size_t ik, i;
+    double * delta_tot = mymalloc("tmp_delta",nk * ia * sizeof(double));
+    /*Save a flat memory block*/
+    for(ik=0;ik< nk;ik++)
+        for(i=0;i< ia;i++)
+            delta_tot[ik*ia+i] = delta_tot_table.delta_tot[ik][i];
+
+    BigBlock bn = {0};
+    if(0 != big_file_mpi_create_block(bf, &bn, "Neutrino", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
+        endrun(0, "Failed to create block at %s:%s\n", "Neutrino",
+                big_file_get_error_message());
+    }
+    if ( (0 != big_block_set_attr(&bn, "Nscale", &ia, "u8", 1)) ||
+       (0 != big_block_set_attr(&bn, "scalefact", scalefact, "f8", ia)) ||
+        (0 != big_block_set_attr(&bn, "Nkval", &nk, "u8", 1)) ) {
+        endrun(0, "Failed to write neutrino attributes %s\n",
+                    big_file_get_error_message());
+    }
+    if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD)) {
+        endrun(0, "Failed to close block %s\n",
+                    big_file_get_error_message());
+    }
+    BigArray deltas = {0};
+    size_t dims[2] = {0 , ia};
+    /*The neutrino state is shared between all processors,
+     *so only write on master task*/
+    if(ThisTask == 0) {
+        dims[0] = nk;
+    }
+    ptrdiff_t strides[2] = {sizeof(double) * ia, sizeof(double)};
+    big_array_init(&deltas, delta_tot, "=f8", 2, dims, strides);
+    petaio_save_block(bf, "Neutrino/Deltas", &deltas);
+    myfree(delta_tot);
+    /*Now write the initial neutrino power*/
+    BigArray delta_nu = {0};
+    dims[1] = 1;
+    strides[0] = sizeof(double);
+    big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
+    petaio_save_block(bf, "Neutrino/DeltaNuInit", &delta_nu);
+    /*Now write the k values*/
+    BigArray kvalue = {0};
+    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
+    petaio_save_block(bf, "Neutrino/kvalue", &kvalue);
+    }
+}
+
+void petaio_read_icnutransfer(BigFile * bf, int ThisTask)
+{
+#pragma omp master
+    {
+    t_init->NPowerTable = 2;
+    BigBlock bn = {{0}};
+    /* Read the size of the ICTransfer block.
+     * If we can't read it, just set it to zero*/
+    if(0 == big_file_mpi_open_block(bf, &bn, "ICTransfers", MPI_COMM_WORLD)) {
+        if(0 != big_block_get_attr(&bn, "Nentry", &t_init->NPowerTable, "u8", 1))
+            endrun(0, "Failed to read attr: %s\n", big_file_get_error_message());
+        if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD))
+            endrun(0, "Failed to close block %s\n",big_file_get_error_message());
+    }
+    message(1,"Found transfer function, using %d rows.\n", t_init->NPowerTable);
+    t_init->logk = (double *) mymalloc2("Transfer_functions", 2*t_init->NPowerTable* sizeof(double));
+    t_init->T_nu=t_init->logk+t_init->NPowerTable;
+
+    /*Defaults: zero*/
+    t_init->logk[0] = -100;
+    t_init->logk[t_init->NPowerTable-1] = 100;
+
+    t_init->T_nu[0] = 0;
+    t_init->T_nu[t_init->NPowerTable-1] = 0;
+
+    /*Now read the arrays*/
+    BigArray Tnu = {0};
+    BigArray logk = {0};
+
+    size_t dims[2] = {0, 1};
+    ptrdiff_t strides[2] = {sizeof(double), sizeof(double)};
+    /*The neutrino state is shared between all processors,
+     *so only read on master task and broadcast*/
+    if(ThisTask == 0) {
+        dims[0] = t_init->NPowerTable;
+    }
+    big_array_init(&Tnu, t_init->T_nu, "=f8", 2, dims, strides);
+    big_array_init(&logk, t_init->logk, "=f8", 2, dims, strides);
+    /*This is delta_nu / delta_tot: note technically the most massive eigenstate only.
+     * But if there are significant differences the mass is so low this is basically zero.*/
+    petaio_read_block(bf, "ICTransfers/DELTA_NU", &Tnu, 0);
+    petaio_read_block(bf, "ICTransfers/logk", &logk, 0);
+    /*Also want d_{cdm+bar} / d_tot so we can get d_nu/(d_cdm+d_b)*/
+    double * T_cb = (double *) mymalloc("tmp1", t_init->NPowerTable* sizeof(double));
+    BigArray Tcb = {0};
+    big_array_init(&Tcb, T_cb, "=f8", 2, dims, strides);
+    petaio_read_block(bf, "ICTransfers/DELTA_CB", &Tcb, 0);
+    int i;
+    for(i = 0; i < t_init->NPowerTable; i++)
+        t_init->T_nu[i] /= T_cb[i];
+    myfree(T_cb);
+    /*Broadcast the arrays.*/
+    MPI_Bcast(t_init->logk,2*t_init->NPowerTable,MPI_DOUBLE,0,MPI_COMM_WORLD);
+    }
+}
+
+/*Read the neutrino data from the snapshot*/
+void petaio_read_neutrinos(BigFile * bf, int ThisTask)
+{
+#pragma omp master
+    {
+    size_t nk, ia, ik, i;
+    BigBlock bn = {0};
+    if(0 != big_file_mpi_open_block(bf, &bn, "Neutrino", MPI_COMM_WORLD)) {
+        endrun(0, "Failed to open block at %s:%s\n", "Neutrino",
+                    big_file_get_error_message());
+    }
+    if(
+    (0 != big_block_get_attr(&bn, "Nscale", &ia, "u8", 1)) ||
+    (0 != big_block_get_attr(&bn, "Nkval", &nk, "u8", 1))) {
+        endrun(0, "Failed to read attr: %s\n",
+                    big_file_get_error_message());
+    }
+    double *delta_tot = (double *) mymalloc("tmp_nusave",ia*nk*sizeof(double));
+    /*Allocate list of scale factors, and space for delta_tot, in one operation.*/
+    if(0 != big_block_get_attr(&bn, "scalefact", delta_tot_table.scalefact, "f8", ia))
+        endrun(0, "Failed to read attr: %s\n", big_file_get_error_message());
+    if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD)) {
+        endrun(0, "Failed to close block %s\n",
+                    big_file_get_error_message());
+    }
+    BigArray deltas = {0};
+    size_t dims[2] = {0, ia};
+    ptrdiff_t strides[2] = {sizeof(double)*ia, sizeof(double)};
+    /*The neutrino state is shared between all processors,
+     *so only read on master task and broadcast*/
+    if(ThisTask == 0) {
+        dims[0] = nk;
+    }
+    big_array_init(&deltas, delta_tot, "=f8", 2, dims, strides);
+    petaio_read_block(bf, "Neutrino/Deltas", &deltas, 1);
+
+    /*Save a flat memory block*/
+    for(ik=0;ik<nk;ik++)
+        for(i=0;i<ia;i++)
+            delta_tot_table.delta_tot[ik][i] = delta_tot[ik*ia+i];
+    delta_tot_table.nk = nk;
+    delta_tot_table.ia = ia;
+    myfree(delta_tot);
+    /* Read the initial delta_nu. This is basically zero anyway,
+     * so for backwards compatibility do not require it*/
+    BigArray delta_nu = {0};
+    dims[1] = 1;
+    strides[0] = sizeof(double);
+    memset(delta_tot_table.delta_nu_init, 0, delta_tot_table.nk);
+    big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
+    petaio_read_block(bf, "Neutrino/DeltaNuInit", &delta_nu, 0);
+    /* Read the k values*/
+    BigArray kvalue = {0};
+    memset(delta_tot_table.wavenum, 0, delta_tot_table.nk);
+    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
+    petaio_read_block(bf, "Neutrino/kvalue", &kvalue, 0);
+
+    /*Broadcast the arrays.*/
+    MPI_Bcast(&(delta_tot_table.ia), 1,MPI_INT,0,MPI_COMM_WORLD);
+    MPI_Bcast(&(delta_tot_table.nk), 1,MPI_INT,0,MPI_COMM_WORLD);
+    MPI_Bcast(delta_tot_table.delta_nu_init,delta_tot_table.nk,MPI_DOUBLE,0,MPI_COMM_WORLD);
+
+    if(delta_tot_table.ia > 0) {
+        /*Broadcast data for scalefact and delta_tot, Delta_tot is allocated as the same block of memory as scalefact.
+          Not all this memory will actually have been used, but it is easiest to bcast all of it.*/
+        MPI_Bcast(delta_tot_table.scalefact,delta_tot_table.namax*(delta_tot_table.nk+1),MPI_DOUBLE,0,MPI_COMM_WORLD);
+    }
+    }
+}

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -440,6 +440,11 @@ void get_delta_nu_combined(const _delta_tot_table * const d_tot, const double a,
     return;
 }
 
+/** Floating point accuracy*/
+#define FLOAT_ACC   1e-6
+/** Number of bins in integrations*/
+#define GSL_VAL 200
+
 /*Update the last value of delta_tot in the table with a new value computed
  from the given delta_cdm_curr and delta_nu_curr.
  If overwrite is true, overwrite the existing final entry.*/

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -172,7 +172,7 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
         /*Get the new delta_nu_curr*/
         get_delta_nu_combined(&delta_tot_table, Time, PowerSpectrum->delta_nu);
         /* Decide whether we save the current time or not */
-        if (Time > exp(delta_tot_table.scalefact[delta_tot_table.ia-2] + 0.009) {
+        if (Time > exp(delta_tot_table.scalefact[delta_tot_table.ia-2]) + 0.009) {
             /* If so update delta_tot(a) correctly, overwriting current power spectrum */
             update_delta_tot(&delta_tot_table, Time, PowerSpectrum->Power, PowerSpectrum->delta_nu, 1);
         }

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -180,7 +180,7 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
         else
             delta_tot_table.ia--;
 
-        message(0,"Done getting neutrino power: nk = %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum->nonzero, PowerSpectrum->kk[1], PowerSpectrum->delta_nu_ratio[1], PowerSpectrum->Power[1]);
+        message(0,"Done getting neutrino power: nk = %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum->nonzero, PowerSpectrum->kk[1], PowerSpectrum->delta_nu[1], PowerSpectrum->Power[1]);
         /*kspace_prefac = M_nu (analytic) / M_particles */
         const double OmegaNu_nop = get_omega_nu_nopart(&CP->ONu, Time);
         const double omega_hybrid = get_omega_nu(&CP->ONu, 1) * partnu / pow(Time, 3);

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -166,15 +166,15 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
         else
             delta_tot_first_init(&delta_tot_table, PowerSpectrum->nonzero, PowerSpectrum->kk, PowerSpectrum->Power, TimeIC);
         /*Initialise the first delta_nu*/
-        get_delta_nu_combined(&delta_tot_table, exp(delta_tot_table.scalefact[delta_tot_table.ia-1]), PowerSpectrum->kk, PowerSpectrum->Pnu);
+        get_delta_nu_combined(&delta_tot_table, exp(delta_tot_table.scalefact[delta_tot_table.ia-1]), PowerSpectrum->kk, PowerSpectrum->delta_nu);
         delta_tot_table.delta_tot_init_done = 1;
     }
     /*This sets up P_nu_curr.*/
-    memset(PowerSpectrum->Pnuratio,0, PowerSpectrum->nonzero*sizeof(PowerSpectrum->Pnuratio[0]));
+    memset(PowerSpectrum->delta_nu_ratio,0, PowerSpectrum->nonzero*sizeof(PowerSpectrum->delta_nu_ratio[0]));
     const double partnu = particle_nu_fraction(&CP->ONu.hybnu, Time, 0);
     if(1 - partnu > 1e-3) {
-        update_delta_nu(&delta_tot_table, Time, PowerSpectrum->nonzero, PowerSpectrum->kk, PowerSpectrum->Power, PowerSpectrum->Pnu);
-        message(0,"Done getting neutrino power: nk = %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum->nonzero, PowerSpectrum->kk[1], PowerSpectrum->Pnuratio[1], PowerSpectrum->Power[1]);
+        update_delta_nu(&delta_tot_table, Time, PowerSpectrum->nonzero, PowerSpectrum->kk, PowerSpectrum->Power, PowerSpectrum->delta_nu);
+        message(0,"Done getting neutrino power: nk = %d, k = %g, delta_nu = %g, delta_cdm = %g,\n", PowerSpectrum->nonzero, PowerSpectrum->kk[1], PowerSpectrum->delta_nu_ratio[1], PowerSpectrum->Power[1]);
         /*kspace_prefac = M_nu (analytic) / M_particles */
         const double OmegaNu_nop = get_omega_nu_nopart(&CP->ONu, Time);
         const double omega_hybrid = get_omega_nu(&CP->ONu, 1) * partnu / pow(Time, 3);
@@ -184,7 +184,7 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
     /*We want to interpolate in log space*/
     for(i=0; i < PowerSpectrum->nonzero; i++) {
         PowerSpectrum->logknu[i] = log(PowerSpectrum->kk[i]);
-        PowerSpectrum->Pnuratio[i] = PowerSpectrum->Pnu[i]/ PowerSpectrum->Power[i];
+        PowerSpectrum->delta_nu_ratio[i] = PowerSpectrum->delta_nu[i]/ PowerSpectrum->Power[i];
     }
 }
 

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -1,0 +1,70 @@
+#include <math.h>
+#include "neutrinos_lra.h"
+#include "utils/endrun.h"
+
+/*Structure which holds the neutrino state*/
+_delta_tot_table delta_tot_table;
+_transfer_init_table t_init;
+
+/* Constructor for delta_tot. Does some sanity checks and initialises delta_nu_last.*/
+void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[])
+{
+    int ik;
+    if(nk_in > d_tot->nk_allocated){
+           endrun(2011,"input power of %d is longer than memory of %d\n",nk_in,d_tot->nk_allocated);
+    }
+    if(d_tot->nk != nk_in)
+        endrun(201, "Number of neutrino bins %d != stored value %d\n",nk_in, d_tot->nk);
+
+    /*Set the wave number*/
+    for(ik=0;ik<d_tot->nk;ik++){
+        d_tot->wavenum[ik] = wavenum[ik];
+    }
+    /*Initialise delta_nu_last*/
+    get_delta_nu_combined(d_tot, exp(d_tot->scalefact[d_tot->ia-1]), wavenum, d_tot->delta_nu_last);
+    d_tot->delta_tot_init_done=1;
+    return;
+}
+
+/* Constructor. transfer_init_tabulate must be called before this function.
+ * Initialises delta_tot (including from a file) and delta_nu_init from the transfer functions.
+ * read_all_nu_state must be called before this if you want reloading from a snapshot to work
+ * Note delta_cdm_curr includes baryons, and is only used if not resuming.*/
+void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const _transfer_init_table * const t_init, const double TimeIC)
+{
+    int ik;
+    if(nk_in > d_tot->nk_allocated){
+           endrun(2011,"input power of %d is longer than memory of %d\n",nk_in,d_tot->nk_allocated);
+    }
+    d_tot->nk=nk_in;
+    const double OmegaNua3=get_omega_nu_nopart(d_tot->omnu, d_tot->TimeTransfer)*pow(d_tot->TimeTransfer,3);
+    const double OmegaNu1 = get_omega_nu(d_tot->omnu, 1);
+    gsl_interp_accel *acc = gsl_interp_accel_alloc();
+    gsl_interp * spline=gsl_interp_alloc(gsl_interp_cspline,t_init->NPowerTable);
+    gsl_interp_init(spline,t_init->logk,t_init->T_nu,t_init->NPowerTable);
+    /*Check we have a long enough power table*/
+    if(log(wavenum[d_tot->nk-1]) > t_init->logk[t_init->NPowerTable-1])
+        endrun(2,"Want k = %g but maximum in CAMB table is %g\n",wavenum[d_tot->nk-1], exp(t_init->logk[t_init->NPowerTable-1]));
+    for(ik=0;ik<d_tot->nk;ik++) {
+            /* T_nu contains T_nu / T_cdm.*/
+            double T_nubyT_nonu = gsl_interp_eval(spline,t_init->logk,t_init->T_nu,log(wavenum[ik]),acc);
+            /*Initialise delta_nu_init to use the first timestep's delta_cdm_curr
+             * so that it includes potential Rayleigh scattering. */
+            d_tot->delta_nu_init[ik] = delta_cdm_curr[ik]*T_nubyT_nonu;
+            const double partnu = particle_nu_fraction(&d_tot->omnu->hybnu, TimeIC, 0);
+            /*Initialise the first delta_tot*/
+            d_tot->delta_tot[ik][0] = get_delta_tot(d_tot->delta_nu_init[ik], delta_cdm_curr[ik], OmegaNua3, d_tot->Omeganonu, OmegaNu1, partnu);
+            d_tot->wavenum[ik] = wavenum[ik];
+    }
+    gsl_interp_accel_free(acc);
+    gsl_interp_free(spline);
+
+    /*If we are not restarting, make sure we set the scale factor*/
+    d_tot->scalefact[0]=log(TimeIC);
+    d_tot->ia=1;
+    /*Initialise delta_nu_last*/
+    get_delta_nu_combined(d_tot, exp(d_tot->scalefact[0]), wavenum, d_tot->delta_nu_last);
+    d_tot->delta_tot_init_done=1;
+    return;
+}
+

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -261,7 +261,7 @@ void petaio_read_icnutransfer(BigFile * bf, int ThisTask)
         if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD))
             endrun(0, "Failed to close block %s\n",big_file_get_error_message());
     }
-    message(1,"Found transfer function, using %d rows.\n", t_init->NPowerTable);
+    message(0,"Found transfer function, using %d rows.\n", t_init->NPowerTable);
     t_init->logk = (double *) mymalloc2("Transfer_functions", 2*t_init->NPowerTable* sizeof(double));
     t_init->T_nu=t_init->logk+t_init->NPowerTable;
 

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -23,48 +23,6 @@
 #include "powerspectrum.h"
 #include "physconst.h"
 
-/** Now we want to define a static object to store all previous delta_tot.
- * This object needs a constructor, a few private data members, and a way to be read and written from disk.
- * nk is fixed, delta_tot, scalefact and ia are updated in get_delta_nu_update*/
-struct _delta_tot_table {
-    /** Number of actually non-zero k values stored in each power spectrum*/
-    int nk;
-    /** Size of arrays allocated to store power spectra*/
-    int nk_allocated;
-    /** Maximum number of redshifts to store. Redshifts are stored every delta a = 0.01 */
-    int namax;
-    /** Number of already "recorded" time steps, i.e. scalefact[0...ia-1] is recorded.
-    * Current time corresponds to index ia (but is only recorded if sufficiently far from previous time).
-    * Caution: ia here is different from Na in get_delta_nu (Na = ia+1).*/
-    int ia;
-    /** Prefactor for use in get_delta_nu. Should be 3/2 Omega_m H^2 /c */
-    double delta_nu_prefac;
-    /** Set to unity once the init routine has run.*/
-    int delta_tot_init_done;
-    /** Pointer to nk arrays of length namax containing the total power spectrum.*/
-    double **delta_tot;
-    /** Array of length namax containing scale factors at which the power spectrum is stored*/
-    double * scalefact;
-    /** Pointer to array of length nk storing initial neutrino power spectrum*/
-    double * delta_nu_init;
-    /** Pointer to array of length nk storing the last neutrino power spectrum we saw, for a first estimate
-    * of the new delta_tot */
-    double * delta_nu_last;
-    /**Pointer to array storing the effective wavenumbers for the above power spectra*/
-    double * wavenum;
-    /** Pointer to a structure for computing omega_nu*/
-    const _omega_nu * omnu;
-    /** Matter density excluding neutrinos*/
-    double Omeganonu;
-    /** Light speed in internal units. C is defined in allvars.h to be lightspeed in cm/s*/
-    double light;
-    /** The time at which we first start our integrator:
-     * NOTE! This is not All.TimeBegin, but the time of the transfer function file,
-     * so that we can support restarting from snapshots.*/
-    double TimeTransfer;
-};
-typedef struct _delta_tot_table _delta_tot_table;
-
 /** Update the last value of delta_tot in the table with a new value computed
  from the given delta_cdm_curr and delta_nu_curr.
  If overwrite is true, overwrite the existing final entry.*/
@@ -82,7 +40,7 @@ void update_delta_tot(_delta_tot_table * const d_tot, const double a, const doub
  * @param delta_nu_curr is an array of length nk which stores the square root of the current neutrino power spectrum. Main output of the function.
  * @param transfer_init is a pointer to the structure containing transfer tables.
 ******************************************************************************************************/
-static void update_delta_nu(_delta_tot_table * const d_tot, const double a, const int nk_in, const double keff[], const double delta_cdm_curr[], double delta_nu_curr[]);
+void update_delta_nu(_delta_tot_table * const d_tot, const double a, const int nk_in, const double keff[], const double delta_cdm_curr[], double delta_nu_curr[]);
 
 /** Main function: given tables of wavenumbers, total delta at Na earlier times (< = a),
  * and initial conditions for neutrinos, computes the current delta_nu.
@@ -115,10 +73,15 @@ double fslength(const double logai, const double logaf, const double light);
  * OmegaNua3 = OmegaNu(a) * a^3
  * Omeganonu = Omega0 - OmegaNu(1)
  * Omeganu1 = OmegaNu(1) */
-double get_delta_tot(const double delta_nu_curr, const double delta_cdm_curr, const double OmegaNua3, const double Omeganonu, const double Omeganu1, const double partnu);
+static inline double get_delta_tot(const double delta_nu_curr, const double delta_cdm_curr, const double OmegaNua3, const double Omeganonu, const double Omeganu1, const double particle_nu_fraction)
+{
+    const double fcdm = 1 - OmegaNua3/(Omeganonu + Omeganu1);
+    return fcdm * (delta_cdm_curr + delta_nu_curr * OmegaNua3/(Omeganonu + Omeganu1*particle_nu_fraction));
+}
+
 
 /*Structure which holds the neutrino state*/
-static _delta_tot_table delta_tot_table;
+_delta_tot_table delta_tot_table;
 
 /** Structure to store the initial transfer functions from CAMB.
  * We store transfer functions because we want to use the
@@ -496,17 +459,9 @@ void update_delta_tot(_delta_tot_table * const d_tot, const double a, const doub
   }
 }
 
-static void update_delta_nu(_delta_tot_table * const d_tot, const double a, const int nk_in, const double keff[], const double delta_cdm_curr[], double delta_nu_curr[])
+void update_delta_nu(_delta_tot_table * const d_tot, const double a, const int nk_in, const double keff[], const double delta_cdm_curr[], double delta_nu_curr[])
 {
   int ik;
-  /* Get a delta_nu_curr from CAMB.*/
-  if(!d_tot->delta_tot_init_done)
-      endrun(2001,"Should have called delta_tot_init first\n");
-  if(nk_in != d_tot->nk)
-      endrun(2002,"Number of kbins %d != stored delta_tot %d\n",nk_in, d_tot->nk);
-  if(d_tot->nk < 2){
-      endrun(2003,"Number of kbins is unreasonably small: %d\n",d_tot->nk);
-  }
   /*If we get called twice with the same scale factor, do nothing*/
   if(log(a)-d_tot->scalefact[d_tot->ia-1] < FLOAT_ACC){
        for (ik = 0; ik < d_tot->nk; ik++)
@@ -537,14 +492,11 @@ static void update_delta_nu(_delta_tot_table * const d_tot, const double a, cons
        d_tot->ia--;
    /*Sanity-check the output*/
    for(ik=0;ik<d_tot->nk;ik++){
-          if(isnan(delta_nu_curr[ik]))
-/*|| delta_nu_curr[ik] < -1e-5*delta_cdm_curr[ik])*/
-{
-              endrun(2004,"delta_nu_curr=%g i=%d delta_cdm_curr=%g kk=%g\n",delta_nu_curr[ik],ik,delta_cdm_curr[ik],keff[ik]);
-          }
-          /*Enforce positivity for sanity reasons*/
-          if(delta_nu_curr[ik] < 0)
-              delta_nu_curr[ik] = 0;
+        if(isnan(delta_nu_curr[ik]))
+            endrun(2004,"delta_nu_curr=%g i=%d delta_cdm_curr=%g kk=%g\n",delta_nu_curr[ik],ik,delta_cdm_curr[ik],keff[ik]);
+        /*Enforce positivity for sanity reasons*/
+        if(delta_nu_curr[ik] < 0)
+            delta_nu_curr[ik] = 0;
    }
    return;
 }
@@ -780,10 +732,4 @@ void get_delta_nu(const _delta_tot_table * const d_tot, const double a, const do
 //     for(ik=0; ik< 3; ik++)
 //         message(0,"k %g d_nu %g\n",wavenum[d_tot->nk/8*ik], delta_nu_curr[d_tot->nk/8*ik]);
    return;
-}
-
-double get_delta_tot(const double delta_nu_curr, const double delta_cdm_curr, const double OmegaNua3, const double Omeganonu, const double Omeganu1, const double particle_nu_fraction)
-{
-    const double fcdm = 1 - OmegaNua3/(Omeganonu + Omeganu1);
-    return fcdm * (delta_cdm_curr + delta_nu_curr * OmegaNua3/(Omeganonu + Omeganu1*particle_nu_fraction));
 }

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -432,7 +432,7 @@ void get_delta_nu_combined(const _delta_tot_table * const d_tot, const double a,
                  int ik;
                  double delta_nu_single[d_tot->nk];
                  const double omeganu = d_tot->omnu->nu_degeneracies[mi] * omega_nu_single(d_tot->omnu, a, mi);
-                 get_delta_nu(d_tot, a, wavenum, delta_nu_single,d_tot->omnu->RhoNuTab[mi]->mnu);
+                 get_delta_nu(d_tot, a, wavenum, delta_nu_single,d_tot->omnu->RhoNuTab[mi].mnu);
                  for(ik=0; ik<d_tot->nk; ik++)
                     delta_nu_curr[ik]+=delta_nu_single[ik]*omeganu/Omega_nu_tot;
             }

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -191,9 +191,9 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
     for(i=0; i < PowerSpectrum->nonzero; i++) {
         if(isnan(PowerSpectrum->delta_nu[i]))
             endrun(2004,"delta_nu_curr=%g i=%d delta_cdm_curr=%g kk=%g\n",PowerSpectrum->delta_nu[i],i,PowerSpectrum->Power[i],PowerSpectrum->kk[i]);
-            /*Enforce positivity for sanity reasons*/
-            if(PowerSpectrum->delta_nu[i] < 0)
-                PowerSpectrum->delta_nu[i] = 0;
+        /*Enforce positivity for sanity reasons*/
+        if(PowerSpectrum->delta_nu[i] < 0)
+            PowerSpectrum->delta_nu[i] = 0;
         PowerSpectrum->logknu[i] = log(PowerSpectrum->kk[i]);
         PowerSpectrum->delta_nu_ratio[i] = PowerSpectrum->delta_nu[i]/ PowerSpectrum->Power[i];
     }

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -162,7 +162,7 @@ static void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in
     return;
 }
 
-void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, int Time, int TimeIC)
+void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, const double Time, const double TimeIC)
 {
     int i;
     double * Pnu = mymalloc("Pnutmp", PowerSpectrum->nonzero*sizeof(double));

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -135,12 +135,12 @@ static void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in
     gsl_interp_accel *acc = gsl_interp_accel_alloc();
     gsl_interp * spline=gsl_interp_alloc(gsl_interp_cspline,t_init->NPowerTable);
     gsl_interp_init(spline,t_init->logk,t_init->T_nu,t_init->NPowerTable);
-    /*Check we have a long enough power table*/
-    if(log(wavenum[d_tot->nk-1]) > t_init->logk[t_init->NPowerTable-1])
-        endrun(2,"Want k = %g but maximum in CAMB table is %g\n",wavenum[d_tot->nk-1], exp(t_init->logk[t_init->NPowerTable-1]));
+    /*Check we have a long enough power table: power tables are in log_10*/
+    if(log10(wavenum[d_tot->nk-1]) > t_init->logk[t_init->NPowerTable-1])
+        endrun(2,"Want k = %g but maximum in CLASS table is %g\n",wavenum[d_tot->nk-1], pow(10, t_init->logk[t_init->NPowerTable-1]));
     for(ik=0;ik<d_tot->nk;ik++) {
             /* T_nu contains T_nu / T_cdm.*/
-            double T_nubyT_nonu = gsl_interp_eval(spline,t_init->logk,t_init->T_nu,log(wavenum[ik]),acc);
+            double T_nubyT_nonu = gsl_interp_eval(spline,t_init->logk,t_init->T_nu,log10(wavenum[ik]),acc);
             /*Initialise delta_nu_init to use the first timestep's delta_cdm_curr
              * so that it includes potential Rayleigh scattering. */
             d_tot->delta_nu_init[ik] = delta_cdm_curr[ik]*T_nubyT_nonu;

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -59,7 +59,7 @@ typedef struct _delta_tot_table _delta_tot_table;
 void init_neutrinos_lra(const int nk_in, const double TimeTransfer, const double TimeMax, const double Omega0, const _omega_nu * const omnu, const double UnitTime_in_s, const double UnitLength_in_cm);
 
 /*Computes delta_nu from a CDM power spectrum.*/
-void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, int Time, int TimeIC);
+void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, const double Time, const double TimeIC);
 
 /*These functions save and load neutrino related data from the snapshots*/
 void petaio_save_neutrinos(BigFile * bf, int ThisTask);

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -29,9 +29,6 @@ struct _delta_tot_table {
     double * scalefact;
     /** Pointer to array of length nk storing initial neutrino power spectrum*/
     double * delta_nu_init;
-    /** Pointer to array of length nk storing the last neutrino power spectrum we saw, for a first estimate
-    * of the new delta_tot */
-    double * delta_nu_last;
     /**Pointer to array storing the effective wavenumbers for the above power spectra*/
     double * wavenum;
     /** Pointer to a structure for computing omega_nu*/

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -35,11 +35,9 @@ struct _delta_tot_table {
     const _omega_nu * omnu;
     /** Matter density excluding neutrinos*/
     double Omeganonu;
-    /** Light speed in internal units. C is defined in allvars.h to be lightspeed in cm/s*/
+    /** Light speed in internal units. LIGHTCGS is lightspeed in cm/s*/
     double light;
-    /** The time at which we first start our integrator:
-     * NOTE! This is not All.TimeBegin, but the time of the transfer function file,
-     * so that we can support restarting from snapshots.*/
+    /** The time at which the simulation starts*/
     double TimeTransfer;
 };
 typedef struct _delta_tot_table _delta_tot_table;

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -1,0 +1,13 @@
+#ifndef NEUTRINOS_LRA_H
+#define NEUTRINOS_LRA_H
+
+#include "kspace-neutrinos/delta_tot_table.h"
+
+/*Defined in neutrinos_lra.h*/
+extern _delta_tot_table delta_tot_table;
+extern _transfer_init_table t_init;
+
+void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[]);
+void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const _transfer_init_table * const t_init, const double TimeIC);
+
+#endif

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -2,14 +2,14 @@
 #define NEUTRINOS_LRA_H
 
 #include <bigfile-mpi.h>
-#include "kspace-neutrinos/delta_tot_table.h"
+#include "powerspectrum.h"
+#include "cosmology.h"
 
-/*Defined in neutrinos_lra.h*/
-extern _delta_tot_table delta_tot_table;
+/*Allocates the memory for the neutrino integrator*/
+void init_neutrinos_lra(const int nk_in, const double TimeTransfer, const double TimeMax, const double Omega0, const _omega_nu * const omnu, const double UnitTime_in_s, const double UnitLength_in_cm);
 
-/*Initialises a delta_tot_table*/
-void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[]);
-void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const double TimeIC);
+/*Computes delta_nu from a CDM power spectrum.*/
+void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, int Time, int TimeIC);
 
 /*These functions save and load neutrino related data from the snapshots*/
 void petaio_save_neutrinos(BigFile * bf, int ThisTask);

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -5,7 +5,14 @@
 #include "powerspectrum.h"
 #include "cosmology.h"
 
-/*Allocates the memory for the neutrino integrator*/
+/** Allocates memory for delta_tot_table.
+ * @param nk_in Number of bins stored in each power spectrum.
+ * @param TimeTransfer Scale factor of the transfer functions.
+ * @param TimeMax Final scale factor up to which we will need memory.
+ * @param Omega0 Matter density at z=0.
+ * @param omnu Pointer to structure containing pre-computed tables for evaluating neutrino matter densities.
+ * @param UnitTime_in_s Time unit of the simulation in s.
+ * @param UnitLength_in_cm Length unit of the simulation in cm*/
 void init_neutrinos_lra(const int nk_in, const double TimeTransfer, const double TimeMax, const double Omega0, const _omega_nu * const omnu, const double UnitTime_in_s, const double UnitLength_in_cm);
 
 /*Computes delta_nu from a CDM power spectrum.*/

--- a/libgadget/neutrinos_lra.h
+++ b/libgadget/neutrinos_lra.h
@@ -1,13 +1,20 @@
 #ifndef NEUTRINOS_LRA_H
 #define NEUTRINOS_LRA_H
 
+#include <bigfile-mpi.h>
 #include "kspace-neutrinos/delta_tot_table.h"
 
 /*Defined in neutrinos_lra.h*/
 extern _delta_tot_table delta_tot_table;
-extern _transfer_init_table t_init;
 
+/*Initialises a delta_tot_table*/
 void delta_tot_resume(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[]);
-void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const _transfer_init_table * const t_init, const double TimeIC);
+void delta_tot_first_init(_delta_tot_table * const d_tot, const int nk_in, const double wavenum[], const double delta_cdm_curr[], const double TimeIC);
+
+/*These functions save and load neutrino related data from the snapshots*/
+void petaio_save_neutrinos(BigFile * bf, int ThisTask);
+void petaio_read_neutrinos(BigFile * bf, int ThisTask);
+/*Loads from the ICs*/
+void petaio_read_icnutransfer(BigFile * bf, int ThisTask);
 
 #endif

--- a/libgadget/omega_nu_single.c
+++ b/libgadget/omega_nu_single.c
@@ -1,0 +1,283 @@
+#include "omega_nu_single.h"
+
+#include <math.h>
+#include <gsl/gsl_integration.h>
+#include <gsl/gsl_errno.h>
+#include <string.h>
+#include "physconst.h"
+#include "utils/mymalloc.h"
+#include "utils/endrun.h"
+
+#define HBAR    6.582119e-16  /*hbar in units of eV s*/
+#define STEFAN_BOLTZMANN 5.670373e-5
+/*Size of matter density tables*/
+#define NRHOTAB 200
+/** Floating point accuracy*/
+#define FLOAT_ACC   1e-6
+/** Number of bins in integrations*/
+#define GSL_VAL 200
+
+void init_omega_nu(_omega_nu * omnu, const double MNu[], const double a0, const double HubbleParam, const double tcmb0)
+{
+    int mi;
+    /*Explicitly disable hybrid neutrinos*/
+    omnu->hybnu.enabled=0;
+    /*CMB temperature*/
+    omnu->tcmb0 = tcmb0;
+    /*Neutrino temperature times k_B*/
+    omnu->kBtnu = BOLEVK * TNUCMB * tcmb0;
+    /*Store conversion between rho and omega*/
+    omnu->rhocrit = (3 * HUBBLE * HubbleParam * HUBBLE * HubbleParam)/ (8 * M_PI * GRAVITY);
+    /*First compute which neutrinos are degenerate with each other*/
+    for(mi=0; mi<NUSPECIES; mi++){
+        int mmi;
+        omnu->nu_degeneracies[mi]=0;
+        for(mmi=0; mmi<mi; mmi++){
+            if(fabs(MNu[mi] -MNu[mmi]) < FLOAT_ACC){
+                omnu->nu_degeneracies[mmi]+=1;
+                break;
+            }
+        }
+        if(mmi==mi) {
+            omnu->nu_degeneracies[mi]=1;
+        }
+    }
+    /*Now allocate a table for the species we want*/
+    for(mi=0; mi<NUSPECIES; mi++){
+        if(omnu->nu_degeneracies[mi]) {
+            omnu->RhoNuTab[mi] = (_rho_nu_single *) mymalloc("RhoNuTab", sizeof(_rho_nu_single));
+            rho_nu_init(omnu->RhoNuTab[mi], a0, MNu[mi], HubbleParam, omnu->kBtnu);
+        }
+        else {
+            omnu->RhoNuTab[mi] = NULL;
+        }
+    }
+}
+
+/* Return the total matter density in neutrinos.
+ * rho_nu and friends are not externally callable*/
+double get_omega_nu(const _omega_nu * const omnu, const double a)
+{
+        double rhonu=0;
+        int mi;
+        for(mi=0; mi<NUSPECIES; mi++) {
+            if(omnu->nu_degeneracies[mi] > 0){
+                 rhonu += omnu->nu_degeneracies[mi] * rho_nu(omnu->RhoNuTab[mi], a, omnu->kBtnu);
+            }
+        }
+        return rhonu/omnu->rhocrit;
+}
+
+
+/* Return the total matter density in neutrinos, excluding that in active particles.*/
+double get_omega_nu_nopart(const _omega_nu * const omnu, const double a)
+{
+    double omega_nu = get_omega_nu(omnu, a);
+    double part_nu = get_omega_nu(omnu, 1) * particle_nu_fraction(&omnu->hybnu, a, 0) / (a*a*a);
+    return omega_nu - part_nu;
+}
+
+/*Return the photon density*/
+double get_omegag(const _omega_nu * const omnu, const double a)
+{
+    const double omegag = 4*STEFAN_BOLTZMANN/(LIGHTCGS*LIGHTCGS*LIGHTCGS)*pow(omnu->tcmb0,4)/omnu->rhocrit;
+    return omegag/pow(a,4);
+}
+
+/** Value of kT/aM_nu on which to switch from the
+ * analytic expansion to the numerical integration*/
+#define NU_SW 100
+
+/*Note q carries units of eV/c. kT/c has units of eV/c.
+ * M_nu has units of eV  Here c=1. */
+double rho_nu_int(double q, void * params)
+{
+        double amnu = *((double *)params);
+        double kT = *((double *)params+1);
+        double epsilon = sqrt(q*q+amnu*amnu);
+        double f0 = 1./(exp(q/kT)+1);
+        return q*q*epsilon*f0;
+}
+
+/*Get the conversion factor to go from (eV/c)^4 to g/cm^3
+ * for a **single** neutrino species. */
+double get_rho_nu_conversion()
+{
+        /*q has units of eV/c, so rho_nu now has units of (eV/c)^4*/
+        double convert=4*M_PI*2; /* The factor of two is for antineutrinos*/
+        /*rho_nu_val now has units of eV^4*/
+        /*To get units of density, divide by (c*hbar)**3 in eV s and cm/s */
+        const double chbar=1./(2*M_PI*LIGHTCGS*HBAR);
+        convert*=(chbar*chbar*chbar);
+        /*Now has units of (eV)/(cm^3)*/
+        /* 1 eV = 1.60217646 × 10-12 g cm^2 s^(-2) */
+        /* So 1eV/c^2 = 1.7826909604927859e-33 g*/
+        /*So this is rho_nu_val in g /cm^3*/
+        convert*=(1.60217646e-12/LIGHTCGS/LIGHTCGS);
+        return convert;
+}
+
+/*Seed a pre-computed table of rho_nu values for speed*/
+void rho_nu_init(_rho_nu_single * const rho_nu_tab, const double a0, const double mnu, const double HubbleParam, const double kBtnu)
+{
+     int i;
+     double abserr;
+     /*Make the table over a slightly wider range than requested, in case there is roundoff error*/
+     const double logA0=log(a0)-log(1.2);
+     const double logaf=log(NU_SW*kBtnu/mnu)+log(1.2);
+     gsl_function F;
+     F.function = &rho_nu_int;
+     /*Initialise constants*/
+     rho_nu_tab->mnu = mnu;
+     /*Shortcircuit if we don't need to do the integration*/
+     if(mnu < 1e-6*kBtnu || logaf < logA0)
+         return;
+
+     /*Allocate memory for arrays*/
+     rho_nu_tab->loga = mymalloc("rho_nu_table",2*NRHOTAB*sizeof(double));
+     rho_nu_tab->rhonu = rho_nu_tab->loga+NRHOTAB;
+     rho_nu_tab->acc = gsl_interp_accel_alloc();
+     rho_nu_tab->interp=gsl_interp_alloc(gsl_interp_cspline,NRHOTAB);
+     if(!rho_nu_tab->interp || !rho_nu_tab->acc || !rho_nu_tab->loga)
+         endrun(2035,"Could not initialise tables for neutrino matter density\n");
+
+     gsl_integration_workspace * w = gsl_integration_workspace_alloc (GSL_VAL);
+     for(i=0; i< NRHOTAB; i++){
+        double param[2];
+        rho_nu_tab->loga[i]=logA0+i*(logaf-logA0)/(NRHOTAB-1);
+        param[0]=mnu*exp(rho_nu_tab->loga[i]);
+        param[1] = kBtnu;
+        F.params = &param;
+        gsl_integration_qag (&F, 0, 500*kBtnu,0 , 1e-9,GSL_VAL,6,w,&(rho_nu_tab->rhonu[i]), &abserr);
+        rho_nu_tab->rhonu[i]=rho_nu_tab->rhonu[i]/pow(exp(rho_nu_tab->loga[i]),4)*get_rho_nu_conversion();
+     }
+     gsl_integration_workspace_free (w);
+     gsl_interp_init(rho_nu_tab->interp,rho_nu_tab->loga,rho_nu_tab->rhonu,NRHOTAB);
+     return;
+}
+
+/*Heavily non-relativistic*/
+static inline double non_rel_rho_nu(const double a, const double kT, const double amnu, const double kTamnu2)
+{
+    /*The constants are Riemann zetas: 3,5,7 respectively*/
+    return amnu*(kT*kT*kT)/(a*a*a*a)*(1.5*1.202056903159594+kTamnu2*45./4.*1.0369277551433704+2835./32.*kTamnu2*kTamnu2*1.0083492773819229+80325/32.*kTamnu2*kTamnu2*kTamnu2*1.0020083928260826)*get_rho_nu_conversion();
+}
+
+/*Heavily relativistic: we could be more accurate here,
+ * but in practice this will only be called for massless neutrinos, so don't bother.*/
+static inline double rel_rho_nu(const double a, const double kT)
+{
+    return 7*pow(M_PI*kT/a,4)/120.*get_rho_nu_conversion();
+}
+
+/*Finds the physical density in neutrinos for a single neutrino species
+  1.878 82(24) x 10-29 h02 g/cm3 = 1.053 94(13) x 104 h02 eV/cm3*/
+double rho_nu(_rho_nu_single * rho_nu_tab, const double a, const double kT)
+{
+        double rho_nu_val;
+        double amnu=a*rho_nu_tab->mnu;
+        const double kTamnu2=(kT*kT/amnu/amnu);
+        /*Do it analytically if we are in a regime where we can
+         * The next term is 141682 (kT/amnu)^8.
+         * At kT/amnu = 8, higher terms are larger and the series stops converging.
+         * Don't go lower than 50 here. */
+        if(NU_SW*NU_SW*kTamnu2 < 1){
+            /*Heavily non-relativistic*/
+            rho_nu_val = non_rel_rho_nu(a, kT, amnu, kTamnu2);
+        }
+        else if(amnu < 1e-6*kT){
+            /*Heavily relativistic*/
+            rho_nu_val=rel_rho_nu(a, kT);
+        }
+        else{
+            const double loga = log(a);
+            /* Deal with early time case. In practice no need to be very accurate.
+             * Use either limiting case. */
+            if (!rho_nu_tab->loga || loga < rho_nu_tab->loga[0]) {
+                if(amnu < 1e-4*kT)
+                    rho_nu_val = rel_rho_nu(a,kT);
+                else
+                    rho_nu_val = non_rel_rho_nu(a, kT, amnu, kTamnu2);
+            }
+            else
+                rho_nu_val=gsl_interp_eval(rho_nu_tab->interp,rho_nu_tab->loga,rho_nu_tab->rhonu,loga,rho_nu_tab->acc);
+        }
+        return rho_nu_val;
+}
+
+/*The following function definitions are only used for hybrid neutrinos*/
+
+/*Fermi-Dirac kernel for below*/
+double fermi_dirac_kernel(double x, void * params)
+{
+  return x * x / (exp(x) + 1);
+}
+
+/* Fraction of neutrinos not followed analytically
+ * This is integral f_0(q) q^2 dq between 0 and qc to compute the fraction of OmegaNu which is in particles.*/
+double nufrac_low(const double qc)
+{
+    /*These functions are so smooth that we don't need much space*/
+    gsl_integration_workspace * w = gsl_integration_workspace_alloc (100);
+    double abserr;
+    gsl_function F;
+    F.function = &fermi_dirac_kernel;
+    F.params = NULL;
+    double total_fd;
+    gsl_integration_qag (&F, 0, qc, 0, 1e-6,100,GSL_INTEG_GAUSS61, w,&(total_fd), &abserr);
+    /*divided by the total F-D probability (which is 3 Zeta(3)/2 ~ 1.8 if MAX_FERMI_DIRAC is large enough*/
+    total_fd /= 1.5*1.202056903159594;
+    gsl_integration_workspace_free (w);
+    return total_fd;
+}
+
+void init_hybrid_nu(_hybrid_nu * const hybnu, const double mnu[], const double vcrit, const double light, const double nu_crit_time, const double kBtnu)
+{
+    hybnu->enabled=1;
+    int i;
+    hybnu->nu_crit_time = nu_crit_time;
+    hybnu->vcrit = vcrit / light;
+    for(i=0; i< NUSPECIES; i++) {
+        const double qc = mnu[i] * vcrit / light / kBtnu;
+        hybnu->nufrac_low[i] = nufrac_low(qc);
+    }
+}
+
+/* Returns the fraction of neutrinos currently traced by particles.
+ * When neutrinos are fully analytic at early times, returns 0.
+ * Last argument: neutrino species to use.
+ */
+double particle_nu_fraction(const _hybrid_nu * const hybnu, const double a, const int i)
+{
+    /*Return zero if hybrid neutrinos not enabled*/
+    if(!hybnu->enabled)
+        return 0;
+    /*Just use a redshift cut for now. Really we want something more sophisticated,
+     * based on the shot noise and average overdensity.*/
+    if (a > hybnu->nu_crit_time){
+        return hybnu->nufrac_low[i];
+    }
+    return 0;
+}
+
+/*End functions used only for hybrid neutrinos*/
+
+/* Return the matter density in neutrino species i.*/
+double omega_nu_single(const _omega_nu * const omnu, const double a, int i)
+{
+    /*Deal with case where we want a species degenerate with another one*/
+    if(omnu->nu_degeneracies[i] == 0) {
+        int j;
+        for(j=i; j >=0; j--)
+            if(omnu->nu_degeneracies[j]){
+                i = j;
+                break;
+            }
+    }
+    double omega_nu = rho_nu(omnu->RhoNuTab[i], a,omnu->kBtnu)/omnu->rhocrit;
+    double omega_part = rho_nu(omnu->RhoNuTab[i], 1,omnu->kBtnu)/omnu->rhocrit;
+    omega_part *= particle_nu_fraction(&omnu->hybnu, a, i)/(a*a*a);
+    omega_nu -= omega_part;
+    return omega_nu;
+
+}

--- a/libgadget/omega_nu_single.c
+++ b/libgadget/omega_nu_single.c
@@ -45,12 +45,10 @@ void init_omega_nu(_omega_nu * omnu, const double MNu[], const double a0, const 
     /*Now allocate a table for the species we want*/
     for(mi=0; mi<NUSPECIES; mi++){
         if(omnu->nu_degeneracies[mi]) {
-            omnu->RhoNuTab[mi] = (_rho_nu_single *) mymalloc("RhoNuTab", sizeof(_rho_nu_single));
-            rho_nu_init(omnu->RhoNuTab[mi], a0, MNu[mi], HubbleParam, omnu->kBtnu);
+            rho_nu_init(&omnu->RhoNuTab[mi], a0, MNu[mi], HubbleParam, omnu->kBtnu);
         }
-        else {
-            omnu->RhoNuTab[mi] = NULL;
-        }
+        else
+            omnu->RhoNuTab[mi].loga = 0;
     }
 }
 
@@ -62,7 +60,7 @@ double get_omega_nu(const _omega_nu * const omnu, const double a)
         int mi;
         for(mi=0; mi<NUSPECIES; mi++) {
             if(omnu->nu_degeneracies[mi] > 0){
-                 rhonu += omnu->nu_degeneracies[mi] * rho_nu(omnu->RhoNuTab[mi], a, omnu->kBtnu);
+                 rhonu += omnu->nu_degeneracies[mi] * rho_nu(&omnu->RhoNuTab[mi], a, omnu->kBtnu);
             }
         }
         return rhonu/omnu->rhocrit;
@@ -172,7 +170,7 @@ static inline double rel_rho_nu(const double a, const double kT)
 
 /*Finds the physical density in neutrinos for a single neutrino species
   1.878 82(24) x 10-29 h02 g/cm3 = 1.053 94(13) x 104 h02 eV/cm3*/
-double rho_nu(_rho_nu_single * rho_nu_tab, const double a, const double kT)
+double rho_nu(const _rho_nu_single * rho_nu_tab, const double a, const double kT)
 {
         double rho_nu_val;
         double amnu=a*rho_nu_tab->mnu;
@@ -274,8 +272,8 @@ double omega_nu_single(const _omega_nu * const omnu, const double a, int i)
                 break;
             }
     }
-    double omega_nu = rho_nu(omnu->RhoNuTab[i], a,omnu->kBtnu)/omnu->rhocrit;
-    double omega_part = rho_nu(omnu->RhoNuTab[i], 1,omnu->kBtnu)/omnu->rhocrit;
+    double omega_nu = rho_nu(&omnu->RhoNuTab[i], a,omnu->kBtnu)/omnu->rhocrit;
+    double omega_part = rho_nu(&omnu->RhoNuTab[i], 1,omnu->kBtnu)/omnu->rhocrit;
     omega_part *= particle_nu_fraction(&omnu->hybnu, a, i)/(a*a*a);
     omega_nu -= omega_part;
     return omega_nu;

--- a/libgadget/omega_nu_single.h
+++ b/libgadget/omega_nu_single.h
@@ -1,0 +1,136 @@
+#ifndef OMEGA_NU_SINGLE_H
+#define OMEGA_NU_SINGLE_H
+/** \file 
+ * Routines for computing the matter density in a single neutrino species*/
+
+#include <gsl/gsl_interp.h>
+
+/** Ratio between the massless neutrino temperature and the CMB temperature.
+ * Note there is a slight correction from 4/11
+ * due to the neutrinos being slightly coupled at e+- annihilation.
+ * See Mangano et al 2005 (hep-ph/0506164)
+ * We use the CLASS default value, chosen so that omega_nu = m_nu / 93.14 h^2
+ * At time of writing this is T_nu / T_gamma = 0.71611.
+ * See https://github.com/lesgourg/class_public/blob/master/explanatory.ini
+ */
+#define TNUCMB     (pow(4/11.,1/3.)*1.00328)
+/** Number of massive neutrino species: 3
+ * Could be made configurable at some point
+ * Neutrino masses are in eV*/
+#define NUSPECIES 3
+
+/** Tables for rho_nu (neutrino density): stores precomputed values between
+ * simulation start and a M_nu = 20 kT_nu for a single neutrino species.*/
+struct _rho_nu_single {
+    double * loga;
+    double * rhonu;
+    gsl_interp * interp;
+    gsl_interp_accel * acc;
+    /*Neutrino mass for this structure*/
+    double mnu;
+};
+typedef struct _rho_nu_single _rho_nu_single;
+
+/** Initialise the tables for matter density in a single neutrino species, by doing numerical integration.
+ * @param rho_nu_tab Structure to initialise
+ * @param a0 First scale factor in rho_nu_tab. Do not try and evaluate rho_nu at higher redshift!
+ * @param mnu neutrino mass to compute neutrino matter density for in eV
+ * @param HubbleParam (dimensionless) reduced hubble parameter, eg, 0.7. Unused.
+ * @param kBtnu Boltzmann constant times neutrino temperature. Dimensionful factor.*/
+void rho_nu_init(_rho_nu_single * rho_nu_tab, double a0, const double mnu, const double HubbleParam, const double kBtnu);
+
+/** Computes the neutrino density for a single neutrino species at a given redshift, either by looking up in a table, 
+ * or a simple calculation in the limits, or by direct integration.
+ * @param rho_nu_tab Pre-computed table of values
+ * @param a Redshift desired.
+ * @param kT Boltzmann constant times neutrino temperature. Dimensionful factor.
+ * @returns neutrino density in g cm^-3 */
+double rho_nu(_rho_nu_single * rho_nu_tab, const double a, const double kT);
+
+/** \section Hybrid
+ * Hybrid Neutrinos: The following functions and structures are used for hybrid neutrinos only.*/
+
+/** Structure storing parameters related to the hybrid neutrino code.*/
+struct _hybrid_nu {
+    /*True if hybrid neutrinos are enabled*/
+    int enabled;
+    /* This is the fraction of neutrino mass not followed by the analytic integrator.
+    The analytic method is cutoff at q < qcrit (specified using vcrit, below) and use
+    particles for the slower neutrinos.*/
+    double nufrac_low[NUSPECIES];
+    /* Time at which to turn on the particle neutrinos.
+     * Ultimately we want something better than this.*/
+    double nu_crit_time;
+    /*Critical velocity as a fraction of lightspeed*/
+    double vcrit;
+};
+typedef struct _hybrid_nu _hybrid_nu;
+
+/**Set up parameters for the hybrid neutrinos
+ * @param hybnu initialised structure
+ * @param mnu array of neutrino masses in eV
+ * @param vcrit Critical velocity above which to treat neutrinos with particles.
+ *   Note this is unperturbed velocity *TODAY*
+ *   To get velocity at redshift z, multiply by (1+z)
+ * @param light speed of light in internal units
+ * @param nu_crit_time critical time to make neutrino particles live
+ * @param kBtnu Boltzmann constant times neutrino temperature. Dimensionful factor.*/
+void init_hybrid_nu(_hybrid_nu * const hybnu, const double mnu[], const double vcrit, const double light, const double nu_crit_time, const double kBtnu);
+
+/** Get fraction of neutrinos currently followed by particles.
+ * @param hybnu Structure with hybrid neutrino parameters.
+ * @param i index of neutrino species to use.
+ * @param a redshift of interest.
+ * @returns the fraction of neutrinos currently traced by particles. 
+ * 0 when neutrinos are fully analytic at early times.
+ */
+double particle_nu_fraction(const _hybrid_nu * const hybnu, const double a, int i);
+
+/** Integrate the fermi-dirac kernel between 0 and qc to find the fraction of neutrinos that are particles*/
+double nufrac_low(const double qc);
+
+/**End hybrid neutrino-only structures.*/
+
+/**\section External
+ * Externally callable functions.*/
+/** Structure containing cosmological parameters related to the massive neutrinos*/
+struct _omega_nu {
+    /*Pointers to the array of structures we use to store rho_nu*/
+    _rho_nu_single * RhoNuTab[NUSPECIES];
+    /* Which species have the same mass and can thus be counted together.*/
+    int nu_degeneracies[NUSPECIES];
+    /* Prefactor to turn density into matter density omega*/
+    double rhocrit;
+    /*neutrino temperature times Boltzmann constant*/
+    double kBtnu;
+    /*CMB temperature*/
+    double tcmb0;
+    /* Pointer to structure for hybrid neutrinos. */
+    _hybrid_nu hybnu;
+};
+typedef struct _omega_nu _omega_nu;
+
+/**Initialise the neutrino structure, do the time integration and allocate memory for the subclass rho_nu_single
+ * @param omnu structure to initialise
+ * @param MNu array of neutrino masses in eV. Three entries.
+ * @param a0 initial scale factor.
+ * @param HubbleParam Hubble parameter h0, eg, 0.7.
+ * @param tcmb0 Redshift zero CMB temperature.*/
+void init_omega_nu(_omega_nu * const omnu, const double MNu[], const double a0, const double HubbleParam, const double tcmb0);
+
+/** Return the total matter density in neutrinos at scale factor a.*/
+double get_omega_nu(const _omega_nu * const omnu, const double a);
+
+/** Return the total matter density in neutrinos at scale factor a , excluding active particles.*/
+double get_omega_nu_nopart(const _omega_nu * const omnu, const double a);
+
+/** Return the photon matter density at scale factor a*/
+double get_omegag(const _omega_nu * const omnu, const double a);
+
+/** Return the matter density in a single neutrino species
+ * @param rho_nu_tab structure containing pre-computed matter density values. 
+ * @param i index of neutrino species we want
+ * @param a scale factor desired*/
+double omega_nu_single(const _omega_nu * const rho_nu_tab, const double a, const int i);
+
+#endif

--- a/libgadget/omega_nu_single.h
+++ b/libgadget/omega_nu_single.h
@@ -45,7 +45,7 @@ void rho_nu_init(_rho_nu_single * rho_nu_tab, double a0, const double mnu, const
  * @param a Redshift desired.
  * @param kT Boltzmann constant times neutrino temperature. Dimensionful factor.
  * @returns neutrino density in g cm^-3 */
-double rho_nu(_rho_nu_single * rho_nu_tab, const double a, const double kT);
+double rho_nu(const _rho_nu_single * rho_nu_tab, const double a, const double kT);
 
 /** \section Hybrid
  * Hybrid Neutrinos: The following functions and structures are used for hybrid neutrinos only.*/
@@ -96,7 +96,7 @@ double nufrac_low(const double qc);
 /** Structure containing cosmological parameters related to the massive neutrinos*/
 struct _omega_nu {
     /*Pointers to the array of structures we use to store rho_nu*/
-    _rho_nu_single * RhoNuTab[NUSPECIES];
+    _rho_nu_single RhoNuTab[NUSPECIES];
     /* Which species have the same mass and can thus be counted together.*/
     int nu_degeneracies[NUSPECIES];
     /* Prefactor to turn density into matter density omega*/

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -174,6 +174,10 @@ void petaio_save_neutrinos(BigFile * bf)
     strides[0] = sizeof(double);
     big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
     petaio_save_block(bf, "Neutrino/DeltaNuInit", &delta_nu);
+    /*Now write the k values*/
+    BigArray kvalue = {0};
+    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
+    petaio_save_block(bf, "Neutrino/kvalue", &kvalue);
     }
 }
 
@@ -227,6 +231,10 @@ void petaio_read_neutrinos(BigFile * bf)
     strides[0] = sizeof(double);
     big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
     petaio_read_block(bf, "Neutrino/DeltaNuInit", &delta_nu, 0);
+    /* Read the k values*/
+    BigArray kvalue = {0};
+    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
+    petaio_read_block(bf, "Neutrino/kvalue", &kvalue, 0);
 
     /*Broadcast the arrays.*/
     MPI_Bcast(&(delta_tot_table.ia), 1,MPI_INT,0,MPI_COMM_WORLD);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -17,7 +17,7 @@
 #include "slotsmanager.h"
 #include "partmanager.h"
 #include "config.h"
-#include "kspace-neutrinos/delta_tot_table.h"
+#include "neutrinos_lra.h"
 
 #include "utils.h"
 
@@ -123,12 +123,6 @@ petaio_build_selection(int * selection,
         }
     }
 }
-
-/*These two functions are only ued for the semi-linear neutrino implementation,
- * and store data specific to that in the snapshots*/
-/*Defined in gravpm.c*/
-extern _delta_tot_table delta_tot_table;
-extern _transfer_init_table t_init;
 
 void petaio_save_neutrinos(BigFile * bf)
 {

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -124,186 +124,6 @@ petaio_build_selection(int * selection,
     }
 }
 
-void petaio_save_neutrinos(BigFile * bf)
-{
-#pragma omp master
-    {
-    double * scalefact = delta_tot_table.scalefact;
-    size_t nk = delta_tot_table.nk, ia = delta_tot_table.ia;
-    size_t ik, i;
-    double * delta_tot = mymalloc("tmp_delta",nk * ia * sizeof(double));
-    /*Save a flat memory block*/
-    for(ik=0;ik< nk;ik++)
-        for(i=0;i< ia;i++)
-            delta_tot[ik*ia+i] = delta_tot_table.delta_tot[ik][i];
-
-    BigBlock bn = {0};
-    if(0 != big_file_mpi_create_block(bf, &bn, "Neutrino", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to create block at %s:%s\n", "Neutrino",
-                big_file_get_error_message());
-    }
-    if ( (0 != big_block_set_attr(&bn, "Nscale", &ia, "u8", 1)) ||
-       (0 != big_block_set_attr(&bn, "scalefact", scalefact, "f8", ia)) ||
-        (0 != big_block_set_attr(&bn, "Nkval", &nk, "u8", 1)) ) {
-        endrun(0, "Failed to write neutrino attributes %s\n",
-                    big_file_get_error_message());
-    }
-    if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to close block %s\n",
-                    big_file_get_error_message());
-    }
-    BigArray deltas = {0};
-    size_t dims[2] = {0 , ia};
-    /*The neutrino state is shared between all processors,
-     *so only write on master task*/
-    if(ThisTask == 0) {
-        dims[0] = nk;
-    }
-    ptrdiff_t strides[2] = {sizeof(double) * ia, sizeof(double)};
-    big_array_init(&deltas, delta_tot, "=f8", 2, dims, strides);
-    petaio_save_block(bf, "Neutrino/Deltas", &deltas);
-    myfree(delta_tot);
-    /*Now write the initial neutrino power*/
-    BigArray delta_nu = {0};
-    dims[1] = 1;
-    strides[0] = sizeof(double);
-    big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
-    petaio_save_block(bf, "Neutrino/DeltaNuInit", &delta_nu);
-    /*Now write the k values*/
-    BigArray kvalue = {0};
-    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
-    petaio_save_block(bf, "Neutrino/kvalue", &kvalue);
-    }
-}
-
-void petaio_read_icnutransfer(BigFile * bf, _transfer_init_table * t_init)
-{
-#pragma omp master
-    {
-    t_init->NPowerTable = 2;
-    BigBlock bn = {{0}};
-    /* Read the size of the ICTransfer block.
-     * If we can't read it, just set it to zero*/
-    if(0 == big_file_mpi_open_block(bf, &bn, "ICTransfers", MPI_COMM_WORLD)) {
-        if(0 != big_block_get_attr(&bn, "Nentry", &t_init->NPowerTable, "u8", 1))
-            endrun(0, "Failed to read attr: %s\n", big_file_get_error_message());
-        if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD))
-            endrun(0, "Failed to close block %s\n",big_file_get_error_message());
-    }
-    message(1,"Found transfer function, using %d rows.\n", t_init->NPowerTable);
-    t_init->logk = (double *) mymalloc("Transfer_functions", 2*t_init->NPowerTable* sizeof(double));
-    t_init->T_nu=t_init->logk+t_init->NPowerTable;
-
-    /*Defaults: zero*/
-    t_init->logk[0] = -100;
-    t_init->logk[t_init->NPowerTable-1] = 100;
-
-    t_init->T_nu[0] = 0;
-    t_init->T_nu[t_init->NPowerTable-1] = 0;
-
-    /*Now read the arrays*/
-    BigArray Tnu = {0};
-    BigArray logk = {0};
-
-    size_t dims[2] = {0, 1};
-    ptrdiff_t strides[2] = {sizeof(double), sizeof(double)};
-    /*The neutrino state is shared between all processors,
-     *so only read on master task and broadcast*/
-    if(ThisTask == 0) {
-        dims[0] = t_init->NPowerTable;
-    }
-    big_array_init(&Tnu, t_init->T_nu, "=f8", 2, dims, strides);
-    big_array_init(&logk, t_init->logk, "=f8", 2, dims, strides);
-    /*This is delta_nu / delta_tot: note technically the most massive eigenstate only.
-     * But if there are significant differences the mass is so low this is basically zero.*/
-    petaio_read_block(bf, "ICTransfers/DELTA_NU", &Tnu, 0);
-    petaio_read_block(bf, "ICTransfers/logk", &logk, 0);
-    /*Also want d_{cdm+bar} / d_tot so we can get d_nu/(d_cdm+d_b)*/
-    double * T_cb = (double *) mymalloc("tmp1", t_init->NPowerTable* sizeof(double));
-    BigArray Tcb = {0};
-    big_array_init(&Tcb, T_cb, "=f8", 2, dims, strides);
-    petaio_read_block(bf, "ICTransfers/DELTA_CB", &Tcb, 0);
-    int i;
-    for(i = 0; i < t_init->NPowerTable; i++)
-        t_init->T_nu[i] /= T_cb[i];
-    myfree(T_cb);
-    /*Broadcast the arrays.*/
-    MPI_Bcast(t_init->logk,2*t_init->NPowerTable,MPI_DOUBLE,0,MPI_COMM_WORLD);
-    }
-}
-
-/*Read the neutrino data from the snapshot*/
-void petaio_read_neutrinos(BigFile * bf)
-{
-#pragma omp master
-    {
-    size_t nk, ia, ik, i;
-    BigBlock bn = {0};
-    if(0 != big_file_mpi_open_block(bf, &bn, "Neutrino", MPI_COMM_WORLD)) {
-        endrun(0, "Failed to open block at %s:%s\n", "Neutrino",
-                    big_file_get_error_message());
-    }
-    if(
-    (0 != big_block_get_attr(&bn, "Nscale", &ia, "u8", 1)) ||
-    (0 != big_block_get_attr(&bn, "Nkval", &nk, "u8", 1))) {
-        endrun(0, "Failed to read attr: %s\n",
-                    big_file_get_error_message());
-    }
-    double *delta_tot = (double *) mymalloc("tmp_nusave",ia*nk*sizeof(double));
-    /*Allocate list of scale factors, and space for delta_tot, in one operation.*/
-    if(0 != big_block_get_attr(&bn, "scalefact", delta_tot_table.scalefact, "f8", ia))
-        endrun(0, "Failed to read attr: %s\n", big_file_get_error_message());
-    if(0 != big_block_mpi_close(&bn, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to close block %s\n",
-                    big_file_get_error_message());
-    }
-    BigArray deltas = {0};
-    size_t dims[2] = {0, ia};
-    ptrdiff_t strides[2] = {sizeof(double)*ia, sizeof(double)};
-    /*The neutrino state is shared between all processors,
-     *so only read on master task and broadcast*/
-    if(ThisTask == 0) {
-        dims[0] = nk;
-    }
-    big_array_init(&deltas, delta_tot, "=f8", 2, dims, strides);
-    petaio_read_block(bf, "Neutrino/Deltas", &deltas, 1);
-
-    /*Save a flat memory block*/
-    for(ik=0;ik<nk;ik++)
-        for(i=0;i<ia;i++)
-            delta_tot_table.delta_tot[ik][i] = delta_tot[ik*ia+i];
-    delta_tot_table.nk = nk;
-    delta_tot_table.ia = ia;
-    myfree(delta_tot);
-    /* Read the initial delta_nu. This is basically zero anyway,
-     * so for backwards compatibility do not require it*/
-    BigArray delta_nu = {0};
-    dims[1] = 1;
-    strides[0] = sizeof(double);
-    memset(delta_tot_table.delta_nu_init, 0, delta_tot_table.nk);
-    big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
-    petaio_read_block(bf, "Neutrino/DeltaNuInit", &delta_nu, 0);
-    /* Read the k values*/
-    BigArray kvalue = {0};
-    memset(delta_tot_table.wavenum, 0, delta_tot_table.nk);
-    big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
-    petaio_read_block(bf, "Neutrino/kvalue", &kvalue, 0);
-
-    /*Broadcast the arrays.*/
-    MPI_Bcast(&(delta_tot_table.ia), 1,MPI_INT,0,MPI_COMM_WORLD);
-    MPI_Bcast(&(delta_tot_table.nk), 1,MPI_INT,0,MPI_COMM_WORLD);
-    MPI_Bcast(delta_tot_table.delta_nu_init,delta_tot_table.nk,MPI_DOUBLE,0,MPI_COMM_WORLD);
-
-    if(delta_tot_table.ia > 0) {
-        /*Broadcast data for scalefact and delta_tot, Delta_tot is allocated as the same block of memory as scalefact.
-          Not all this memory will actually have been used, but it is easiest to bcast all of it.*/
-        MPI_Bcast(delta_tot_table.scalefact,delta_tot_table.namax*(delta_tot_table.nk+1),MPI_DOUBLE,0,MPI_COMM_WORLD);
-    }
-    }
-}
-/*End of massive neutrino functions*/
-
-
 static void petaio_save_internal(char * fname) {
     BigFile bf = {0};
     if(0 != big_file_mpi_create(&bf, fname, MPI_COMM_WORLD)) {
@@ -340,7 +160,7 @@ static void petaio_save_internal(char * fname) {
     }
 
     if(All.MassiveNuLinRespOn) {
-        petaio_save_neutrinos(&bf);
+        petaio_save_neutrinos(&bf, ThisTask);
     }
     if(0 != big_file_mpi_close(&bf, MPI_COMM_WORLD)){
         endrun(0, "Failed to close snapshot at %s:%s\n", fname,
@@ -468,9 +288,9 @@ void petaio_read_internal(char * fname, int ic) {
     if(All.MassiveNuLinRespOn) {
         /*Read the neutrino transfer function from the ICs*/
         if(ic)
-            petaio_read_icnutransfer(&bf, &t_init);
+            petaio_read_icnutransfer(&bf, ThisTask);
         else
-            petaio_read_neutrinos(&bf);
+            petaio_read_neutrinos(&bf, ThisTask);
     }
 
     if(0 != big_file_mpi_close(&bf, MPI_COMM_WORLD)) {

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -229,10 +229,12 @@ void petaio_read_neutrinos(BigFile * bf)
     BigArray delta_nu = {0};
     dims[1] = 1;
     strides[0] = sizeof(double);
+    memset(delta_tot_table.delta_nu_init, 0, delta_tot_table.nk);
     big_array_init(&delta_nu, delta_tot_table.delta_nu_init, "=f8", 2, dims, strides);
     petaio_read_block(bf, "Neutrino/DeltaNuInit", &delta_nu, 0);
     /* Read the k values*/
     BigArray kvalue = {0};
+    memset(delta_tot_table.wavenum, 0, delta_tot_table.nk);
     big_array_init(&kvalue, delta_tot_table.wavenum, "=f8", 2, dims, strides);
     petaio_read_block(bf, "Neutrino/kvalue", &kvalue, 0);
 

--- a/libgadget/physconst.h
+++ b/libgadget/physconst.h
@@ -8,8 +8,11 @@
 #define  RAD_CONST   7.565e-15
 #define  AVOGADRO    6.0222e23
 #define  BOLTZMANN   1.38066e-16
+/** The Boltzmann constant in units of eV/K*/
+#define BOLEVK 8.61734e-5
 #define  GAS_CONST   8.31425e7
-#define  C           2.9979e10
+/** Speed of light in cm/s: used to be called 'C'*/
+#define  LIGHTCGS           2.99792458e10
 #define  PLANCK      6.6262e-27
 #define  CM_PER_MPC  3.085678e24
 #define  PROTONMASS  1.6726e-24

--- a/libgadget/powerspectrum.c
+++ b/libgadget/powerspectrum.c
@@ -13,15 +13,19 @@
 /*Power spectrum related functions*/
 
 /*Allocate memory for the power spectrum*/
-void powerspectrum_alloc(struct _powerspectrum * PowerSpectrum, const int nbins, const int nthreads)
+void powerspectrum_alloc(struct _powerspectrum * PowerSpectrum, const int nbins, const int nthreads, const int MassiveNuLinResp)
 {
     PowerSpectrum->size = nbins;
     const int nalloc = nbins*nthreads;
     PowerSpectrum->nalloc = nalloc;
-    PowerSpectrum->kk = mymalloc("Powerspectrum", sizeof(double) * (2*nalloc + 3*nbins));
+    PowerSpectrum->kk = mymalloc("Powerspectrum", sizeof(double) * 2*nalloc);
     PowerSpectrum->Power = PowerSpectrum->kk + nalloc;
-    PowerSpectrum->logknu = PowerSpectrum->kk + 2*nalloc;
-    PowerSpectrum->Pnuratio = PowerSpectrum-> logknu + nbins;
+    if(MassiveNuLinResp) {
+        /*These arrays are stored separately to make interpolation more accurate*/
+        PowerSpectrum->logknu = mymalloc("PowerNu", sizeof(double) * 3*nbins);
+        PowerSpectrum->Pnuratio = PowerSpectrum-> logknu + nbins;
+        PowerSpectrum->Pnu = PowerSpectrum-> logknu + 2*nbins;
+    }
     PowerSpectrum->Nmodes = mymalloc("Powermodes", sizeof(int64_t) * nalloc);
 }
 
@@ -111,9 +115,8 @@ void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * O
      * We have that O_0 d_t = O_cdm d_cdm (1 + Pnuratio)
      * so that d_nu = Pnuratio /O_nu (O_cdm d_cdm) = Pnuratio/(1+Pnuratio) d_t O_0/O_nu
      * and O_0 / O_nu = 1 + O_nonu/O_nu = 1 + 1/n_prefac*/
-    for(i = 0; i < PowerSpectrum->nonzero; i++){//pow(PowerSpectrum->Pnuratio[i],2) * PowerSpectrum-> Power[i
-        double delta_nu = PowerSpectrum->Pnuratio[i] / (1 + PowerSpectrum->Pnuratio[i]) * PowerSpectrum->Power[i] * (1 + 1/PowerSpectrum->nu_prefac);
-        fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(delta_nu,2), PowerSpectrum->Nmodes[i]);
+    for(i = 0; i < PowerSpectrum->nonzero; i++){
+        fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(PowerSpectrum->Pnu[i],2), PowerSpectrum->Nmodes[i]);
     }
     fclose(fp);
     /*Clean up the neutrino memory now we saved the power spectrum.*/

--- a/libgadget/powerspectrum.c
+++ b/libgadget/powerspectrum.c
@@ -23,8 +23,8 @@ void powerspectrum_alloc(struct _powerspectrum * PowerSpectrum, const int nbins,
     if(MassiveNuLinResp) {
         /*These arrays are stored separately to make interpolation more accurate*/
         PowerSpectrum->logknu = mymalloc("PowerNu", sizeof(double) * 3*nbins);
-        PowerSpectrum->Pnuratio = PowerSpectrum-> logknu + nbins;
-        PowerSpectrum->Pnu = PowerSpectrum-> logknu + 2*nbins;
+        PowerSpectrum->delta_nu_ratio = PowerSpectrum-> logknu + nbins;
+        PowerSpectrum->delta_nu = PowerSpectrum-> logknu + 2*nbins;
     }
     PowerSpectrum->Nmodes = mymalloc("Powermodes", sizeof(int64_t) * nalloc);
 }
@@ -116,7 +116,7 @@ void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * O
      * so that d_nu = Pnuratio /O_nu (O_cdm d_cdm) = Pnuratio/(1+Pnuratio) d_t O_0/O_nu
      * and O_0 / O_nu = 1 + O_nonu/O_nu = 1 + 1/n_prefac*/
     for(i = 0; i < PowerSpectrum->nonzero; i++){
-        fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(PowerSpectrum->Pnu[i],2), PowerSpectrum->Nmodes[i]);
+        fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(PowerSpectrum->delta_nu[i],2), PowerSpectrum->Nmodes[i]);
     }
     fclose(fp);
     /*Clean up the neutrino memory now we saved the power spectrum.*/

--- a/libgadget/powerspectrum.c
+++ b/libgadget/powerspectrum.c
@@ -7,7 +7,7 @@
 
 #include "types.h"
 #include "powerspectrum.h"
-
+#include "physconst.h"
 #include "utils.h"
 
 /*Power spectrum related functions*/
@@ -62,8 +62,8 @@ void powerspectrum_sum(struct _powerspectrum * PowerSpectrum, const double BoxSi
         PowerSpectrum->Power[i] /= PowerSpectrum->Norm;
         PowerSpectrum->kk[i] /= PowerSpectrum->Nmodes[i];
         /* Mpc/h units */
-        PowerSpectrum->kk[i] *= 2 * M_PI / (BoxSize_in_cm / 3.085678e24 );
-        PowerSpectrum->Power[i] *= pow(BoxSize_in_cm / 3.085678e24 , 3.0);
+        PowerSpectrum->kk[i] *= 2 * M_PI / (BoxSize_in_cm / CM_PER_MPC );
+        PowerSpectrum->Power[i] *= pow(BoxSize_in_cm / CM_PER_MPC , 3.0);
         /*Move the power spectrum earlier, removing zero modes*/
         PowerSpectrum->Power[nk_nz] = PowerSpectrum->Power[i];
         PowerSpectrum->kk[nk_nz] = PowerSpectrum->kk[i];

--- a/libgadget/powerspectrum.c
+++ b/libgadget/powerspectrum.c
@@ -111,10 +111,6 @@ void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * O
     fprintf(fp, "# k P_nu(k) Nmodes\n");
     fprintf(fp, "# a= %g\n", Time);
     fprintf(fp, "# nk = %ld\n", PowerSpectrum->nonzero);
-    /* Pnuratio contains O_nu d_nu / (O_cdm d_cdm). Power contains P_t.
-     * We have that O_0 d_t = O_cdm d_cdm (1 + Pnuratio)
-     * so that d_nu = Pnuratio /O_nu (O_cdm d_cdm) = Pnuratio/(1+Pnuratio) d_t O_0/O_nu
-     * and O_0 / O_nu = 1 + O_nonu/O_nu = 1 + 1/n_prefac*/
     for(i = 0; i < PowerSpectrum->nonzero; i++){
         fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(PowerSpectrum->delta_nu[i],2), PowerSpectrum->Nmodes[i]);
     }

--- a/libgadget/powerspectrum.h
+++ b/libgadget/powerspectrum.h
@@ -14,6 +14,9 @@ struct _powerspectrum {
     size_t nonzero;
     double Norm;
     /*These are for the LRA neutrino code*/
+    /*neutrino perturbations*/
+    double * Pnu;
+    /*log k bins and ratio of Pnu to Pcdm: stored so interpolation is accurate*/
     double * logknu;
     double * Pnuratio;
     double nu_prefac;
@@ -23,7 +26,7 @@ struct _powerspectrum {
 };
 
 /*Allocate memory for the power spectrum*/
-void powerspectrum_alloc(struct _powerspectrum * PowerSpectrum, const int nbins, const int nthreads);
+void powerspectrum_alloc(struct _powerspectrum * PowerSpectrum, const int nbins, const int nthreads, const int MassiveNuLinResp);
 
 /*Zero memory for the power spectrum*/
 void powerspectrum_zero(struct _powerspectrum * PowerSpectrum);

--- a/libgadget/powerspectrum.h
+++ b/libgadget/powerspectrum.h
@@ -12,6 +12,7 @@ struct _powerspectrum {
     int64_t * Nmodes;
     size_t size;
     size_t nalloc;
+    size_t nonzero;
     double Norm;
 };
 

--- a/libgadget/powerspectrum.h
+++ b/libgadget/powerspectrum.h
@@ -3,17 +3,23 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <gsl/gsl_interp.h>
 
 struct _powerspectrum {
     double * kk;
     double * Power;
-    double * logknu;
-    double * Pnuratio;
     int64_t * Nmodes;
     size_t size;
     size_t nalloc;
     size_t nonzero;
     double Norm;
+    /*These are for the LRA neutrino code*/
+    double * logknu;
+    double * Pnuratio;
+    double nu_prefac;
+    gsl_interp *nu_spline;
+    gsl_interp_accel * nu_acc;
+
 };
 
 /*Allocate memory for the power spectrum*/
@@ -29,4 +35,6 @@ void powerspectrum_sum(struct _powerspectrum * PowerSpectrum, const double BoxSi
 /*Save the power spectrum to a file*/
 void powerspectrum_save(struct _powerspectrum * PowerSpectrum, const char * OutputDir, const double Time, const double D1);
 
+/*Save the neutrino power spectrum to a file*/
+void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * OutputDir, const double Time);
 #endif

--- a/libgadget/powerspectrum.h
+++ b/libgadget/powerspectrum.h
@@ -15,10 +15,10 @@ struct _powerspectrum {
     double Norm;
     /*These are for the LRA neutrino code*/
     /*neutrino perturbations*/
-    double * Pnu;
+    double * delta_nu;
     /*log k bins and ratio of Pnu to Pcdm: stored so interpolation is accurate*/
     double * logknu;
-    double * Pnuratio;
+    double * delta_nu_ratio;
     double nu_prefac;
     gsl_interp *nu_spline;
     gsl_interp_accel * nu_acc;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -25,9 +25,6 @@
 #include "slotsmanager.h"
 #include "hci.h"
 
-
-#include "kspace-neutrinos/delta_tot_table.h"
-
 void energy_statistics(void); /* stats.c only used here */
 void init(int snapnum); /* init.c only used here */
 
@@ -61,10 +58,6 @@ open_outputfiles(int RestartSnapNum);
 
 static void
 close_outputfiles(void);
-
-/*Defined in gravpm.c*/
-extern _delta_tot_table delta_tot_table;
-extern _transfer_init_table transfer_init;
 
 /*! This function performs the initial set-up of the simulation. First, the
  *  parameterfile is set, then routines for setting units, reading

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -466,7 +466,7 @@ set_units(void)
         All.InitGasTemp = DMAX(All.MinGasTemp, All.CP.CMBTemperature / All.TimeInit);
     /*Initialise the hybrid neutrinos, after Omega_nu*/
     if(All.HybridNeutrinosOn)
-        init_hybrid_nu(&All.CP.ONu.hybnu, All.CP.MNu, All.HybridVcrit, C/1e5, All.HybridNuPartTime, All.CP.ONu.kBtnu);
+        init_hybrid_nu(&All.CP.ONu.hybnu, All.CP.MNu, All.HybridVcrit, LIGHTCGS/1e5, All.HybridNuPartTime, All.CP.ONu.kBtnu);
 
     meanweight = 4.0 / (1 + 3 * HYDROGEN_MASSFRAC);	/* note: assuming NEUTRAL GAS */
 

--- a/libgadget/tests/test_neutrinos_lra.c
+++ b/libgadget/tests/test_neutrinos_lra.c
@@ -59,7 +59,6 @@ static void test_allocate_delta_tot_table(void **state)
     assert_true(delta_tot_table.namax > 10);
     assert_true(delta_tot_table.scalefact);
     assert_true(delta_tot_table.delta_nu_init);
-    assert_true(delta_tot_table.delta_nu_last);
     assert_true(delta_tot_table.delta_tot);
     for(int i=0; i<delta_tot_table.nk_allocated; i++){
         assert_true(delta_tot_table.delta_tot[i]);

--- a/libgadget/tests/test_neutrinos_lra.c
+++ b/libgadget/tests/test_neutrinos_lra.c
@@ -1,0 +1,120 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include "../neutrinos_lra.h"
+#include "../omega_nu_single.h"
+#include "../physconst.h"
+#include "../utils/endrun.h"
+#include "stub.h"
+
+#define T_CMB0 2.7255
+/** Fit to the special function J(x) that is accurate to better than 3% relative and 0.07% absolute*/
+double specialJ(const double x, const double vcmnubylight, const double nufrac_low);
+double fslength(const double logai, const double logaf, const double light);
+
+void petaio_save_block(BigFile * bf, char * blockname, BigArray * array) {};
+int petaio_read_block(BigFile * bf, char * blockname, BigArray * array, int required)
+{
+    return 0;
+}
+
+
+extern _delta_tot_table delta_tot_table;
+
+
+void setup_cosmology(Cosmology * CP, double MNu[])
+{
+    CP->CMBTemperature = 2.7255;
+    CP->Omega0 = 0.2793;
+    CP->OmegaLambda = 1- CP->Omega0;
+    CP->OmegaBaryon = 0.0464;
+    CP->HubbleParam = 0.7;
+    CP->RadiationOn = 1;
+    CP->Omega_fld = 0;
+    CP->Omega_ur = 0;
+    int i;
+    for(i = 0; i<3; i++)
+        CP->MNu[i] = MNu[i];
+    /*Default value for L=kpc v=km/s*/
+    double UnitTime_in_s = 3.08568e+16;
+    /*Should be 0.1*/
+    CP->Hubble = HUBBLE * UnitTime_in_s;
+    /*Do the main cosmology initialisation*/
+    init_cosmology(CP,0.01);
+}
+
+/* Test that the allocations are done correctly.
+ * delta_tot is still empty (but allocated) after this.*/
+static void test_allocate_delta_tot_table(void **state)
+{
+    _omega_nu omnu;
+    double MNu[3] = {0, 0, 0};
+    init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
+    init_neutrinos_lra(300, 0.01, 1, 0.2793, &omnu, 1, 1);
+    assert_true(delta_tot_table.ia == 0);
+    assert_true(delta_tot_table.namax > 10);
+    assert_true(delta_tot_table.scalefact);
+    assert_true(delta_tot_table.delta_nu_init);
+    assert_true(delta_tot_table.delta_nu_last);
+    assert_true(delta_tot_table.delta_tot);
+    for(int i=0; i<delta_tot_table.nk_allocated; i++){
+        assert_true(delta_tot_table.delta_tot[i]);
+    }
+}
+
+/*Check that the fits to the special J function are accurate, by doing explicit integration.*/
+static void test_specialJ(void **state)
+{
+    /*Check against mathematica computed values:
+    Integrate[(Sinc[q*x])*(q^2/(Exp[q] + 1)), {q, 0, Infinity}]*/
+    assert_true(specialJ(0,-1,0) == 1);
+    assert_true(fabs(specialJ(1,-1, 0) - 0.2117) < 1e-3);
+    assert_true(fabs(specialJ(2,-1, 0) - 0.0223807) < 1e-3);
+    assert_true(fabs(specialJ(0.5,-1, 0) - 0.614729) < 1e-3);
+    assert_true(fabs(specialJ(0.3,-1, 0) - 0.829763) < 1e-3);
+    /*Test that it is ok when truncated*/
+    /*Mathematica: Jfrac[x_, qc_] := NIntegrate[(Sinc[q*x])*(q^2/(Exp[q] + 1)), {q, qc, Infinity}]/(3*Zeta[3]/2) */
+    assert_true(fabs(specialJ(0,1, 0) - 0.940437) < 1e-4);
+    assert_true(fabs(specialJ(0.5,1e-2, 0.5) - 0.614729/0.5) < 1e-3);
+    assert_true(fabs(specialJ(0.5,1, 0.5) - 0.556557/0.5) < 1e-4);
+    assert_true(fabs(specialJ(1,0.1, 0.5) - 0.211662/0.5) < 1e-4);
+}
+
+/* Check that we accurately work out the free-streaming length.
+ * Free-streaming length for a non-relativistic particle of momentum q = T0, from scale factor ai to af.
+ * The 'light' argument defines the units.
+ * Test values use the following mathematica snippet:
+ kB = 8.61734*10^(-5);
+ Tnu = 2.7255*(4/11.)^(1/3.)*1.00328;
+ omegar = 5.04672*10^(-5);
+ Hubble[a_] := 3.085678*10^(21)/10^5*3.24077929*10^(-18)*Sqrt[0.2793/a^3 + (1 - 0.2793) + omegar/a^4]
+  fs[a_, Mnu_] := kB*Tnu/(a*Mnu)/(a*Hubble[a])
+  fslength[ai_, af_, Mnu_] := 299792*NIntegrate[fs[Exp[loga], Mnu], {loga, Log[ai], Log[af]}]
+ */
+static void test_fslength(void **state)
+{
+    Cosmology CP;
+    double MNu[3] = {0.15, 0.15, 0.15};
+    setup_cosmology(&CP, MNu);
+    /*Note that MNu is the mass of a single neutrino species:
+     *we use large masses so that we don't have to compute omega_nu in mathematica.*/
+    double kT = BOLEVK*TNUCMB*T_CMB0;
+    /*fslength function returns fslength * (MNu / kT)*/
+    assert_true(fabs(fslength(log(0.5), log(1), 299792.)/ 1272.92/(0.45/kT) -1 ) < 1e-5);
+    double MNu2[3] = {0.2, 0.2, 0.2};
+    setup_cosmology(&CP, MNu2);
+    assert_true(fabs(fslength(log(0.1), log(0.5),299792.)/ 5427.8/(0.6/kT) -1 ) < 1e-5);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_allocate_delta_tot_table),
+        cmocka_unit_test(test_specialJ),
+        cmocka_unit_test(test_fslength),
+    };
+    return cmocka_run_group_tests_mpi(tests, NULL, NULL);
+}

--- a/libgadget/tests/test_omega_nu_single.c
+++ b/libgadget/tests/test_omega_nu_single.c
@@ -1,0 +1,205 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <math.h>
+#include <gsl/gsl_integration.h>
+#include "stub.h"
+#include "../omega_nu_single.h"
+#include "../physconst.h"
+
+#define  T_CMB0      2.7255	/* present-day CMB temperature, from Fixsen 2009 */
+
+/* A test case that checks initialisation. */
+static void test_rho_nu_init(void **state) {
+    (void) state; /* unused */
+    double mnu = 0.06;
+    _rho_nu_single rho_nu_tab;
+    /*Initialise*/
+    rho_nu_init(&rho_nu_tab, 0.01, mnu, 0.7,BOLEVK*TNUCMB*T_CMB0);
+    /*Check everything initialised ok*/
+    assert_true(rho_nu_tab.mnu == mnu);
+    assert_true(rho_nu_tab.acc);
+    assert_true(rho_nu_tab.interp);
+    assert_true(rho_nu_tab.loga);
+    assert_true(rho_nu_tab.rhonu);
+    /*Check that loga is correctly ordered (or interpolation won't work)*/
+    for(int i=1; i<200; i++){
+        assert_true(rho_nu_tab.loga[i] > rho_nu_tab.loga[i-1]);
+    }
+}
+/*Check massless neutrinos work*/
+#define STEFAN_BOLTZMANN 5.670373e-5
+#define OMEGAR (4*STEFAN_BOLTZMANN*8*M_PI*GRAVITY/(3*LIGHTCGS*LIGHTCGS*LIGHTCGS*HUBBLE*HUBBLE*HubbleParam*HubbleParam)*pow(T_CMB0,4))
+#define GSL_VAL 200
+
+
+/* Check that the table gives the right answer. */
+static void test_omega_nu_single(void **state) {
+    (void) state; /* unused */
+    double mnu = 0.5;
+    double HubbleParam = 0.7;
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {mnu, mnu, 0};
+    init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
+    assert_true(omnu.RhoNuTab[0]->mnu == mnu);
+    /*This is the critical density at z=0:
+     * we allow it to change by what is (at the time of writing) the uncertainty on G.*/
+    assert_true(fabs(omnu.rhocrit - 1.8784e-29*HubbleParam*HubbleParam) < 5e-3*omnu.rhocrit);
+    /*Check everything initialised ok*/
+    double omnuz0 = omega_nu_single(&omnu, 1, 0);
+    /*Check redshift scaling*/
+    assert_true(fabs(omnuz0/pow(0.5,3) - omega_nu_single(&omnu, 0.5, 0)) < 5e-3*omnuz0);
+    /*Check not just a^-3 scaling*/
+    assert_true(omnuz0/pow(0.01,3) <  omega_nu_single(&omnu, 0.01, 0));
+    /*Check that we have correctly accounted for neutrino decoupling*/
+    assert_true(fabs(omnuz0 - mnu/93.14/HubbleParam/HubbleParam) < 1e-3*omnuz0);
+    /*Check degenerate species works*/
+    assert_true(omega_nu_single(&omnu, 0.1, 1) == omega_nu_single(&omnu, 0.1, 0));
+    /*Check we get it right for massless neutrinos*/
+    double omnunomassz0 = omega_nu_single(&omnu, 1, 2);
+    assert_true(omnunomassz0 - OMEGAR*7./8.*pow(pow(4/11.,1/3.)*1.00381,4)< 1e-5*omnunomassz0);
+    assert_true(omnunomassz0/pow(0.5,4) == omega_nu_single(&omnu, 0.5, 2));
+    /*Check that we return something vaguely sensible for very early times*/
+    assert_true(omega_nu_single(&omnu,1e-4,0) > omega_nu_single(&omnu, 1,0)/pow(1e-4,3));
+}
+
+
+double get_rho_nu_conversion();
+
+/*Note q carries units of eV/c. kT/c has units of eV/c.
+ * M_nu has units of eV  Here c=1. */
+double rho_nu_int(double q, void * params);
+
+double do_exact_rho_nu_integration(double a, double mnu, double rhocrit)
+{
+    gsl_function F;
+    gsl_integration_workspace * w = gsl_integration_workspace_alloc (GSL_VAL);
+    double abserr;
+    F.function = &rho_nu_int;
+    double kTnu = BOLEVK*TNUCMB*T_CMB0;
+    double param[2] = {mnu * a, kTnu};
+    F.params = &param;
+    double result;
+    gsl_integration_qag (&F, 0, 500*kTnu,0 , 1e-9,GSL_VAL,6,w,&result, &abserr);
+    result*=get_rho_nu_conversion()/pow(a,4)/rhocrit;
+    gsl_integration_workspace_free (w);
+    return result;
+}
+
+/*Check exact integration against the interpolation table*/
+static void test_omega_nu_single_exact(void **state)
+{
+    double mnu = 0.05;
+    double hubble = 0.7;
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {mnu, mnu, mnu};
+    init_omega_nu(&omnu, MNu, 0.01, hubble,T_CMB0);
+    double omnuz0 = omega_nu_single(&omnu, 1, 0);
+    double rhocrit = omnu.rhocrit;
+    assert_true(fabs(1 - do_exact_rho_nu_integration(1, mnu, rhocrit)/omnuz0) < 1e-6);
+    for(int i=1; i< 123; i++) {
+        double a = 0.01 + i/123.;
+        omnuz0 = omega_nu_single(&omnu, a, 0);
+        double omexact = do_exact_rho_nu_integration(a, mnu, rhocrit);
+        if(fabs(omnuz0 - omexact) > 1e-6 * omnuz0)
+            printf("a=%g %g %g %g\n",a, omnuz0, omexact, omnuz0/omexact-1);
+        assert_true(fabs(1 - omexact/omnuz0) < 1e-6);
+    }
+}
+
+static void test_omega_nu_init_degenerate(void **state) {
+    /*Check we correctly initialise omega_nu with degenerate neutrinos*/
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {0.2,0.2,0.2};
+    init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
+    /*Check that we initialised the right number of arrays*/
+    assert_int_equal(omnu.nu_degeneracies[0], 3);
+    assert_int_equal(omnu.nu_degeneracies[1], 0);
+    assert_true(omnu.RhoNuTab[0]);
+    assert_false(omnu.RhoNuTab[1]);
+}
+
+static void test_omega_nu_init_nondeg(void **state) {
+    /*Now check that it works with a non-degenerate set*/
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {0.2,0.1,0.3};
+    init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
+    /*Check that we initialised the right number of arrays*/
+    for(int i=0; i<3; i++) {
+        assert_int_equal(omnu.nu_degeneracies[i], 1);
+        assert_true(omnu.RhoNuTab[i]);
+    }
+}
+
+static void test_get_omega_nu(void **state) {
+    /*Check that we get the right answer from get_omega_nu, in terms of rho_nu*/
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {0.2,0.1,0.3};
+    init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
+    double total =0;
+    for(int i=0; i<3; i++) {
+        total += omega_nu_single(&omnu, 0.5, i);
+    }
+    assert_true(fabs(get_omega_nu(&omnu, 0.5) - total) < 1e-6*total);
+}
+
+static void test_get_omegag(void **state) {
+    /*Check that we get the right answer from get_omegag*/
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {0.2,0.1,0.3};
+    const double HubbleParam = 0.7;
+    init_omega_nu(&omnu, MNu, 0.01, HubbleParam,T_CMB0);
+    const double omegag = OMEGAR/pow(0.5,4);
+    assert_true(fabs(get_omegag(&omnu, 0.5)/omegag -1)< 1e-6);
+}
+
+/*Test integrate the fermi-dirac kernel between 0 and qc*/
+static void test_nufrac_low(void **state)
+{
+    assert_true(nufrac_low(0) == 0);
+    /*Mathematica integral: 1.*Integrate[x*x/(Exp[x] + 1), {x, 0, 0.5}]/(3*Zeta[3]/2)*/
+    assert_true(fabs(nufrac_low(1)/0.0595634-1)< 1e-5);
+    assert_true(fabs(nufrac_low(0.5)/0.00941738-1)< 1e-5);
+}
+
+static void test_hybrid_neutrinos(void **state)
+{
+    /*Check that we get the right answer from get_omegag*/
+    _omega_nu omnu;
+    /*Initialise*/
+    double MNu[3] = {0.2,0.2,0.2};
+    const double HubbleParam = 0.7;
+    init_omega_nu(&omnu, MNu, 0.01, HubbleParam,T_CMB0);
+    init_hybrid_nu(&omnu.hybnu, MNu, 700, 299792, 0.5,omnu.kBtnu);
+    /*Check that the fraction of omega change over the jump*/
+    double nufrac_part = nufrac_low(700/299792.*0.2/omnu.kBtnu);
+    assert_true(fabs(particle_nu_fraction(&omnu.hybnu, 0.50001, 0)/nufrac_part -1) < 1e-5);
+    assert_true(particle_nu_fraction(&omnu.hybnu, 0.49999, 0) == 0);
+    assert_true(fabs(get_omega_nu_nopart(&omnu, 0.499999)*(1-nufrac_part)/get_omega_nu_nopart(&omnu, 0.500001)-1) < 1e-4);
+    /*Ditto omega_nu_single*/
+    assert_true(fabs(omega_nu_single(&omnu, 0.499999, 0)*(1-nufrac_part)/omega_nu_single(&omnu, 0.500001, 0)-1) < 1e-4);
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_rho_nu_init),
+        cmocka_unit_test(test_omega_nu_single),
+        cmocka_unit_test(test_omega_nu_init_degenerate),
+        cmocka_unit_test(test_omega_nu_init_nondeg),
+        cmocka_unit_test(test_get_omega_nu),
+        cmocka_unit_test(test_get_omegag),
+        cmocka_unit_test(test_omega_nu_single_exact),
+        cmocka_unit_test(test_nufrac_low),
+        cmocka_unit_test(test_hybrid_neutrinos),
+    };
+    return cmocka_run_group_tests_mpi(tests, NULL, NULL);
+}

--- a/libgadget/tests/test_omega_nu_single.c
+++ b/libgadget/tests/test_omega_nu_single.c
@@ -44,7 +44,7 @@ static void test_omega_nu_single(void **state) {
     /*Initialise*/
     double MNu[3] = {mnu, mnu, 0};
     init_omega_nu(&omnu, MNu, 0.01, 0.7,T_CMB0);
-    assert_true(omnu.RhoNuTab[0]->mnu == mnu);
+    assert_true(omnu.RhoNuTab[0].mnu == mnu);
     /*This is the critical density at z=0:
      * we allow it to change by what is (at the time of writing) the uncertainty on G.*/
     assert_true(fabs(omnu.rhocrit - 1.8784e-29*HubbleParam*HubbleParam) < 5e-3*omnu.rhocrit);
@@ -120,8 +120,8 @@ static void test_omega_nu_init_degenerate(void **state) {
     /*Check that we initialised the right number of arrays*/
     assert_int_equal(omnu.nu_degeneracies[0], 3);
     assert_int_equal(omnu.nu_degeneracies[1], 0);
-    assert_true(omnu.RhoNuTab[0]);
-    assert_false(omnu.RhoNuTab[1]);
+    assert_true(omnu.RhoNuTab[0].loga);
+    assert_false(omnu.RhoNuTab[1].loga);
 }
 
 static void test_omega_nu_init_nondeg(void **state) {
@@ -133,7 +133,7 @@ static void test_omega_nu_init_nondeg(void **state) {
     /*Check that we initialised the right number of arrays*/
     for(int i=0; i<3; i++) {
         assert_int_equal(omnu.nu_degeneracies[i], 1);
-        assert_true(omnu.RhoNuTab[i]);
+        assert_true(omnu.RhoNuTab[i].loga);
     }
 }
 

--- a/libgadget/tests/test_powerspectrum.c
+++ b/libgadget/tests/test_powerspectrum.c
@@ -25,7 +25,7 @@ static void test_total_powerspectrum(void **state) {
     struct _powerspectrum PowerSpectrum;
     MPI_Comm_size(MPI_COMM_WORLD, &nmpi);
 
-    powerspectrum_alloc(&PowerSpectrum,15,NUM_THREADS);
+    powerspectrum_alloc(&PowerSpectrum,15,NUM_THREADS, 0);
     assert_true(PowerSpectrum.Nmodes);
     assert_true(PowerSpectrum.Power);
     assert_true(PowerSpectrum.kk);

--- a/libgadget/tests/test_powerspectrum.c
+++ b/libgadget/tests/test_powerspectrum.c
@@ -46,15 +46,13 @@ static void test_total_powerspectrum(void **state) {
     powerspectrum_sum(&PowerSpectrum,3.085678e24);
 
     /*Check summation was done correctly*/
-    assert_true(PowerSpectrum.Nmodes[0] == 0);
-    assert_true(PowerSpectrum.Nmodes[1] == NUM_THREADS*nmpi);
-    assert_true(PowerSpectrum.Nmodes[14] == NUM_THREADS*nmpi*14);
+    assert_true(PowerSpectrum.Nmodes[0] == NUM_THREADS*nmpi);
+    assert_true(PowerSpectrum.Nmodes[13] == NUM_THREADS*nmpi*14);
 
-    assert_true(PowerSpectrum.Power[0] == 0);
-    assert_true(fabs(PowerSpectrum.Power[1] - sin(1)*sin(1)) < 1e-5);
-    assert_true(fabs(PowerSpectrum.Power[13] - sin(13)*sin(13)) < 1e-5);
-    assert_true(fabs(PowerSpectrum.kk[13] - 2 * M_PI *13) < 1e-5);
-    assert_true(fabs(PowerSpectrum.kk[1] - 2 * M_PI ) < 1e-5);
+    assert_true(fabs(PowerSpectrum.Power[0] - sin(1)*sin(1)) < 1e-5);
+    assert_true(fabs(PowerSpectrum.Power[12] - sin(13)*sin(13)) < 1e-5);
+    assert_true(fabs(PowerSpectrum.kk[12] - 2 * M_PI *13) < 1e-5);
+    assert_true(fabs(PowerSpectrum.kk[0] - 2 * M_PI ) < 1e-5);
 
 }
 

--- a/libgadget/tests/test_powerspectrum.c
+++ b/libgadget/tests/test_powerspectrum.c
@@ -11,6 +11,7 @@
 #include <math.h>
 #include <mpi.h>
 #include "stub.h"
+#include <bigfile-mpi.h>
 
 #include <libgadget/powerspectrum.h>
 

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <stddef.h>
 #include <mpi.h>
 #include <gsl/gsl_integration.h>
 #include <gsl/gsl_interp.h>

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -366,7 +366,7 @@ int init_powerspectrum(int ThisTask, double InitTime, double UnitLength_in_cm_in
 
     Norm = 1.0;
     if (ppar->Sigma8 > 0) {
-        double R8 = 8 * (3.085678e24 / UnitLength_in_cm);	/* 8 Mpc/h */
+        double R8 = 8 * (CM_PER_MPC / UnitLength_in_cm);	/* 8 Mpc/h */
         double res = TopHatSigma2(R8);
         Norm = ppar->Sigma8 / sqrt(res);
         message(0, "Normalization adjusted to  Sigma8=%g   (Normfac=%g). \n", ppar->Sigma8, Norm);
@@ -430,7 +430,7 @@ double tk_eh(double k)		/* from Martin White */
   if(CP->OmegaBaryon == 0)
     ombh2 = 0.044 * CP->HubbleParam * CP->HubbleParam;
 
-  k *= (3.085678e24 / UnitLength_in_cm);	/* convert to h/Mpc */
+  k *= (CM_PER_MPC / UnitLength_in_cm);	/* convert to h/Mpc */
 
   theta = 2.728 / 2.7;
   ommh2 = omegam * hubble * hubble;

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -210,7 +210,7 @@ void parse_transfer(int i, double k, char * line, struct table *out_tab, int * I
     out_tab->logD[VEL_NU][i] = 0;
     for(j=0; j < nnu; j++)
         out_tab->logD[VEL_NU][i] = transfers[13 + nnu + j] * omega_nu_single(Onu, InitTime, j);
-    /*Should be weighted bu omega_nu*/
+    /*Should be weighted by omega_nu*/
     out_tab->logD[VEL_NU][i] /= onu;
 }
 

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -9,6 +9,7 @@
 #include <libgadget/cosmology.h>
 #include <libgadget/utils.h>
 
+#include <libgadget/physconst.h>
 #include "power.h"
 
 /*Defined in save.c*/

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -14,7 +14,7 @@
 #include "power.h"
 
 /*Defined in save.c*/
-void saveblock_name(BigFile * bf, void * baseptr, char * name, char * dtype, size_t dims[], ptrdiff_t elsize, int64_t TotNumPart);
+void _bigfile_utils_create_block_from_c_array(BigFile * bf, void * baseptr, char * name, char * dtype, size_t dims[], ptrdiff_t elsize, int64_t TotNumPart, MPI_Comm comm);
 
 static double Delta_EH(double k);
 static double Delta_Tabulated(double k, enum TransferType Type);
@@ -117,12 +117,12 @@ static void save_transfer(BigFile * bf, int ncol, struct table * ttable, const c
     char buf[100];
     snprintf(buf, 100, "%s/logk", bname);
 
-    saveblock_name(bf, ttable->logk, buf, "f8", dims, sizeof(double), transfer_table.Nentry);
+    _bigfile_utils_create_block_from_c_array(bf, ttable->logk, buf, "f8", dims, sizeof(double), transfer_table.Nentry, MPI_COMM_WORLD);
 
     for(i = 0; i < ncol; i++)
     {
         snprintf(buf, 100, "%s/%s", bname, colnames[i]);
-        saveblock_name(bf, ttable->logD[i], buf, "f8", dims, sizeof(double), transfer_table.Nentry);
+        _bigfile_utils_create_block_from_c_array(bf, ttable->logD[i], buf, "f8", dims, sizeof(double), transfer_table.Nentry, MPI_COMM_WORLD);
     }
 }
 

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -212,7 +212,7 @@ void parse_transfer(int i, double k, char * line, struct table *out_tab, int * I
     for(j=0; j < nnu; j++)
         out_tab->logD[DELTA_NU][i] = -1*transfers[4+j] * omega_nu_single(Onu, InitTime, j);
     const double onu = get_omega_nu(&CP->ONu, InitTime);
-    /*Should be weighted bu omega_nu*/
+    /*Should be weighted by omega_nu*/
     out_tab->logD[DELTA_NU][i] /= onu;
     /*h_prime is entry 8 + nnu. t_b is 12 + nnu, t_ncdm[2] is 13 + nnu * 2.*/
     out_tab->logD[VEL_BAR][i] = transfers[12+nnu];

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -41,6 +41,10 @@ struct table
     gsl_interp_accel * mat_intp_acc[MAXCOLS];
 };
 
+/*Typedef for a function that parses the table from text*/
+typedef void (*_parse_fn)(int i, double k, char * line, struct table *, int *InputInLog10, const double InitTime);
+
+
 static struct table power_table;
 /*Columns: 0 == baryon, 1 == CDM, 2 == neutrino, 3 == baryon velocity, 4 == CDM velocity, 5 = neutrino velocity*/
 static struct table transfer_table;
@@ -224,7 +228,7 @@ void parse_transfer(int i, double k, char * line, struct table *out_tab, int * I
     out_tab->logD[VEL_NU][i] /= onu;
 }
 
-void read_power_table(int ThisTask, const char * inputfile, const int ncols, struct table * out_tab, const double InitTime, void (*parse_line)(int i, double k, char * line, struct table *, int *InputInLog10, const double InitTime))
+void read_power_table(int ThisTask, const char * inputfile, const int ncols, struct table * out_tab, const double InitTime, _parse_fn parse_line)
 {
     FILE *fd = NULL;
     int j;

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -49,7 +49,7 @@ static struct table power_table;
 /*Columns: 0 == baryon, 1 == CDM, 2 == neutrino, 3 == baryon velocity, 4 == CDM velocity, 5 = neutrino velocity*/
 static struct table transfer_table;
 
-static const char * tnames[MAXCOLS] = {"DELTA_BAR", "DELTA_CDM", "DELTA_NU", "VEL_BAR", "VEL_CDM", "VEL_NU", "VEL_CB", "VEL_TOT", "DELTA_CB"};
+static const char * tnames[MAXCOLS] = {"DELTA_BAR", "DELTA_CDM", "DELTA_NU", "DELTA_CB", "VEL_BAR", "VEL_CDM", "VEL_NU", "VEL_CB", "VEL_TOT"};
 /*Symbolic constants for the rows of the transfer table*/
 /*Number of types with defined transfers.*/
 enum TransferCols
@@ -57,12 +57,12 @@ enum TransferCols
     DELTA_BAR = 0,
     DELTA_CDM = 1,
     DELTA_NU = 2,
-    VEL_BAR = 3,
-    VEL_CDM = 4,
-    VEL_NU = 5,
-    VEL_CB = 6,
-    VEL_TOT = 7,
-    DELTA_CB = 8,
+    DELTA_CB = 3,
+    VEL_BAR = 4,
+    VEL_CDM = 5,
+    VEL_NU = 6,
+    VEL_CB = 7,
+    VEL_TOT = 8,
 };
 
 double DeltaSpec(double k, int Type)

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -81,7 +81,7 @@ double dlogGrowth(double kmag, int Type)
   /*Use the velocity entries*/
   double growth =  gsl_interp_eval(transfer_table.mat_intp[VEL_BAR + Type], transfer_table.logk, transfer_table.logD[VEL_BAR + Type], logk, transfer_table.mat_intp_acc[VEL_BAR+Type]);
 
-  if(isinf(growth) || isnan(growth) || growth < 0)
+  if(!isfinite(growth))
       endrun(1,"Growth function is: %g for k = %g, Type = %d\n", growth, kmag, Type);
   return growth;
 }

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -303,7 +303,7 @@ init_transfer_table(int ThisTask, double InitTime, const struct power_params * c
 
     /*Now normalise the velocity transfer functions: divide by a * hubble, where hubble is the hubble function in Mpc^-1, so H0/c*/
     const double fac = InitTime * hubble_function(InitTime)/CP->Hubble * 100 * CP->HubbleParam/(LIGHTCGS / 1e5);
-    const double onu = get_omega_nu(&CP->ONu, 1);
+    const double onu = get_omega_nu(&CP->ONu, InitTime)*pow(InitTime,3);
     double meangrowth[5] = {0};
     /* At this point the transfer table contains: (3,4,5) t_b, 0.5 * h_prime, t_ncdm.
      * After, if t_cdm = 0.5 h_prime / (a H(a) / H0 /c) we need:

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -81,11 +81,15 @@ double dlogGrowth(double kmag, int Type)
       return 1;
 
   /*Default to total growth: type 3 is cdm + baryons.*/
-  if(Type < 0 || Type >= 3) {
-      Type = MAXCOLS-4;
+  if(Type < 0 || Type > 3) {
+      Type = VEL_TOT;
+  }
+  else {
+      /*Type should be an offset from the first velocity*/
+      Type = VEL_BAR + Type;
   }
   /*Use the velocity entries*/
-  double growth =  gsl_interp_eval(transfer_table.mat_intp[VEL_BAR + Type], transfer_table.logk, transfer_table.logD[VEL_BAR + Type], logk, transfer_table.mat_intp_acc[VEL_BAR+Type]);
+  double growth =  gsl_interp_eval(transfer_table.mat_intp[Type], transfer_table.logk, transfer_table.logD[Type], logk, transfer_table.mat_intp_acc[Type]);
 
   if(!isfinite(growth))
       endrun(1,"Growth function is: %g for k = %g, Type = %d\n", growth, kmag, Type);

--- a/libgenic/power.h
+++ b/libgenic/power.h
@@ -36,13 +36,29 @@ struct power_params
  * at k = 0.002 h/Mpc at 2% for z_ic = 100. It is larger at higher redshift.
  */
 
+/*Symbolic constants for the possible types transfer function types*/
+enum TransferType
+{
+    DELTA_BAR = 0,
+    DELTA_CDM = 1,
+    DELTA_NU = 2,
+    DELTA_CB = 3,
+    VEL_BAR = 4,
+    VEL_CDM = 5,
+    VEL_NU = 6,
+    VEL_CB = 7,
+    VEL_TOT = 8,
+    /*Always unity, so there is no memory for it*/
+    DELTA_TOT = 9,
+};
+
 /* delta (square root of power spectrum) at current redshift.
- * Type == 0 is Gas, Type == 1 is DM, Type == 2 is neutrinos, Type == 3 is CDM + baryons.
+ * Type == 0 is Gas, Type == 1 is DM, Type == 2 is neutrinos, Type == 3 is CDM + baryons (as in the enum)
  * Other types are total power. */
-double DeltaSpec(double kmag, int Type);
+double DeltaSpec(double kmag, enum TransferType Type);
 /* Scale-dependent derivative of the growth function,
  * computed by differentiating the provided transfer functions. */
-double dlogGrowth(double kmag, int ptype);
+double dlogGrowth(double kmag, enum TransferType Type);
 /* Read power spectrum and transfer function tables from disk, set up growth factors, init cosmology. */
 int init_powerspectrum(int ThisTask, double InitTime, double UnitLength_in_cm_in, Cosmology * CPin, struct power_params * ppar);
 

--- a/libgenic/power.h
+++ b/libgenic/power.h
@@ -2,6 +2,7 @@
 #define GENIC_POWER_H
 
 #include <libgadget/cosmology.h>
+#include <bigfile-mpi.h>
 
 struct power_params
 {
@@ -44,5 +45,8 @@ double DeltaSpec(double kmag, int Type);
 double dlogGrowth(double kmag, int ptype);
 /* Read power spectrum and transfer function tables from disk, set up growth factors, init cosmology. */
 int init_powerspectrum(int ThisTask, double InitTime, double UnitLength_in_cm_in, Cosmology * CPin, struct power_params * ppar);
+
+/*Save the transfer function tables and matter power spectrum to the IC bigfile*/
+void save_all_transfer_tables(BigFile * bf, int ThisTask);
 
 #endif

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -2,8 +2,9 @@
 #define GENIC_PROTO_H
 #include <bigfile.h>
 #include <stdint.h>
+#include "power.h"
 
-void   displacement_fields(int Type);
+void   displacement_fields(enum TransferType Type);
 void setup_grid(double shift, int Ngrid);
 uint64_t id_offset_from_index(const int i, const int Ngrid);
 void   free_ffts(void);

--- a/libgenic/tests/test_power.c
+++ b/libgenic/tests/test_power.c
@@ -20,7 +20,7 @@ struct test_state
 };
 
 /*stub*/
-void saveblock_name(BigFile * bf, void * baseptr, char * name, char * dtype, size_t dims[], ptrdiff_t elsize, int64_t TotNumPart)
+void _bigfile_utils_create_block_from_c_array(BigFile * bf, void * baseptr, char * name, char * dtype, size_t dims[], ptrdiff_t elsize, int64_t TotNumPart, MPI_Comm comm)
 {
     return;
 }

--- a/libgenic/tests/test_power.c
+++ b/libgenic/tests/test_power.c
@@ -19,6 +19,12 @@ struct test_state
     Cosmology CP;
 };
 
+/*stub*/
+void saveblock_name(BigFile * bf, void * baseptr, char * name, char * dtype, size_t dims[], ptrdiff_t elsize, int64_t TotNumPart)
+{
+    return;
+}
+
 /*Simple test without rescaling*/
 static void
 test_read_no_rescale(void ** state)

--- a/libgenic/thermal.c
+++ b/libgenic/thermal.c
@@ -23,7 +23,7 @@
 double
 NU_V0(const double Time, const double kBTNubyMNu, const double UnitVelocity_in_cm_per_s)
 {
-    return kBTNubyMNu / Time * (C / UnitVelocity_in_cm_per_s);
+    return kBTNubyMNu / Time * (LIGHTCGS / UnitVelocity_in_cm_per_s);
 }
 
 //Amplitude of the random velocity for WDM

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -139,9 +139,9 @@ static PetaPMRegion * makeregion(void * userdata, int * Nregions) {
 }
 
 /*Global to pass type to *_transfer functions*/
-static int ptype;
+static enum TransferType ptype;
 
-void displacement_fields(int Type) {
+void displacement_fields(enum TransferType Type) {
     /*MUST set this before doing force.*/
     ptype = Type;
     PetaPMParticleStruct pstruct = {

--- a/tools/make_class_power.py
+++ b/tools/make_class_power.py
@@ -109,6 +109,9 @@ def _build_cosmology_params(config):
         gparams['tol_ncdm_synchronous'] = 1e-5
         gparams['tol_ncdm_bg'] = 1e-10
         gparams['l_max_ncdm'] = 50
+        #This disables the fluid approximations, which make P_nu not match camb on small scales.
+        #We need accurate P_nu to initialise our neutrino code.
+        gparams['ncdm_fluid_approximation'] = 3
     else:
         gparams['N_ur'] = 3.046
     #Power spectrum amplitude

--- a/tools/make_class_power.py
+++ b/tools/make_class_power.py
@@ -122,7 +122,7 @@ def _build_cosmology_params(config):
         gparams['A_s'] = config["PrimordialAmp"]
     return gparams
 
-def make_class_power(paramfile, external_pk = None, extraz=None):
+def make_class_power(paramfile, external_pk = None, extraz=None, verbose=False):
     """Main routine: parses a parameter file and makes a matter power spectrum.
     Will not over-write power spectra if already present.
     Options are loaded from the MP-GenIC parameter file.
@@ -162,6 +162,10 @@ def make_class_power(paramfile, external_pk = None, extraz=None):
     maxk = 2*math.pi/boxmpc*config['Ngrid']*16
     powerparams = {'output': 'dTk vTk mPk', 'P_k_max_h/Mpc' : maxk, "z_max_pk" : 1+np.max(outputs),'z_pk': outputs, 'extra metric transfer functions': 'y'}
     pre_params.update(powerparams)
+
+    if verbose:
+        verb_params = {'input_verbose': 1, 'background_verbose': 1, 'thermodynamics_verbose': 1, 'perturbations_verbose': 1, 'transfer_verbose': 1, 'primordial_verbose': 1, 'spectra_verbose': 1, 'nonlinear_verbose': 1, 'lensing_verbose': 1, 'output_verbose': 1}
+        pre_params.update(verb_params)
 
     #Specify an external primordial power spectrum
     if external_pk is not None:
@@ -225,5 +229,6 @@ if __name__ ==  "__main__":
     parser.add_argument('paramfile', type=str, help='genic paramfile')
     parser.add_argument('--extpk', type=str, help='optional external primordial power spectrum',required=False)
     parser.add_argument('--extraz', type=float,nargs='*', help='optional external primordial power spectrum',required=False)
+    parser.add_argument('--verbose', action='store_true', help='print class runtime information',required=False)
     args = parser.parse_args()
-    make_class_power(args.paramfile, args.extpk, args.extraz)
+    make_class_power(args.paramfile, args.extpk, args.extraz,args.verbose)

--- a/tools/make_class_power.py
+++ b/tools/make_class_power.py
@@ -99,6 +99,7 @@ def _build_cosmology_params(config):
     if omeganu > 0:
         gparams['m_ncdm'] = '%.2f,%.2f,%.2f' % (config['MNue'], config['MNum'], config['MNut'])
         gparams['N_ncdm'] = 3
+        gparams['N_ur'] = 0.00641
         #Neutrino accuracy: Default pk_ref.pre has tol_ncdm_* = 1e-10,
         #which takes 45 minutes (!) on my laptop.
         #tol_ncdm_* = 1e-8 takes 20 minutes and is machine-accurate.
@@ -108,6 +109,8 @@ def _build_cosmology_params(config):
         gparams['tol_ncdm_synchronous'] = 1e-5
         gparams['tol_ncdm_bg'] = 1e-10
         gparams['l_max_ncdm'] = 50
+    else:
+        gparams['N_ur'] = 3.046
     #Power spectrum amplitude
     if config['Sigma8'] > 0:
         gparams['sigma8'] = config['Sigma8']


### PR DESCRIPTION
This PR fixes the linear response neutrino code, which was broken when we moved to class formatted transfer functions. It also improves the accuracy of the make_class_power.py script for neutrinos (which was the hardest part!).

I took the opportunity to fix a few niggles with the linear response code - in particular the neutrino power spectrum now has modes-per-bin associated with it. I also store the initial transfer functions and matter power spectrum in the IC bigfile, so we don't need to reload them from a text file on disc when starting a simulation. I saved all the transfer functions in case we want to use them for something else later. Note that the IC transfer and matter power are only stored in the initial conditions, not the later snapshots. Let me know if you would like me to change this.

Since it turned out that after this we were only using a small core of kspace-neutrinos, I moved the remaining code directly into MP-Gadget, with tests, and removed the submodule. This should make it easier to work with in future.

The LinearTransferFunction parameter now has no effect: I left the parameter in there so it was easy to switch between branches while developing, but I will remove it after this is merged.

There are also some cleanups: the speed of light is now LIGHTCGS, not 'C', which was impossible to grep for.

@andreufont : This is a good base to run neutrino simulations on dirac from. I have tested that the kspace integrator works the same as it did before.