### PR TITLE
Treewalk opt

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -159,11 +159,12 @@ density_internal(int update_hsml)
     #pragma omp parallel for
     for(i = 0; i < NumActiveParticle; i++)
     {
-        const int p_i = ActiveParticle[i];
+        int p_i = i;
+        if(ActiveParticle)
+            p_i = ActiveParticle[i];
         P[p_i].DensityIterationDone = 0;
         DENSITY_GET_PRIV(tw)->Left[p_i] = 0;
         DENSITY_GET_PRIV(tw)->Right[p_i] = 0;
-
     }
 
     /* allocate buffers to arrange communication */

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -9,7 +9,6 @@
 #include "utils.h"
 
 #include "allvars.h"
-#include "forcetree.h"
 #include "mpsort.h"
 #include "domain.h"
 #include "timestep.h"
@@ -151,8 +150,6 @@ void domain_decompose_full(void)
 
     walltime_measure("/Misc");
 
-    if(force_tree_allocated()) force_tree_free();
-
     domain_free();
 
     message(0, "domain decomposition... (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
@@ -218,9 +215,6 @@ void domain_decompose_full(void)
     report_memory_usage("DOMAIN");
 
     walltime_measure("/Domain/Peano");
-
-    /* this is a full decomposition, need to rebuild the force tree because all TopLeaves are out of date. */
-    force_tree_rebuild();
 }
 
 /* This is a cut-down version of the domain decomposition that leaves the
@@ -231,11 +225,6 @@ void domain_maintain(void)
 
     walltime_measure("/Misc");
 
-    /* We rebuild the tree every timestep in order to
-     * make sure it is consistent.
-     * May as well free it here.*/
-    if(force_tree_allocated()) force_tree_free();
-
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
@@ -243,9 +232,6 @@ void domain_maintain(void)
         domain_decompose_full();
         return;
     }
-
-    /* need to rebuild the force tree because all particles have been moved around in memory */
-    force_tree_rebuild();
 }
 
 /* this function generates several domain decomposition policies for attempting

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -342,7 +342,7 @@ void fof_label_primary(void)
     {
         t0 = second();
 
-        treewalk_run(tw, NULL, -1);
+        treewalk_run(tw, NULL, PartManager->NumPart);
 
         t1 = second();
 
@@ -1112,7 +1112,7 @@ static void fof_label_secondary(void)
         FOF_SECONDARY_GET_PRIV(tw)->npleft = 0;
         FOF_SECONDARY_GET_PRIV(tw)->count = 0;
 
-        treewalk_run(tw, NULL, -1);
+        treewalk_run(tw, NULL, PartManager->NumPart);
 
         sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->npleft, &ntot);
         sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->count, &counttot);

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -996,9 +996,6 @@ fof_save_groups(int num)
     t1 = second();
 
     message(0, "Group catalogues saved. took = %g sec\n", timediff(t0, t1));
-
-    /* fof with IO will break the tree by changing particle order; rebuild it */
-    force_tree_rebuild();
 }
 
 /* FIXME: these shall goto the private member of secondary tree walk */

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1055,7 +1055,7 @@ void force_update_hmax(int * activeset, int size)
 
     for(i = 0; i < size; i++)
     {
-        const int p_i = activeset[i];
+        const int p_i = activeset ? activeset[i] : i;
 
         if(P[p_i].Type != 0)
             continue;

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -33,7 +33,7 @@ void grav_short_pair(void)
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterGravShort);
     tw->ngbiter = (TreeWalkNgbIterFunction) grav_short_pair_ngbiter;
 
-    tw->haswork = grav_short_haswork;
+    tw->haswork = NULL;
     tw->fill = (TreeWalkFillQueryFunction) grav_short_copy;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -80,7 +80,7 @@ void grav_short_tree_old(void)
 
     tw->ev_label = "FORCETREE_SHORTRANGE";
     tw->visit = (TreeWalkVisitFunction) force_treeevaluate_shortrange;
-    tw->haswork = grav_short_haswork;
+    tw->haswork = NULL;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;
     tw->UseNodeList = 1;

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -54,7 +54,8 @@ void grav_short_tree(void)
 
     tw->ev_label = "FORCETREE_SHORTRANGE";
     tw->visit = (TreeWalkVisitFunction) force_treeev_shortrange;
-    tw->haswork = grav_short_haswork;
+    /* gravity applies to all particles. Including Tracer particles to enhance numerical stability. */
+    tw->haswork = NULL;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;
     tw->UseNodeList = 1;

--- a/libgadget/gravshort.h
+++ b/libgadget/gravshort.h
@@ -24,11 +24,6 @@ typedef struct {
     int Ninteractions;
 } TreeWalkResultGravShort;
 
-static int
-grav_short_haswork(int i, TreeWalk * tw)
-{
-    return 1; /* gravity applies to all particles. Including Tracer particles to enhance numerical stability. */
-}
 
 static void
 grav_short_postprocess(int i, TreeWalk * tw)

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -185,6 +185,7 @@ setup_smoothinglengths(int RestartSnapNum)
 {
     int i;
 
+    force_tree_rebuild();
     if(RestartSnapNum == -1)
     {
 #pragma omp parallel for
@@ -317,4 +318,6 @@ setup_smoothinglengths(int RestartSnapNum)
 #ifdef DENSITY_INDEPENDENT_SPH
     density_update();
 #endif //DENSITY_INDEPENDENT_SPH
+
+    if(force_tree_allocated()) force_tree_free();
 }

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -126,7 +126,9 @@ void init(int RestartSnapNum)
 
     domain_decompose_full();	/* do initial domain decomposition (gives equal numbers of particles) */
 
-    rebuild_activelist(0);
+    /*At the first time step all particles should be active*/
+    ActiveParticle = NULL;
+    NumActiveParticle = PartManager->NumPart;
 
     setup_smoothinglengths(RestartSnapNum);
 }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -196,9 +196,6 @@ void petaio_read_internal(char * fname, int ic) {
     /* sets the maximum number of particles that may reside on a processor */
     int MaxPart = (int) (All.PartAllocFactor * All.TotNumPartInit / NTask);
 
-    /*Allocates ActiveParticle array*/
-    timestep_allocate_memory(MaxPart);
-
     /*Allocate the particle memory*/
     particle_alloc_memory(MaxPart);
 

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -452,10 +452,10 @@ static void layout_prepare (struct Layout * L, double * meshbuf, PetaPMRegion * 
 
     /* some checks */
     if(L->DpSend[NTask - 1] + L->NpSend[NTask -1] != L->NpExport) {
-        endrun(1, "NpExport = %d\n", L->NpExport);
+        endrun(1, "NpExport = %d NpSend=%d DpSend=%d\n", L->NpExport, L->NpSend[NTask -1], L->DpSend[NTask - 1]);
     }
     if(L->DcSend[NTask - 1] + L->NcSend[NTask -1] != L->NcExport) {
-        endrun(1, "NcExport = %d\n", L->NcExport);
+        endrun(1, "NcExport = %d NcSend=%d DcSend=%d\n", L->NcExport, L->NcSend[NTask -1], L->DcSend[NTask - 1]);
     }
     int64_t totNpAlloc = reduce_int64(NpAlloc);
     int64_t totNpExport = reduce_int64(L->NpExport);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -253,11 +253,12 @@ void run(void)
         /* Update velocity to the new step, with the newly computed step size */
         apply_half_kick();
 
-        free_activelist();
-
         if(is_PM) {
             apply_PM_half_kick();
         }
+
+        /* We can now free the active list: the new step have new active particles*/
+        free_activelist();
     }
 
     close_outputfiles();

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -249,6 +249,8 @@ void run(void)
         /* Update velocity to the new step, with the newly computed step size */
         apply_half_kick();
 
+        free_activelist();
+
         if(is_PM) {
             apply_PM_half_kick();
         }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -181,9 +181,7 @@ void run(void)
             domain_maintain();
         }
 
-        rebuild_activelist(All.Ti_Current);
-
-        print_timebin_statistics(NumCurrentTiStep);
+        rebuild_activelist(All.Ti_Current, NumCurrentTiStep);
 
         set_random_numbers(All.RandomSeed + All.Ti_Current);
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -219,12 +219,12 @@ void run(void)
 
         if(WriteSnapshot) {
             /* The accel may have created garbage -- collect them before writing a snapshot.
-             * If we do collect, rebuild tree and active list.*/
+             * If we do collect, rebuild tree and reset active list size.*/
             int compact[6] = {0};
 
             if(slots_gc(compact)) {
                 force_tree_rebuild();
-                rebuild_activelist(All.Ti_Current);
+                NumActiveParticle = PartManager->NumPart;
             }
         }
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -185,6 +185,9 @@ void run(void)
 
         set_random_numbers(All.RandomSeed + All.Ti_Current);
 
+        /* Need to rebuild the force tree because all TopLeaves are out of date.*/
+        force_tree_rebuild();
+
         /* update force to Ti_Current */
         compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled);
 
@@ -233,6 +236,9 @@ void run(void)
         NumCurrentTiStep++;
 
         report_memory_usage("RUN");
+
+        /*Note FoF will free the tree too*/
+        if(force_tree_allocated()) force_tree_free();
 
         if(!next_sync || stop) {
             /* out of sync points, or a requested stop, the run has finally finished! Yay.*/

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -42,7 +42,7 @@ void runtests()
     }
 
     domain_decompose_full();	/* do domain decomposition */
-    rebuild_activelist(All.Ti_Current);
+    rebuild_activelist(All.Ti_Current, 0);
 
     grav_short_pair();
     message(0, "GravShort Pairs %s\n", GDB_format_particle(0));

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -225,9 +225,16 @@ static int slot_cmp_reverse_link(const void * b1in, const void * b2in) {
 static int
 slots_gc_mark()
 {
-    int i;
+    int i, ptype;
+    int gc_slots = 0;
+    for(ptype = 0; ptype < 6; ptype ++)
+        if(SLOTS_ENABLED(ptype))
+            gc_slots = 1;
+
+    if(!gc_slots)
+        return 0;
+
 #ifdef DEBUG
-    int ptype;
     /*Initially set all reverse links to an obviously invalid value*/
     for(ptype = 0; ptype < 6; ptype++)
     {
@@ -379,15 +386,8 @@ slots_gc_sorted()
         PartManager->NumPart--;
     }
 
-    int gc_slots = 0;
-    for(ptype = 0; ptype < 6; ptype ++)
-        if(SLOTS_ENABLED(ptype))
-            gc_slots = 1;
-
-    if(gc_slots) {
-        /*Set up ReverseLink*/
-        slots_gc_mark();
-    }
+    /*Set up ReverseLink*/
+    slots_gc_mark();
 
     for(ptype = 0; ptype < 6; ptype++) {
         if(!SLOTS_ENABLED(ptype))

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -379,8 +379,15 @@ slots_gc_sorted()
         PartManager->NumPart--;
     }
 
-    /*Set up ReverseLink*/
-    slots_gc_mark();
+    int gc_slots = 0;
+    for(ptype = 0; ptype < 6; ptype ++)
+        if(SLOTS_ENABLED(ptype))
+            gc_slots = 1;
+
+    if(gc_slots) {
+        /*Set up ReverseLink*/
+        slots_gc_mark();
+    }
 
     for(ptype = 0; ptype < 6; ptype++) {
         if(!SLOTS_ENABLED(ptype))

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -708,10 +708,11 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
     memset(TimeBinCountType, 0, 6 * (TIMEBINS+1) * All.NumThreads * sizeof(int));
 
     /*We want a lockless algorithm which preserves the ordering of the particle list.*/
-    size_t NActiveThread[All.NumThreads];
+    size_t *NActiveThread = ta_malloc("NActiveThread", size_t, All.NumThreads);
+    int **ActivePartSets = ta_malloc("ActivePartSets", int *, All.NumThreads);
+
     /*Each thread gets an area for the active list of this size*/
     const int ActiveSetSz = PartManager->MaxPart / All.NumThreads;
-    int * ActivePartSets[All.NumThreads];
     for(i = 0; i < All.NumThreads; i++) {
         ActivePartSets[i] = ActiveParticle + i * ActiveSetSz;
         NActiveThread[i] = 0;
@@ -738,6 +739,8 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
         /*Now we want a merge step for the ActiveParticle list.*/
         NumActiveParticle = gadget_compact_thread_arrays(ActiveParticle, ActivePartSets, NActiveThread, All.NumThreads);
     }
+    ta_free(ActivePartSets);
+    ta_free(NActiveThread);
 
     /*Print statistics for this time bin*/
     print_timebin_statistics(NumCurrentTiStep, TimeBinCountType);

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -70,11 +70,6 @@ timestep_eh_slots_fork(EIBase * event, void * userdata)
     return 0;
 }
 
-void timestep_allocate_memory(int MaxPart)
-{
-    ActiveParticle = (int *) mymalloc("ActiveParticle", MaxPart * sizeof(int));
-}
-
 static void reverse_and_apply_gravity();
 static inttime_t get_timestep_ti(const int p, const inttime_t dti_max);
 static int get_timestep_bin(inttime_t dti);
@@ -698,6 +693,8 @@ int rebuild_activelist(inttime_t Ti_Current)
 {
     int i;
 
+    ActiveParticle = (int *) mymalloc("ActiveParticle", PartManager->MaxPart * sizeof(int));
+
     memset(TimeBinCountType, 0, 6*(TIMEBINS+1)*sizeof(int));
     NumActiveParticle = 0;
 
@@ -714,8 +711,18 @@ int rebuild_activelist(inttime_t Ti_Current)
         }
         TimeBinCountType[P[i].Type][bin]++;
     }
+    if(NumActiveParticle == PartManager->NumPart) {
+        myfree(ActiveParticle);
+        ActiveParticle = NULL;
+    }
     walltime_measure("/Timeline/Active");
     return 0;
+}
+
+void free_activelist(void)
+{
+    if(ActiveParticle)
+        myfree(ActiveParticle);
 }
 
 /*! This routine writes one line for every timestep.

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -745,6 +745,10 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
     print_timebin_statistics(NumCurrentTiStep, TimeBinCountType);
     myfree(TimeBinCountType);
 
+    /* Shrink the ActiveParticle array. We still need extra space for star formation,
+     * but we do not need space for the known-inactive particles*/
+    if(ActiveParticle)
+        ActiveParticle = myrealloc(ActiveParticle, sizeof(int)*(NumActiveParticle + PartManager->MaxPart - PartManager->NumPart));
     walltime_measure("/Timeline/Active");
 
     return 0;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -159,18 +159,16 @@ find_timesteps(int * MinTimeBin)
 
     /* Now assign new timesteps and kick */
     if(All.ForceEqualTimesteps) {
-        #pragma omp parallel for
-        for(pa = 0; pa < NumActiveParticle; pa++)
+        int i;
+        #pragma omp parallel for reduction(min:dti_min)
+        for(i = 0; i < PartManager->NumPart; i++)
         {
-            const int i = ActiveParticle[pa];
             if(P[i].IsGarbage)
                 continue;
             inttime_t dti = get_timestep_ti(i, PM.length);
-
             if(dti < dti_min)
                 dti_min = dti;
         }
-
         /* FIXME : this assumes inttime_t is int*/
         MPI_Allreduce(MPI_IN_PLACE, &dti_min, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
     }

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -7,14 +7,13 @@ set in rebuild_activelist.*/
 extern int NumActiveParticle;
 extern int *ActiveParticle;
 
-int rebuild_activelist(inttime_t ti_current);
+int rebuild_activelist(inttime_t ti_current, int NumCurrentTiStep);
 void free_activelist(void);
 void set_global_time(double newtime);
 int find_timesteps(int * MinTimeBin);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 
-void print_timebin_statistics(int NumCurrentTiStep);
 int is_timebin_active(int i, inttime_t current);
 void set_timebin_active(binmask_t mask);
 

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -3,12 +3,12 @@
 
 #include "timebinmgr.h"
 /*Flat array containing all active particles:
-set in run.c: find_next_sync_point_and_drift*/
+set in rebuild_activelist.*/
 extern int NumActiveParticle;
 extern int *ActiveParticle;
 
-void timestep_allocate_memory(int MaxPart);
 int rebuild_activelist(inttime_t ti_current);
+void free_activelist(void);
 void set_global_time(double newtime);
 int find_timesteps(int * MinTimeBin);
 void apply_half_kick(void);

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -231,7 +231,7 @@ static void real_ev(TreeWalk * tw, int * ninter, int * nnodes) {
         k++) {
         if(tw->BufferFullFlag) break;
 
-        i = tw->WorkSet[k];
+        i = tw->WorkSet ? tw->WorkSet[k] : k;
 
         if(P[i].Evaluated) {
             BREAKPOINT;
@@ -570,7 +570,8 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
         int i;
         #pragma omp parallel for if(tw->WorkSetSize > 64)
         for(i = 0; i < tw->WorkSetSize; i ++) {
-            tw->preprocess(tw->WorkSet[i], tw);
+            const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;
+            tw->preprocess(p_i, tw);
         }
     }
 
@@ -601,7 +602,8 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
         int i;
         #pragma omp parallel for if(tw->WorkSetSize > 64)
         for(i = 0; i < tw->WorkSetSize; i ++) {
-            tw->postprocess(tw->WorkSet[i], tw);
+            const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;
+            tw->postprocess(p_i, tw);
         }
     }
     tend = second();

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -170,7 +170,7 @@ static void ev_finish(TreeWalk * tw)
 {
     myfree(tw->currentEnd);
     myfree(tw->currentIndex);
-    if(tw->work_set_allocated)
+    if(!tw->work_set_stolen_from_active)
         myfree(tw->WorkSet);
     myfree(DataNodeList);
     myfree(DataIndexTable);
@@ -293,12 +293,12 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
     {
         tw->WorkSetSize = size;
         tw->WorkSet = active_set;
-        tw->work_set_allocated = 0;
+        tw->work_set_stolen_from_active = 1;
         return;
     }
 
     tw->WorkSet = mymalloc("ActiveQueue", size * sizeof(int));
-    tw->work_set_allocated = 1;
+    tw->work_set_stolen_from_active = 0;
 
     int * queue = tw->WorkSet;
     int nqueue = 0;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -406,6 +406,10 @@ static int ev_primary(TreeWalk * tw)
         tw->Nexport --;
     }
 
+    if(tw->BufferFullFlag) {
+        message(1, "Tree export buffer full with %d particles. Increase BufferSize if possible.\n", tw->Nexport);
+    }
+
     if(tw->Nexport == 0 && tw->BufferFullFlag) {
         endrun(1231245, "Buffer too small for even one particle. For example, there are too many nodes");
     }

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -407,7 +407,7 @@ static int ev_primary(TreeWalk * tw)
     }
 
     if(tw->BufferFullFlag) {
-        message(1, "Tree export buffer full with %d particles. Increase BufferSize if possible.\n", tw->Nexport);
+        message(1, "Tree export buffer full with %d particles. This is not fatal but slows the treewalk. Increase BufferSize if possible.\n", tw->Nexport);
     }
 
     if(tw->Nexport == 0 && tw->BufferFullFlag) {

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -153,7 +153,7 @@ ev_begin(TreeWalk * tw, int * active_set, int size)
 
     tw->WorkSetSize = 0;
 
-    tw->WorkSet = mymalloc("ActiveQueue", PartManager->NumPart * sizeof(int));
+    tw->WorkSet = mymalloc("ActiveQueue", size * sizeof(int));
 
     treewalk_build_queue(tw, active_set, size);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -304,8 +304,9 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
     int nqueue = 0;
 
     /*We want a lockless algorithm which preserves the ordering of the particle list.*/
-    size_t nqthr[All.NumThreads];
-    int * thrqueue[All.NumThreads];
+    size_t *nqthr = ta_malloc("nqthr", size_t, All.NumThreads);
+    int **thrqueue = ta_malloc("thrqueue", int *, All.NumThreads);
+
     thrqueue[0] = queue;
     for(i=0; i < All.NumThreads; i++) {
         thrqueue[i] = queue + i * size;
@@ -330,6 +331,8 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
     }
     /*Merge step for the queue.*/
     nqueue = gadget_compact_thread_arrays(queue, thrqueue, nqthr, All.NumThreads);
+    ta_free(thrqueue);
+    ta_free(nqthr);
     /*Shrink memory*/
     queue = myrealloc(queue, sizeof(int) * nqueue);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -148,7 +148,11 @@ ev_begin(TreeWalk * tw, int * active_set, int size)
 
     memset(DataNodeList, -1, sizeof(struct data_nodelist) * tw->BunchSize);
 
-    treewalk_build_queue(tw, active_set, size, 1);
+    /* The last argument is may_have_garbage: in practice the only
+     * trivial haswork is the gravtree, which has no garbage because
+     * an exchange just occurred. If we ever add a trivial haswork after
+     * sfr/bh we should change this*/
+    treewalk_build_queue(tw, active_set, size, 0);
 
     treewalk_init_evaluated(active_set, size);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -298,9 +298,9 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, int size) {
     } else {
         int i;
         #pragma omp parallel for
-        for(i=0; i < NumActiveParticle; i++)
+        for(i=0; i < size; i++)
         {
-            const int p_i = ActiveParticle[i];
+            const int p_i = active_set[i];
 
             /* Skip the garbage particles */
             if(P[p_i].IsGarbage) continue;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -117,8 +117,8 @@ struct TreeWalk {
 
     int * WorkSet;
     int WorkSetSize;
-    /*Did we allocate our own memory to store the WorkSet?*/
-    int work_set_allocated;
+    /*Did we use the active_set array as the WorkSet?*/
+    int work_set_stolen_from_active;
 
     /* per worker thread*/
     int *currentIndex;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -117,6 +117,8 @@ struct TreeWalk {
 
     int * WorkSet;
     int WorkSetSize;
+    /*Did we allocate our own memory to store the WorkSet?*/
+    int work_set_allocated;
 
     /* per worker thread*/
     int *currentIndex;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -115,7 +115,6 @@ struct TreeWalk {
     int BufferFullFlag;
     int BunchSize;
 
-    struct ev_task * PrimaryTasks;
     int * WorkSet;
     int WorkSetSize;
 

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -494,3 +494,16 @@ MPIU_write_pids(char * filename)
         MPI_Barrier(MPI_COMM_WORLD);
     }
 }
+
+size_t gadget_compact_thread_arrays(int * dest, int * srcs[], size_t sizes[], int narrays)
+{
+    int i;
+    size_t asize = 0;
+
+    for(i = 0; i < narrays; i++)
+    {
+        memmove(dest + asize, srcs[i], sizeof(int) * sizes[i]);
+        asize += sizes[i];
+    }
+    return asize;
+}

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -35,6 +35,11 @@ int64_t count_sum(int64_t countLocal);
 int MPIU_Any(int condition, MPI_Comm comm);
 void MPIU_write_pids(char * filename);
 
+/* Compact an array which has segments (usually corresponding to different threads).
+ * After this is run, it will be a single contiguous array. The memory can then be realloced.
+ * Function returns size of the final array.*/
+size_t gadget_compact_thread_arrays(int * dest, int * srcs[], size_t sizes[], int narrays);
+
 int MPI_Alltoallv_smart(void *sendbuf, int *sendcnts, int *sdispls,
         MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
         int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);


### PR DESCRIPTION
Treewalk optimisations for high thread count, especially knights landing

I ran the code on Stampede's knight's landing nodes. Our performance kind of sucks (perhaps half of a normal intel skylake node). Part of this is because I was using a very small problem size, but part of it is that our code needs to be threaded better. I was able to get an extra 10% of the total runtime by careful massaging of the tree: in particular I made sure that the WorkSet queue preserves the order of particles in memory.

Making the ActiveParticle list was also a hot-spot at high thread count: I parallelized it and was able to skip it entirely during a PM step. Skipping it entirely during a PM step saved memory but didn't noticeably decrease CPU time, probably because a PM step is relatively rare.

Tested that this gives almost identical output to master on both dm-only and hydro examples.