### PR TITLE
Exchange thread scaling

### DIFF
--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -201,7 +201,7 @@ void domain_decompose_full(void)
     myfree(TopTreeTempMemory);
     TopTreeTempMemory = NULL;
 
-    if(domain_exchange(domain_layoutfunc))
+    if(domain_exchange(domain_layoutfunc, 0))
         endrun(1929,"Could not exchange particles\n");
 
     /*Do a garbage collection so that the slots are ordered
@@ -228,7 +228,7 @@ void domain_maintain(void)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc)) {
+    if(0 != domain_exchange(domain_layoutfunc, 1)) {
         domain_decompose_full();
         return;
     }

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -34,7 +34,11 @@ typedef struct {
     int * ExchangeList;
     /*Total number of exchanged particles*/
     int nexchange;
-    /*First and last particles in this exchange*/
+    /* First and last particles in current
+     * batch of the exchange, relative to ExchangeList[0].
+     * After each batch, first will be updated to last
+     * and last will be recomputed.
+     * Exchange stops when last == nexchange.*/
     int first;
     int last;
     ExchangePartCache * layouts;

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -1,7 +1,7 @@
 #ifndef __EXCHANGE_H
 #define __EXCHANGE_H
 
-int domain_exchange(int (*layoutfunc)(int p));
+int domain_exchange(int (*layoutfunc)(int p), int do_gc);
 void domain_test_id_uniqueness();
 
 #endif

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -211,7 +211,7 @@ static void fof_distribute_particles() {
     }
     myfree(pi);
 
-    if(domain_exchange(fof_sorted_layout))
+    if(domain_exchange(fof_sorted_layout, 1))
         endrun(1930,"Could not exchange particles\n");
     /* sort SPH and Others independently */
 
@@ -225,7 +225,7 @@ static void fof_distribute_particles() {
 
 }
 static void fof_return_particles() {
-    if(domain_exchange(fof_origin_layout))
+    if(domain_exchange(fof_origin_layout, 1))
         endrun(1931,"Could not exchange particles\n");
 }
 

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -28,18 +28,16 @@ struct particle_data
 
         unsigned int IsGarbage            :1; /* True for a garbage particle. readonly: Use slots_mark_garbage to mark this.*/
         unsigned int Evaluated            :1; /* True if already query already ran in treewalk */
-        unsigned int OnAnotherDomain      :1; /* particle is hosted by another rank; used in domain; */
-        unsigned int WillExport           :1; /* particle will be exported in current run of exchange; */
-
         unsigned int DensityIterationDone :1; /* True if the density-like iterations already finished; */
         unsigned int IsNewParticle        :1; /* True if the particle is created this step; used in SFR */
         unsigned int Swallowed            :1; /* True if the particle is being swallowed; used in BH to determine swallower and swallowee;*/
 #ifdef DEBUG
         unsigned int SufferFromCoupling:1; /* whether it suffers from particle-coupling (nearest neighbour << gravity smoothing)*/
 #else
-        unsigned int spare_4              :1;
+        unsigned int spare_6              :1;
 #endif
-
+        unsigned int spare_5              :1;
+        unsigned int spare_4              :1;
         unsigned int spare_3              :1;
         unsigned int spare_2              :1;
         unsigned int spare_1              :1;

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -101,7 +101,7 @@ test_exchange(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func);
+    int fail = domain_exchange(&test_exchange_layout_func, 1);
 
     assert_all_true(!fail);
 
@@ -125,7 +125,7 @@ test_exchange_zero_slots(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func);
+    int fail = domain_exchange(&test_exchange_layout_func, 1);
 
     assert_all_true(!fail);
 
@@ -151,7 +151,7 @@ test_exchange_with_garbage(void **state)
     slots_mark_garbage(0); /* watch out! this propogates the garbage flag to children */
     TotNumPart -= NTask;
 
-    int fail = domain_exchange(&test_exchange_layout_func);
+    int fail = domain_exchange(&test_exchange_layout_func, 1);
 
     assert_all_true(!fail);
 
@@ -187,7 +187,7 @@ test_exchange_uneven(void **state)
     int i;
 
     /* this will trigger a slot growth on slot type 0 due to the inbalance */
-    int fail = domain_exchange(&test_exchange_layout_func_uneven);
+    int fail = domain_exchange(&test_exchange_layout_func_uneven, 1);
 
     assert_all_true(!fail);
 

--- a/libgadget/tests/test_memory.c
+++ b/libgadget/tests/test_memory.c
@@ -26,6 +26,9 @@ test_allocator(void ** state)
     q2[2000] = 1;
     q2 = allocator_realloc(A0, q2, 3072*sizeof(int));
     assert_int_equal(q2[2000] ,1);
+    /*Realloc to something smaller*/
+    q2 = allocator_realloc(A0, q2, 2048*sizeof(int));
+    assert_int_equal(q2[2000] ,1);
 
     /* Assert that reallocing does not move the base pointer.
      * Note this is true only for bottom allocations*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -308,11 +308,7 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
     size_t *nqthr = ta_malloc("nqthr", size_t, All.NumThreads);
     int **thrqueue = ta_malloc("thrqueue", int *, All.NumThreads);
 
-    thrqueue[0] = queue;
-    for(i=0; i < All.NumThreads; i++) {
-        thrqueue[i] = queue + i * size;
-        nqthr[i] = 0;
-    }
+    gadget_setup_thread_arrays(queue, thrqueue, nqthr, size, All.NumThreads);
 
     /* We enforce schedule static to ensure that each thread executes on contiguous particles.*/
     #pragma omp parallel for schedule(static)

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -509,3 +509,13 @@ size_t gadget_compact_thread_arrays(int * dest, int * srcs[], size_t sizes[], in
     }
     return asize;
 }
+
+void gadget_setup_thread_arrays(int * dest, int * srcs[], size_t sizes[], size_t total_size, int narrays)
+{
+    int i;
+    srcs[0] = dest;
+    for(i=0; i < narrays; i++) {
+        srcs[i] = dest + i * total_size;
+        sizes[i] = 0;
+    }
+}

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -40,6 +40,9 @@ void MPIU_write_pids(char * filename);
  * Function returns size of the final array.*/
 size_t gadget_compact_thread_arrays(int * dest, int * srcs[], size_t sizes[], int narrays);
 
+/* Set up pointers to different parts of a single segmented array (usually corresponding to different threads).*/
+void gadget_setup_thread_arrays(int * dest, int * srcs[], size_t sizes[], size_t total_size, int narrays);
+
 int MPI_Alltoallv_smart(void *sendbuf, int *sendcnts, int *sdispls,
         MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
         int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);


### PR DESCRIPTION
A few changes to make the exchange faster and more thread friendly. After this all the expensive functions during exchange should be parallelized and, at the cost of some memory, some loops over all particles are avoided. The export flags are removed and replaced with an ExchangeList array (not too much of a memory cost because we no longer have an ActiveParticle list allocated during exchange).

On a KNL node with 16 threads per MPI this reduces the total exchange time by a factor of two and the non-garbage exchange time by a factor of three.