### PR TITLE
Remove Barriers

### DIFF
--- a/genic/main.c
+++ b/genic/main.c
@@ -155,7 +155,6 @@ int main(int argc, char **argv)
   message(0, "IC's generated.\n");
   message(0, "Initial scale factor = %g\n", All.TimeIC);
 
-  MPI_Barrier(MPI_COMM_WORLD);
   print_spec();
 
   MPI_Finalize();		/* clean up & finalize MPI */

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -156,6 +156,8 @@ int force_tree_build(int npart)
 
     force_treeupdate_pseudos(PartManager->MaxPart, tb);
 
+    myrealloc(Nodes_base, (Numnodestree +1) * sizeof(struct NODE));
+
     event_listen(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
     return Numnodestree;
 }
@@ -1151,15 +1153,15 @@ struct TreeBuilder force_treeallocate(int maxnodes, int maxpart, int first_node_
     MaxNodes = maxnodes;
     RootNode = first_node_offset;
     message(0, "Allocating memory for %d tree-nodes (MaxPart=%d).\n", maxnodes, maxpart);
+    Nextnode = (int *) mymalloc("Nextnode", bytes = (maxpart + NTopNodes) * sizeof(int));
+    Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));
+    allbytes += bytes;
     Nodes_base = (struct NODE *) mymalloc("Nodes_base", bytes = (MaxNodes + 1) * sizeof(struct NODE));
     allbytes += bytes;
     Nodes = Nodes_base - first_node_offset;
     tb.firstnode = first_node_offset;
     tb.lastnode = first_node_offset + maxnodes;
     tb.Nodes = Nodes_base - first_node_offset;
-    Nextnode = (int *) mymalloc("Nextnode", bytes = (maxpart + NTopNodes) * sizeof(int));
-    allbytes += bytes;
-    Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));
     allbytes += bytes;
     message(0, "Allocated %g MByte for BH-tree, (presently allocated %g MB)\n",
          allbytes / (1024.0 * 1024.0),
@@ -1174,8 +1176,8 @@ void force_tree_free(void)
 {
     event_unlisten(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
 
+    myfree(Nodes_base);
     myfree(Father);
     myfree(Nextnode);
-    myfree(Nodes_base);
     tree_allocated_flag = 0;
 }

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -323,6 +323,9 @@ pfft_complex * petapm_force_r2c(
     petapm_transfer_func global_transfer = global_functions->global_transfer;
     pm_apply_transfer_function(&fourier_space_region, complx, rho_k, global_transfer);
     walltime_measure("/PMgrav/r2c");
+
+    report_memory_usage("PetaPM");
+
     myfree(complx);
     return rho_k;
 }
@@ -708,7 +711,6 @@ static void pm_init_regions(PetaPMRegion * regions, const int Nregions) {
         meshbuf = (double *) mymalloc("PMmesh", size * sizeof(double));
         /* this takes care of the padding */
         memset(meshbuf, 0, size * sizeof(double));
-        report_memory_usage("PetaPM");
         size = 0;
         for(i = 0 ; i < Nregions; i ++) {
             regions[i].buffer = meshbuf + size;

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -297,8 +297,7 @@ pfft_complex * petapm_force_r2c(
      * CFT = DFT * dx **3
      * CFT[rho] = DFT [rho * dx **3] = DFT[CIC]
      * */
-    pfft_complex * complx = (pfft_complex *) mymalloc("PMcomplex", fftsize * sizeof(double));
-    double * real = (double * ) mymalloc("PMreal", fftsize * sizeof(double));
+    double * real = (double * ) mymalloc2("PMreal", fftsize * sizeof(double));
     memset(real, 0, sizeof(double) * fftsize);
     layout_build_and_exchange_cells_to_pfft(&layout, meshbuf, real);
     walltime_measure("/PMgrav/comm2");
@@ -308,6 +307,7 @@ pfft_complex * petapm_force_r2c(
     walltime_measure("/PMgrav/Misc");
 #endif
 
+    pfft_complex * complx = (pfft_complex *) mymalloc("PMcomplex", fftsize * sizeof(double));
     pfft_execute_dft_r2c(plan_forw, real, complx);
     myfree(real);
 

--- a/libgadget/utils/memory.h
+++ b/libgadget/utils/memory.h
@@ -83,6 +83,9 @@ allocator_dealloc (Allocator * alloc, void * ptr);
 size_t
 allocator_get_free_size(Allocator * alloc);
 
+size_t
+allocator_get_used_size(Allocator * alloc, int dir);
+
 int
 allocator_iter_ended(AllocatorIter * iter);
 

--- a/libgadget/utils/mymalloc.c
+++ b/libgadget/utils/mymalloc.c
@@ -64,7 +64,7 @@ static size_t highest_memory_usage = 0;
 
 void report_detailed_memory_usage(const char *label, const char * fmt, ...)
 {
-    if(allocator_get_free_size(A_MAIN) < highest_memory_usage) {
+    if(allocator_get_used_size(A_MAIN, ALLOC_DIR_BOTH) < highest_memory_usage) {
         return;
     }
 
@@ -80,7 +80,7 @@ void report_detailed_memory_usage(const char *label, const char * fmt, ...)
         return;
     }
 
-    highest_memory_usage = allocator_get_free_size(A_MAIN);
+    highest_memory_usage = allocator_get_used_size(A_MAIN, ALLOC_DIR_BOTH);
 
     va_list va;
     char buf[4096];


### PR DESCRIPTION
While working on something else I noticed that we were spending a lot of time syncing at MPI_Barrier calls after message(0, ). So I removed the MPI_Barrier - I think it is mostly around so that we have well-measured timestamps in the log, but walltime_measure does that for us better. I get a speed-up of about 1.5% on a small 2 node, 48 MPI run, which is not large but not that small either for the size of the change.
I also removed some MPI_Barrier calls in debug functions, and stray calls in a couple of other places.

There is the possibility that removing what is effectively a sync after every major function will reveal some latent race conditions somewhere, and initially I thought this was happening, but it went away after a recompile (or maybe required a specific timing condition only found on some specific cluster nodes).

In case it resurfaces, the symptom is a crash in find_timesteps because GravPM[1] ~ 1e180 for some SPH particles.

I then noticed an interesting bug - the peak memory usage was actually reporting the peak *free* memory! I fixed this and then made small changes to petapm and treewalk to reduce the peak a bit.

Feel free to object to this - I might have missed good reasons for these Barriers.