### PR TITLE
Reintroduce Barnes-Hut criterion, use it on first timestep.

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -155,6 +155,8 @@ create_gadget_parameter_set()
     param_declare_int   (ps, "TopNodeIncreaseFactor", OPTIONAL, 4, "Create on average this number of topNodes per MPI rank. Higher numbers improve the load balancing but make domain more expensive. Similar to DomainOverDecompositionFactor, but ignored by load balancer.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
+    param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.5, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
+    param_declare_int(ps, "TreeUseBH", OPTIONAL, 0, "If true, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle.");
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");
 
@@ -379,6 +381,8 @@ void read_parameter_file(char *fname)
         All.TimeMax = param_get_double(ps, "TimeMax");
         All.ErrTolIntAccuracy = param_get_double(ps, "ErrTolIntAccuracy");
         All.ErrTolForceAcc = param_get_double(ps, "ErrTolForceAcc");
+        All.BHOpeningAngle = param_get_double(ps, "BHOpeningAngle");
+        All.TreeUseBH= param_get_int(ps, "TreeUseBH");
         All.Asmth = param_get_double(ps, "Asmth");
         All.Nmesh = param_get_int(ps, "Nmesh");
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -156,7 +156,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
     param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.5, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
-    param_declare_int(ps, "TreeUseBH", OPTIONAL, 0, "If true, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle.");
+    param_declare_int(ps, "TreeUseBH", OPTIONAL, 0, "If 1, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle. If 2, use BH criterion for the first timestep only, before we have relative accelerations.");
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -155,7 +155,7 @@ create_gadget_parameter_set()
     param_declare_int   (ps, "TopNodeIncreaseFactor", OPTIONAL, 4, "Create on average this number of topNodes per MPI rank. Higher numbers improve the load balancing but make domain more expensive. Similar to DomainOverDecompositionFactor, but ignored by load balancer.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
-    param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.5, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
+    param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.175, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
     param_declare_int(ps, "TreeUseBH", OPTIONAL, 2, "If 1, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle. If 2, use BH criterion for the first timestep only, before we have relative accelerations.");
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -156,7 +156,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
     param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.5, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
-    param_declare_int(ps, "TreeUseBH", OPTIONAL, 0, "If 1, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle. If 2, use BH criterion for the first timestep only, before we have relative accelerations.");
+    param_declare_int(ps, "TreeUseBH", OPTIONAL, 2, "If 1, use Barnes-Hut opening angle rather than the standard Gadget acceleration based opening angle. If 2, use BH criterion for the first timestep only, before we have relative accelerations.");
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");
 

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -289,6 +289,9 @@ extern struct global_data_all_processes
     /* tree code opening criterion */
 
     double ErrTolForceAcc;	/*!< parameter for relative opening criterion in tree walk */
+    double BHOpeningAngle;	/*!< Barnes-Hut parameter for opening criterion in tree walk */
+    int TreeUseBH;              /*!< If true, use the BH opening angle. Otherwise use acceleration */
+
 
     /*! The scale of the short-range/long-range force split in units of FFT-mesh cells */
     double Asmth;

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -220,7 +220,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
                 mass = nop->u.d.mass;
                 /*Check Barnes-Hut opening angle or relative opening criterion*/
-                if(((All.TreeUseBH > 0 && nop->len * nop->len > r2 * All.BHOpeningAngle)) ||
+                if(((All.TreeUseBH > 0 && nop->len * nop->len > r2 * All.BHOpeningAngle * All.BHOpeningAngle)) ||
                      (All.TreeUseBH == 0 && (mass * nop->len * nop->len > r2 * r2 * aold)))
                 {
                     /* open cell */

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -219,9 +219,9 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 }
 
                 mass = nop->u.d.mass;
-
-                /* check relative opening criterion */
-                if(mass * nop->len * nop->len > r2 * r2 * aold)
+                /*Check Barnes-Hut opening angle or relative opening criterion*/
+                if(((All.TreeUseBH > 0 && nop->len * nop->len > r2 * All.BHOpeningAngle)) ||
+                     (All.TreeUseBH == 0 && (mass * nop->len * nop->len > r2 * r2 * aold)))
                 {
                     /* open cell */
                     no = nop->u.d.nextnode;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -306,6 +306,10 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
      * are zero and so the tree is opened maximally
      * on the first timestep.*/
     grav_short_tree();
+    /* TreeUseBH > 1 means use the BH criterion on the initial timestep only,
+     * avoiding the fully open O(N^2) case.*/
+    if(All.TreeUseBH > 1)
+        All.TreeUseBH = 0;
 
     /* We use the total gravitational acc.
      * to open the tree and total acc for the timestep.

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -332,7 +332,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
      * This happens after PM because we want to
      * use the total acceleration for tree opening.
      */
-    if(FirstStep)
+    if(FirstStep && All.TreeUseBH == 0)
         grav_short_tree();
 
     /* Note this must be after gravaccel and hydro,


### PR DESCRIPTION
This PR reintroduces a Barnes-Hut tree-opening criterion and uses it on the first timestep, which allows us to avoid an O(N^2) treewalk on restarts. This was done because restarting can get *very* slow at low redshift.