### PR TITLE
Improve threading scalability

### DIFF
--- a/benchmarks/dm-50-512/paramfile.gadget
+++ b/benchmarks/dm-50-512/paramfile.gadget
@@ -46,7 +46,6 @@ MinGasTemp = 5.0
 
 # Memory allocation
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 # Softening lengths
 MinGasHsmlFractional 0.01

--- a/examples/dm-only/paramfile.gadget
+++ b/examples/dm-only/paramfile.gadget
@@ -45,7 +45,6 @@ MinGasTemp = 5.0
 
 # Memory allocation
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 # Softening lengths
 MinGasHsmlFractional 0.01

--- a/examples/fastpm-compat/paramfile.gadget
+++ b/examples/fastpm-compat/paramfile.gadget
@@ -54,7 +54,6 @@ MinGasTemp = 5.0
 # Memory allocation
 
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 # Softening lengths
 

--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -55,7 +55,6 @@ MinGasTemp = 5.0
 # Memory allocation
 
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 # Softening lengths
 

--- a/examples/linear_growth/paramfile.gadget
+++ b/examples/linear_growth/paramfile.gadget
@@ -39,7 +39,6 @@ MinGasTemp = 100
 # Memory allocation
 
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 BlackHoleOn=0
 
 ## Massive neutrinos

--- a/examples/neutrinos/paramfile.gadget
+++ b/examples/neutrinos/paramfile.gadget
@@ -30,7 +30,6 @@ FOFHaloMinLength = 32
 # Memory allocation
 
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 #Massive neutrinos
 MassiveNuLinRespOn = 1

--- a/examples/small/paramfile.gadget
+++ b/examples/small/paramfile.gadget
@@ -53,7 +53,6 @@ MinGasTemp = 5.0
 # Memory allocation
 
 PartAllocFactor = 2.0
-BufferSize = 100          # in MByte
 
 # Softening lengths
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -205,7 +205,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "GravitySoftening", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM. ForceSoftening is 2.8 times this.");
     param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisional particles (Gas); units of mean separation of DM; 0 to use Hsml of last step. ");
 
-    param_declare_double(ps, "BufferSize", OPTIONAL, 100, "");
+    param_declare_int(ps, "ImportBufferBoost", OPTIONAL, 6, "Memory factor to allow for there being more particles imported during treewlk than exported. Increase this if code crashes during treewalk with out of memory.");
     param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "");
     param_declare_double(ps, "TopNodeAllocFactor", OPTIONAL, 0.5, "");
 
@@ -428,7 +428,7 @@ void read_parameter_file(char *fname)
         All.GravitySoftening = param_get_double(ps, "GravitySoftening");
         All.GravitySofteningGas = param_get_double(ps, "GravitySofteningGas");
 
-        All.BufferSize = param_get_double(ps, "BufferSize");
+        All.ImportBufferBoost = param_get_double(ps, "ImportBufferBoost");
         All.PartAllocFactor = param_get_double(ps, "PartAllocFactor");
         All.TopNodeAllocFactor = param_get_double(ps, "TopNodeAllocFactor");
 

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -182,7 +182,7 @@ extern struct global_data_all_processes
         int UsePeculiarVelocity;
     } IO;
 
-    double BufferSize;		/*!< size of communication buffer in MB */
+    int ImportBufferBoost;		/*!< Memory factor to leave for (N imported particles) > (N exported particles). */
 
     double PartAllocFactor;	/*!< in order to maintain work-load balance, the particle load will usually
                               NOT be balanced.  Each processor allocates memory for PartAllocFactor times

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -705,20 +705,23 @@ void blackhole_make_one(int index) {
     if(P[index].Type != 0)
         endrun(7772, "Only Gas turns into blackholes, what's wrong?");
 
-    int child = slots_fork(index, 5);
+    int child;
 
-    BHP(child).FormationTime = All.Time;
-    /*Ensure that mass is conserved*/
-    double BHmass = All.SeedBlackHoleMass;
+    /*If the particle mass is less than that needed for a black hole, convert.*/
     if(P[index].Mass <= All.SeedBlackHoleMass) {
-        slots_mark_garbage(index);
-        BHmass = P[index].Mass;
+        child = slots_convert(index, 5);
     }
-    P[child].Mass = BHmass;
-    P[index].Mass -= BHmass;
+    /*Otherwise create a new particle*/
+    else {
+        child = slots_fork(index, 5);
+        /*Ensure that mass is conserved*/
+        P[child].Mass = All.SeedBlackHoleMass;
+        P[index].Mass -= All.SeedBlackHoleMass;
+    }
     BHP(child).base.ID = P[child].ID;
-    BHP(child).Mass = BHmass;
+    BHP(child).Mass = P[child].Mass;
     BHP(child).Mdot = 0;
+    BHP(child).FormationTime = All.Time;
 
     /* It is important to initialize MinPotPos to the current position of
      * a BH to avoid drifting to unknown locations (0,0,0) immediately

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -719,6 +719,7 @@ void blackhole_make_one(int index) {
         P[index].Mass -= All.SeedBlackHoleMass;
     }
     BHP(child).base.ID = P[child].ID;
+    /*This is min(P[index].Mass, SeedBlackHoleMass */
     BHP(child).Mass = P[child].Mass;
     BHP(child).Mdot = 0;
     BHP(child).FormationTime = All.Time;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -719,8 +719,9 @@ void blackhole_make_one(int index) {
         P[index].Mass -= All.SeedBlackHoleMass;
     }
     BHP(child).base.ID = P[child].ID;
-    /*This is min(P[index].Mass, SeedBlackHoleMass */
-    BHP(child).Mass = P[child].Mass;
+    /* The accretion mass should always be the seed black hole mass,
+     * irrespective of the gravitational mass of the particle.*/
+    BHP(child).Mass = All.SeedBlackHoleMass;
     BHP(child).Mdot = 0;
     BHP(child).FormationTime = All.Time;
 

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -1307,6 +1307,10 @@ domain_compute_costs(int64_t *TopLeafWork, int64_t *TopLeafCount)
         #pragma omp for
         for(n = 0; n < PartManager->NumPart; n++)
         {
+            /* Skip garbage particles: they have zero work
+             * and can be removed by exchange if under memory pressure.*/
+            if(P[n].IsGarbage)
+                continue;
             int no = domain_get_topleaf(P[n].Key);
 
             mylocal_TopLeafWork[no] += domain_particle_costfactor(n);

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -214,7 +214,7 @@ void domain_decompose_full(void)
 
     report_memory_usage("DOMAIN");
 
-    walltime_measure("/Domain/Peano");
+    walltime_measure("/Domain/PeanoSort");
 }
 
 /* This is a cut-down version of the domain decomposition that leaves the

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -228,7 +228,7 @@ void domain_maintain(void)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc, 1)) {
+    if(0 != domain_exchange(domain_layoutfunc, 0)) {
         domain_decompose_full();
         return;
     }

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -117,7 +117,15 @@ int domain_exchange(int (*layoutfunc)(int p), int do_gc) {
 
         message(0, "iter=%d exchange of %013ld particles\n", iter, sumtogo);
 
-        failure = domain_exchange_once(layoutfunc, &plan, do_gc || (plan.last < plan.nexchange));
+        /* Do a GC if we are asked to, if this isn't the last iteration,
+         * or if we are exchanging a peculiarly large number of particles,
+         * indicating large garbage. In practice, if memory is not tight,
+         * this means we will usually only gc on PM steps. The gc decision
+         * is made collective in domain_exchange_once*/
+        int really_do_gc = do_gc || (plan.last < plan.nexchange)
+            || (plan.nexchange > PartManager->NumPart / 1000);
+
+        failure = domain_exchange_once(layoutfunc, &plan, really_do_gc);
 
         myfree(plan.ExchangeList);
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -435,7 +435,7 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
     }
     int other = iter->base.other;
 
-#pragma omp critical (_fofp_merge_)
+/* #pragma omp critical (_fofp_merge_) */
     {
         if(lv->mode == 0) {
             /* Local FOF */

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -733,26 +733,9 @@ static void pm_iterate_one(int i, pm_iterator iterator, PetaPMRegion * regions) 
         iCell[k] = floor(tmp);
         Res[k] = tmp - iCell[k];
         iCell[k] -= region->offset[k];
-        /* 
-           a special rare case is that
-           a particle is somehow wrapped inside the box, thus
-           appear to be not in the node.
-           this really shouldn't happen with regular tree code
-           but who knows ....
-           We attempt to fix this here.
-           */
-        if(iCell[k] < 0) {
-            iCell[k] += Nmesh;
-        }
-        if(iCell[k] >= region->size[k] - 1) {
-            iCell[k] -= Nmesh;
-        }
-        if(iCell[k] >= region->size[k] - 1) {
-            /* seriously?! particles are supposed to be contained in cells */
-            endrun(1, "particle out of cell better stop %d %td\n", iCell[k], region->size[k]);
-        }
-        if(iCell[k] < 0) {
-            endrun(1, "particle out of cell better stop (negative) %d %g %g %g region: %td %td\n", iCell[k], 
+        /* seriously?! particles are supposed to be contained in cells */
+        if(iCell[k] >= region->size[k] - 1 || iCell[k] < 0) {
+            endrun(1, "particle out of cell better stop %d (k=%d) %g %g %g region: %td %td\n", iCell[k],k,
                 Pos[0], Pos[1], Pos[2],
                 region->offset[k], region->size[k]);
         }

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -708,8 +708,8 @@ static int make_particle_star(int i) {
         endrun(7772, "Only gas forms stars, what's wrong?");
 
     int tid = omp_get_thread_num();
-    /*Store the index of the SPH particle properties as overwritten in slots_convert*/
-    int oldslot = P[i].PI;
+    /*Store the SPH particle slot properties, overwritten in slots_convert*/
+    struct sph_particle_data oldslot = SPHP(i);
     /* ok, make a star */
     if(P[i].Mass < 1.1 * mass_of_star || All.QuickLymanAlphaProbability > 0)
     {
@@ -732,9 +732,9 @@ static int make_particle_star(int i) {
     /*Set properties*/
     sum_mass_stars[tid] += P[child].Mass;
     STARP(child).FormationTime = All.Time;
-    STARP(child).BirthDensity = SphP[oldslot].Density;
+    STARP(child).BirthDensity = oldslot.Density;
     /*Copy metallicity*/
-    STARP(child).Metallicity = SphP[oldslot].Metallicity;
+    STARP(child).Metallicity = oldslot.Metallicity;
     P[child].IsNewParticle = 1;
     return 0;
 }

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -237,6 +237,8 @@ void cooling_and_starformation(void)
 
     walltime_measure("/Misc");
 
+    /*When we switch to OpenMP 4.5, which supports array reduction,
+     * we can perhaps remove this*/
     stars_spawned = ta_malloc("stars_spawned", int, All.NumThreads);
     stars_converted = ta_malloc("stars_converted", int, All.NumThreads);
     sum_sm = ta_malloc("sum_sm", double, All.NumThreads);

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -62,6 +62,8 @@ slots_convert(int parent, int ptype)
     uint64_t g = P[parent].Generation;
     /* change the child ID according to the generation. */
     P[parent].ID = (P[parent].ID & 0x00ffffffffffffffL) + (g << 56L);
+    if(g >= (1 << (64-56L)))
+        endrun(1, "Particle %d (ID: %ld) generated too many particles: generation %d wrapped.\n", parent, P[parent].ID, g);
 
     if(SLOTS_ENABLED(ptype)) {
         /*Set old slot as garbage*/

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -23,7 +23,8 @@ static int
 slots_gc_slots(int * compact_slots);
 
 /* Initialise a new slot with type at index pi
- * for the particle at index i.*/
+ * for the particle at index i.
+ * This will modify both P[i] and the slot at pi in type.*/
 static void
 slots_connect_new_slot(int i, int pi, int type)
 {
@@ -83,7 +84,8 @@ slots_convert(int parent, int ptype)
     return parent;
 }
 
-/* this will fork a zero mass particle at the given location of parent of the given type.
+/* This will fork a zero mass particle at the parent particle, with a new type
+ * as specified.
  *
  * Assumes the particle is protected by locks in threaded env.
  *
@@ -423,7 +425,9 @@ order_by_type_and_key(const void *a, const void *b)
 }
 
 /*Returns the number of non-Garbage particles in an array with garbage sorted to the end.
- * Used to trim recently sorted arrays. If ptype < 0, P array is trimmed.*/
+ * The index returned always points to a garbage particle.
+ * If ptype < 0, find the last garbage particle in the P array.
+ * If ptype >= 0, find the last garbage particle in the slot associated with ptype. */
 int slots_get_last_garbage(int nfirst, int nlast, int ptype)
 {
     /* nfirst is always not garbage, nlast is always garbage*/

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -117,6 +117,8 @@ slots_fork(int parent, int ptype)
     /* change the child ID according to the generation. */
     P[child] = P[parent];
     P[child].ID = (P[parent].ID & 0x00ffffffffffffffL) + (g << 56L);
+    if(g >= (1 << (64-56L)))
+        endrun(1, "Particle %d (ID: %ld) generated too many particles: generation %d wrapped.\n", parent, P[parent].ID, g);
 
     P[child].Mass = 0;
     P[child].Type = ptype;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -140,6 +140,7 @@ void slots_mark_garbage(int i);
 void slots_setup_topology();
 void slots_setup_id();
 int slots_fork(int parent, int ptype);
+int slots_convert(int parent, int ptype);
 int slots_gc(int * compact_slots);
 void slots_gc_sorted(void);
 void slots_reserve(int where, int atleast[6]);

--- a/libgadget/tests/test_slotsmanager.c
+++ b/libgadget/tests/test_slotsmanager.c
@@ -197,6 +197,25 @@ test_slots_fork(void **state)
     return;
 }
 
+static void
+test_slots_convert(void **state)
+{
+    setup_particles(state);
+    int i;
+    for(i = 0; i < 6; i ++) {
+        slots_convert(128 * i, P[i * 128].Type);
+    }
+
+    assert_int_equal(PartManager->NumPart, 128 * i);
+
+    assert_int_equal(SlotsManager->info[0].size, 129);
+    assert_int_equal(SlotsManager->info[4].size, 129);
+    assert_int_equal(SlotsManager->info[5].size, 129);
+
+    teardown_particles(state);
+    return;
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_slots_gc),

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -731,11 +731,10 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
     {
         const int bin = P[i].TimeBin;
         const int tid = omp_get_thread_num();
+        if(P[i].IsGarbage)
+            continue;
         if(ActiveParticle && is_timebin_active(bin, Ti_Current))
         {
-            if(P[i].IsGarbage)
-                endrun(2,"Trying to make particle %d active, but it is garbage!\n", i);
-
             /* Store this particle in the ActiveSet for this thread*/
             ActivePartSets[tid][NActiveThread[tid]] = i;
             NActiveThread[tid]++;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -166,6 +166,8 @@ find_timesteps(int * MinTimeBin)
         #pragma omp parallel for reduction(min:dti_min)
         for(i = 0; i < PartManager->NumPart; i++)
         {
+            /* Because we don't GC on short timesteps, there can be garbage here.
+             * Avoid making it active. */
             if(P[i].IsGarbage)
                 continue;
             inttime_t dti = get_timestep_ti(i, PM.length);

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -146,6 +146,9 @@ ev_begin(TreeWalk * tw, int * active_set, int size)
     treewalk_init_evaluated(active_set, size);
 
     Ngblist = (int*) mymalloc("Ngblist", PartManager->NumPart * All.NumThreads * sizeof(int));
+
+    report_memory_usage(tw->ev_label);
+
     /*The amount of memory eventually allocated per tree buffer*/
     int bytesperbuffer = sizeof(struct data_index) + sizeof(struct data_nodelist) + tw->query_type_elsize;
     /*This memory scales like the number of imports. In principle this could be much larger than Nexport
@@ -604,7 +607,6 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
             ev_primary(tw); /* do local particles and prepare export list */
             /* exchange particle data */
             ev_get_remote(tw);
-            report_memory_usage(tw->ev_label);
             /* now do the particles that were sent to us */
             ev_secondary(tw);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -138,8 +138,8 @@ static void
 ev_begin(TreeWalk * tw, int * active_set, int size)
 {
     /* The last argument is may_have_garbage: in practice the only
-     * trivial haswork is the gravtree, which has no garbage because
-     * an exchange just occurred. If we ever add a trivial haswork after
+     * trivial haswork is the gravtree, which has no (active) garbage because
+     * the active list was just rebuilt. If we ever add a trivial haswork after
      * sfr/bh we should change this*/
     treewalk_build_queue(tw, active_set, size, 0);
 


### PR DESCRIPTION
I ran some benchmarks with 48 threads. This addresses places where it did not scale as well as distributed memory, and does a few cleanups. 

- The GC was taking a lot of time. I first tried making it parallel and failed (because it is limited by memory bandwidth, the parallel version was not faster). I then changed the code to not do it on a short timestep (unless there is a big exchange). There is no perceptible performance change due to having garbage left floating around.
- I changed SFR and BH to just convert particles where possible, instead of creating garbage.
- I changed the treewalk buffer to just use available memory, like exchange does. This was motivated by threaded runs generally needing much larger buffers. BufferSize is no longer a parameter, but I added something to leave extra space for imported particles, which we can't strictly bound (although I have never observed the edge case the parameter guards against).
- SFR had an omp critical which serialised the whole loop! Removed it, but performance is still bad. Perhaps the atomic capture in slots_fork()?

With this the threading scalability is very close to linear, as long as there is no star formation. The treewalk in particular is faster at high thread count than with equivalent processors on MPI ranks.

Tested with a Lyman alpha run forming a lot of stars.

Other things that don't thread perfectly:
- The density and hydro calculations are both a little slower at high thread count. Not much, but I guess there is some part of the loop that isn't threading very well.
- The qsort_openmp at the end of a full domain_decompose, because the final copy in the indirect sort is serial. Making the sort direct is so much slower it isn't worth it.
- The pfft r2c transform (nothing I can do about that).