### PR TITLE
Warningsclang7

### DIFF
--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -31,7 +31,7 @@ StarformationCriterion = density
 RadiationOn = 1
 MassiveNuLinRespOn = 0
 WindOn = 1
-
+MetalCoolFile = ../cooling_metal_UVB
 
 # Accuracy of time integration
 MaxSizeTimestep = 0.1

--- a/examples/travis/paramfile.gadget
+++ b/examples/travis/paramfile.gadget
@@ -31,6 +31,7 @@ StarformationCriterion = density
 RadiationOn = 1
 MassiveNuLinRespOn = 0
 
+MetalCoolFile = ../cooling_metal_UVB
 SnapshotWithFOF = 1
 FOFHaloLinkingLength 0.2
 FOFHaloMinLength = 32

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -147,7 +147,7 @@ void blackhole(void)
     int Ntot_gas_swallowed, Ntot_BH_swallowed;
 
     walltime_measure("/Misc");
-    TreeWalk tw_accretion[1] = {0};
+    TreeWalk tw_accretion[1] = {{0}};
 
     tw_accretion->ev_label = "BH_ACCRETION";
     tw_accretion->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
@@ -161,7 +161,7 @@ void blackhole(void)
     tw_accretion->query_type_elsize = sizeof(TreeWalkQueryBHAccretion);
     tw_accretion->result_type_elsize = sizeof(TreeWalkResultBHAccretion);
 
-    TreeWalk tw_feedback[1] = {0};
+    TreeWalk tw_feedback[1] = {{0}};
     tw_feedback->ev_label = "BH_FEEDBACK";
     tw_feedback->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw_feedback->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBHFeedback);

--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -1055,7 +1055,7 @@ static void InitUVF(void) {
     int size;
     UVF.Table = h5readdouble(All.UVFluctuationFile, "Zreion_Table", &size);
     if(UVF.Table[0] < 0.01 || UVF.Table[0] > 100.0) {
-        endrun(123, "UV Flucutaiton doesn't seem right\n");
+        endrun(123, "UV Fluctuation out of range: %g\n", UVF.Table[0]);
     }
 }
 

--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -76,7 +76,6 @@ struct {
 
 static void find_abundances_and_rates(double logT, double nHcgs, struct UVBG * uvbg, struct abundance * y, struct rates * r);
 static double solve_equilibrium_temp(double u, double nHcgs, struct UVBG * uvbg, struct abundance * y);
-static double * h5readdouble(char * filename, char * dataset, int * Nread);
 
 double PrimordialCoolingRate(double logT, double nHcgs, struct UVBG * uvbg, double *nelec);
 double CoolingRateFromU(double u, double nHcgs, struct UVBG * uvbg, double *ne_guess, double Z);
@@ -790,40 +789,6 @@ void MakeCoolingTable(void)
 
 }
 
-static double * h5readdouble(char * filename, char * dataset, int * Nread) {
-    void * buffer;
-    int N;
-    if(ThisTask == 0) {
-        BigFile bf[1];
-        big_file_open(bf, filename);
-        BigBlock bb[1];
-        if(0 != big_file_open_block(bf, bb, dataset)) {
-            endrun(-1, "Cannot open %s %s\n", filename, dataset);
-        }
-
-        N = bb->size;
-        MPI_Bcast(&N, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-        BigArray array[1];
-
-        big_block_read_simple(bb, 0, N, array, "f8");
-        /* steal the buffer */
-        buffer = array->data;
-        big_block_close(bb);
-        big_file_close(bf);
-    } else {
-        MPI_Bcast(&N, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        buffer = malloc(N * sizeof(double));
-    }
-
-    MPI_Bcast(buffer, N, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-    *Nread = N;
-    return buffer;
-}
-
-
-
 /* table input (from file TREECOOL) for ionizing parameters */
 
 #define JAMPL	1.0		/* amplitude factor relative to input table */
@@ -955,6 +920,50 @@ void InitCool(void)
     InitUVF();
 }
 
+/* Read a big array from filename/dataset into an array, allocating memory in buffer.
+ * which is returned. Nread argument is set equal to number of elements read.*/
+static double * h5readdouble(char * filename, char * dataset, int * Nread) {
+    int N;
+    void * buffer=NULL;
+    if(ThisTask == 0) {
+        BigFile bf[1];
+        BigBlockPtr ptr;
+        BigBlock bb[1];
+        BigArray array[1];
+        size_t dims[2];
+        big_file_open(bf, filename);
+        if(0 != big_file_open_block(bf, bb, dataset)) {
+            endrun(-1, "Cannot open %s %s: %s\n", filename, dataset, big_file_get_error_message());
+        }
+
+        N = bb->size;
+
+        buffer = mymalloc("cooling_data", N * dtype_itemsize(bb->dtype) * bb->nmemb);
+
+        dims[0] = N;
+        dims[1] = bb->nmemb;
+
+        big_array_init(array, buffer, bb->dtype, 2, dims, NULL);
+        if(0 != big_block_seek(bb, &ptr, 0))
+            endrun(1, "Failed to seek block %s %s: %s\n", filename, dataset, big_file_get_error_message());
+
+        if(0 != big_block_read(bb, &ptr, array))
+            endrun(-1, "Failed to read %s %s: %s", filename, dataset, big_file_get_error_message());
+        /* steal the buffer */
+        big_block_close(bb);
+        big_file_close(bf);
+    }
+
+    MPI_Bcast(&N, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if(ThisTask != 0)
+        buffer = mymalloc("cooling_data",N * sizeof(double));
+
+    MPI_Bcast(buffer, N, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+    *Nread = N;
+    return buffer;
+}
+
 static void InitMetalCooling() {
     int size;
     //This is never used if All.MetalCoolFile == ""
@@ -963,7 +972,7 @@ static void InitMetalCooling() {
     if(size != 1 || tabbedmet[0] != 0.0) {
         endrun(123, "MetalCool file %s is wrongly tabulated\n", All.MetalCoolFile);
     }
-    free(tabbedmet);
+    myfree(tabbedmet);
     
     MC.Redshift_bins = h5readdouble(All.MetalCoolFile, "Redshift_bins", &MC.NRedshift_bins);
     MC.HydrogenNumberDensity_bins = h5readdouble(All.MetalCoolFile, "HydrogenNumberDensity_bins", &MC.NHydrogenNumberDensity_bins);
@@ -1024,7 +1033,6 @@ static void InitUVF(void) {
         message(0, "Using NON-UNIFORM UV BG from %s and %s\n", All.TreeCoolFile, All.UVFluctuationFile);
         UVF.disabled = 0;
     }
-    int size;
     {
         /* read the reionized fraction */
         UVF.Zbins = h5readdouble(All.UVFluctuationFile, "Redshift_Bins", &UVF.N_Zbins);
@@ -1034,31 +1042,21 @@ static void InitUVF(void) {
         interp_init_dim(&UVF.Finterp, 0, UVF.Zbins[0], UVF.Zbins[UVF.N_Zbins - 1]);
     }
 
-    UVF.Nside = size;
-
-    int Nside = UVF.Nside;
-    /* This is kinda big, so we move it to mymalloc (leaving more free space for
-     * system /MPI */
-    UVF.Table = mymalloc("Zreion", (sizeof(double) * Nside) * (Nside * Nside));
-    int i;
-    double * data = h5readdouble(All.UVFluctuationFile, "Zreion_Table", &size);
-    /* convert to float internally, saving memory */
-    for(i = 0; i < size; i ++) {
-        UVF.Table[i] = data[i];
-    }
-    free(data);
-
-    if(UVF.Table[0] < 0.01 || UVF.Table[0] > 100.0) {
-        endrun(123, "UV Flucutaiton doesn't seem right\n");
-    }
-
-    double * XYZ_Bins = h5readdouble(All.UVFluctuationFile, "XYZ_Bins", &size);
+    int Nside;
+    double * XYZ_Bins = h5readdouble(All.UVFluctuationFile, "XYZ_Bins", &Nside);
     int dims[] = {Nside, Nside, Nside};
     interp_init(&UVF.interp, 3, dims);
     interp_init_dim(&UVF.interp, 0, XYZ_Bins[0], XYZ_Bins[Nside - 1]);
     interp_init_dim(&UVF.interp, 1, XYZ_Bins[0], XYZ_Bins[Nside - 1]);
     interp_init_dim(&UVF.interp, 2, XYZ_Bins[0], XYZ_Bins[Nside - 1]);
-    free(XYZ_Bins);
+    myfree(XYZ_Bins);
+    UVF.Nside = Nside;
+
+    int size;
+    UVF.Table = h5readdouble(All.UVFluctuationFile, "Zreion_Table", &size);
+    if(UVF.Table[0] < 0.01 || UVF.Table[0] > 100.0) {
+        endrun(123, "UV Flucutaiton doesn't seem right\n");
+    }
 }
 
 #if 0

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -121,7 +121,7 @@ density_internal(int update_hsml)
     if(!All.DensityOn)
 	return;
 
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
     struct DensityPriv priv[1];
 
     tw->ev_label = "DENSITY";

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -307,7 +307,7 @@ void fof_label_primary(void)
 
     message(0, "Start linking particles (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
 
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
     tw->ev_label = "FOF_FIND_GROUPS";
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw->ngbiter = (TreeWalkNgbIterFunction) fof_primary_ngbiter;
@@ -1063,7 +1063,7 @@ static void fof_label_secondary(void)
 {
     int n, iter;
 
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
     tw->ev_label = "FOF_FIND_NEAREST";
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw->ngbiter = (TreeWalkNgbIterFunction) fof_secondary_ngbiter;

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -244,7 +244,7 @@ static void build_buffer_fof(BigArray * array, IOTableEntry * ent) {
 }
 
 static void fof_write_header(BigFile * bf) {
-    BigBlock bh = {0};
+    BigBlock bh;
     if(0 != big_file_mpi_create_block(bf, &bh, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
         endrun(0, "Failed to create header\n");
     }

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -24,7 +24,7 @@ grav_short_pair_ngbiter(
 
 void grav_short_pair(void)
 {
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
 
     message(0, "Starting pair-wise short range gravity...\n");
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -50,7 +50,7 @@ void grav_short_tree(void)
     if(!All.TreeGravOn)
         return;
 
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
 
     tw->ev_label = "FORCETREE_SHORTRANGE";
     tw->visit = (TreeWalkVisitFunction) force_treeev_shortrange;

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -91,7 +91,7 @@ void hydro_force(void)
 {
     if(!All.HydroOn)
         return;
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
 
     tw->ev_label = "HYDRO";
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -234,7 +234,7 @@ void petaio_save_neutrinos(BigFile * bf, int ThisTask)
         for(i=0;i< ia;i++)
             delta_tot[ik*ia+i] = delta_tot_table.delta_tot[ik][i];
 
-    BigBlock bn = {0};
+    BigBlock bn;
     if(0 != big_file_mpi_create_block(bf, &bn, "Neutrino", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
         endrun(0, "Failed to create block at %s:%s\n", "Neutrino",
                 big_file_get_error_message());
@@ -337,7 +337,7 @@ void petaio_read_neutrinos(BigFile * bf, int ThisTask)
 #pragma omp master
     {
     size_t nk, ia, ik, i;
-    BigBlock bn = {0};
+    BigBlock bn;
     if(0 != big_file_mpi_open_block(bf, &bn, "Neutrino", MPI_COMM_WORLD)) {
         endrun(0, "Failed to open block at %s:%s\n", "Neutrino",
                     big_file_get_error_message());

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -438,7 +438,7 @@ petaio_read_header_internal(BigFile * bf) {
         endrun(0, "Failed to create block at %s:%s\n", "Header",
                     big_file_get_error_message());
     }
-    double Time;
+    double Time = 0.;
     int ptype;
     int64_t NTotal[6];
     if(

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -31,7 +31,7 @@ void fof_register_io_blocks();
  *
  */
 
-struct IOTable IOTable = {0};
+struct IOTable IOTable;
 
 static void petaio_write_header(BigFile * bf, const int64_t * NTotal);
 static void petaio_read_header_internal(BigFile * bf);
@@ -174,7 +174,7 @@ void petaio_read_internal(char * fname, int ic) {
     int ptype;
     int i;
     BigFile bf = {0};
-    BigBlock bh = {0};
+    BigBlock bh;
     message(0, "Reading snapshot %s\n", fname);
 
     if(0 != big_file_mpi_open(&bf, fname, MPI_COMM_WORLD)) {
@@ -370,7 +370,7 @@ petaio_read_snapshot(int num)
 
 /* write a header block */
 static void petaio_write_header(BigFile * bf, const int64_t * NTotal) {
-    BigBlock bh = {0};
+    BigBlock bh;
     if(0 != big_file_mpi_create_block(bf, &bh, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
         endrun(0, "Failed to create block at %s:%s\n", "Header",
                 big_file_get_error_message());
@@ -433,7 +433,7 @@ _get_attr_int(BigBlock * bh, char * name, int def)
 
 static void
 petaio_read_header_internal(BigFile * bf) {
-    BigBlock bh = {0};
+    BigBlock bh;
     if(0 != big_file_mpi_open_block(bf, &bh, "Header", MPI_COMM_WORLD)) {
         endrun(0, "Failed to create block at %s:%s\n", "Header",
                     big_file_get_error_message());
@@ -788,6 +788,7 @@ static int order_by_type(const void *a, const void *b)
 
 static void register_io_blocks() {
     int i;
+    memset(&IOTable, 0, sizeof(IOTable));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
         IO_REG(Position, "f8", 3, i);

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -245,7 +245,7 @@ void cooling_and_starformation(void)
     sum_mass_stars = ta_malloc("sum_mass_stars", double, All.NumThreads);
     localsfr = ta_malloc("localsfr", double, All.NumThreads);
 
-    TreeWalk tw[1] = {0};
+    TreeWalk tw[1] = {{0}};
 
     tw->visit = NULL; /* no tree walk */
     tw->ev_label = "SFR_COOL";
@@ -312,7 +312,7 @@ void cooling_and_starformation(void)
     /* now lets make winds. this has to be after NumPart is updated */
     if(All.WindOn && !HAS(All.WindModel, WIND_SUBGRID)){
         Wind = (struct winddata * ) mymalloc("WindExtraData", PartManager->NumPart * sizeof(struct winddata));
-        TreeWalk tw[1] = {0};
+        TreeWalk tw[1] = {{0}};
 
         tw->ev_label = "SFR_WIND";
         tw->fill = (TreeWalkFillQueryFunction) sfr_wind_copy;

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -4,7 +4,7 @@
 
 #include "utils.h"
 
-struct slots_manager_type SlotsManager[1] = {0};
+struct slots_manager_type SlotsManager[1] = {{0}};
 
 #define SLOTS_ENABLED(ptype) (SlotsManager->info[ptype].enabled)
 

--- a/libgadget/tests/test_slotsmanager.c
+++ b/libgadget/tests/test_slotsmanager.c
@@ -222,6 +222,7 @@ int main(void) {
         cmocka_unit_test(test_slots_gc_sorted),
         cmocka_unit_test(test_slots_reserve),
         cmocka_unit_test(test_slots_fork),
+        cmocka_unit_test(test_slots_convert),
         cmocka_unit_test(test_slots_zero),
     };
     return cmocka_run_group_tests_mpi(tests, NULL, NULL);

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -779,7 +779,7 @@ static void print_timebin_statistics(int NumCurrentTiStep, int * TimeBinCountTyp
     int i;
     int64_t tot = 0, tot_type[6] = {0};
     int64_t tot_count[TIMEBINS+1] = {0};
-    int64_t tot_count_type[6][TIMEBINS+1] = {0};
+    int64_t tot_count_type[6][TIMEBINS+1] = {{0}};
     int64_t tot_num_force = 0;
     int64_t TotNumPart = 0, TotNumType[6] = {0};
 

--- a/libgadget/utils/interp.c
+++ b/libgadget/utils/interp.c
@@ -4,6 +4,7 @@
 #include <math.h>
 
 #include "interp.h"
+#include "mymalloc.h"
 
 void interp_init(Interp * obj, int Ndim, int * dims) {
     ptrdiff_t N = 1;
@@ -14,7 +15,7 @@ void interp_init(Interp * obj, int Ndim, int * dims) {
 
     /* alloc memory */
     obj->Ndim = Ndim;
-    obj->data = malloc(0
+    obj->data = mymalloc("interp_data", 0
         +   sizeof(double) * Ndim * 3
         +   sizeof(ptrdiff_t) * Ndim
         +   sizeof(int) * Ndim);
@@ -169,6 +170,6 @@ double interp_eval_periodic(Interp * obj, double * x, double * ydata) {
 }
 
 void interp_destroy(Interp * obj) {
-    free(obj->data);
+    myfree(obj->data);
 }
 


### PR DESCRIPTION
Fix some warnings revealed by the new clang v7. Most are unimportant. 

There is one valid bug: the UV fluctuation model was using an uninitialized variable to allocate memory to copy into. The fix for this involves all the cooling data memory being allocated with mymalloc instead of malloc. I also turned on metal cooling in the travis tests to catch future bugs in that code.