### PR TITLE
Optimizations

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -206,8 +206,9 @@ create_gadget_parameter_set()
     param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisional particles (Gas); units of mean separation of DM; 0 to use Hsml of last step. ");
 
     param_declare_int(ps, "ImportBufferBoost", OPTIONAL, 6, "Memory factor to allow for there being more particles imported during treewlk than exported. Increase this if code crashes during treewalk with out of memory.");
-    param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "");
-    param_declare_double(ps, "TopNodeAllocFactor", OPTIONAL, 0.5, "");
+    param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "Over-allocation factor of particles, to deal with load imbalances.");
+    param_declare_double(ps, "TopNodeAllocFactor", OPTIONAL, 0.5, "Initial TopNode allocation as a fraction of maximum particle number.");
+    param_declare_double(ps, "SlotsIncreaseFactor", OPTIONAL, 0.01, "Percentage factor to increase slot allocation by when requested.");
 
     param_declare_double(ps, "InitGasTemp", OPTIONAL, -1, "Initial gas temperature. By default set to CMB temperature at starting redshift.");
     param_declare_double(ps, "MinGasTemp", OPTIONAL, 5, "Minimum gas temperature");
@@ -431,6 +432,7 @@ void read_parameter_file(char *fname)
         All.ImportBufferBoost = param_get_double(ps, "ImportBufferBoost");
         All.PartAllocFactor = param_get_double(ps, "PartAllocFactor");
         All.TopNodeAllocFactor = param_get_double(ps, "TopNodeAllocFactor");
+        All.SlotsIncreaseFactor = param_get_double(ps, "SlotsIncreaseFactor");
 
         All.InitGasTemp = param_get_double(ps, "InitGasTemp");
         All.MinGasTemp = param_get_double(ps, "MinGasTemp");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -196,6 +196,7 @@ extern struct global_data_all_processes
                                   the maximum(!) number of particles.  Note: A typical local tree for N
                                   particles needs usually about ~0.65*N nodes. */
 
+    double SlotsIncreaseFactor; /* !< What percentage to increase the slot allocation by when requested*/
     int OutputPotential;        /*!< Flag whether to include the potential in snapshots*/
 
     /* some SPH parameters */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -416,17 +416,15 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             double u = r * iter->accretion_kernel.Hinv;
             double wk = density_kernel_wk(&iter->accretion_kernel, u);
             float mass_j = P[other].Mass;
-            double VelPred[3];
-            sph_VelPred(other, VelPred);
 
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
             O->SmoothedPressure += (mass_j * wk * PressurePred(other));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
-            O->GasVel[0] += (mass_j * wk * VelPred[0]);
-            O->GasVel[1] += (mass_j * wk * VelPred[1]);
-            O->GasVel[2] += (mass_j * wk * VelPred[2]);
+            O->GasVel[0] += (mass_j * wk * SPHP(other).VelPred[0]);
+            O->GasVel[1] += (mass_j * wk * SPHP(other).VelPred[1]);
+            O->GasVel[2] += (mass_j * wk * SPHP(other).VelPred[2]);
 
             /* here we have a gas particle; check for swallowing */
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -247,7 +247,9 @@ density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw)
     }
     else
     {
-        sph_VelPred(place, I->Vel);
+        I->Vel[0] = SPHP(place).VelPred[0];
+        I->Vel[1] = SPHP(place).VelPred[1];
+        I->Vel[2] = SPHP(place).VelPred[2];
     }
 
 #ifdef SFR
@@ -374,9 +376,8 @@ density_ngbiter(
             double dv[3];
             double rot[3];
             int d;
-            sph_VelPred(other, dv);
             for(d = 0; d < 3; d ++) {
-                dv[d] = I->Vel[d] - dv[d];
+                dv[d] = I->Vel[d] - SPHP(other).VelPred[d];
             }
             O->Div += -fac * dotproduct(dist, dv);
 

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -38,6 +38,24 @@ void drift_particle(int i, inttime_t ti1) {
     unlock_particle(i);
 }
 
+/*Get the predicted velocity for a particle
+ * at the Force computation time, which always coincides with the Drift inttime.
+ * for gravity and hydro forces.
+ * This is mostly used for artificial viscosity.*/
+static void
+sph_VelPred(int i, double * VelPred)
+{
+    const int ti = P[i].Ti_drift;
+    const double Fgravkick2 = get_gravkick_factor(P[i].Ti_kick, ti);
+    const double Fhydrokick2 = get_hydrokick_factor(P[i].Ti_kick, ti);
+    const double FgravkickB = get_gravkick_factor(PM.Ti_kick, ti);
+    int j;
+    for(j = 0; j < 3; j++) {
+        VelPred[j] = P[i].Vel[j] + Fgravkick2 * P[i].GravAccel[j]
+            + P[i].GravPM[j] * FgravkickB + Fhydrokick2 * SPHP(i).HydroAccel[j];
+    }
+}
+
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
 {
     int j;
@@ -107,6 +125,7 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
         if(dloga > 0 && SPHP(i).EntVarPred < 0.5*SPHP(i).Entropy)
             SPHP(i).EntVarPred = 0.5 * SPHP(i).Entropy;
         SPHP(i).EntVarPred = pow(SPHP(i).EntVarPred, 1/GAMMA);
+        sph_VelPred(i, SPHP(i).VelPred);
         //      P[i].Hsml *= exp(0.333333333333 * SPHP(i).DivVel * ddrift);
         //---This was added
         double fac = exp(0.333333333333 * SPHP(i).DivVel * ddrift);

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -352,13 +352,12 @@ void fof_label_primary(void)
         /* let's check out which particles have changed their MinID,
          * mark them for next round. */
         link_across = 0;
-#pragma omp parallel for
+#pragma omp parallel for reduction(+: link_across)
         for(i = 0; i < PartManager->NumPart; i++) {
             MyIDType newMinID = HaloLabel[HEAD(i, tw)].MinID;
             if(newMinID != FOF_PRIMARY_GET_PRIV(tw)->OldMinID[i]) {
                 FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[i] = 1;
-#pragma omp atomic
-                link_across += 1;
+                link_across ++;
             } else {
                 FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[i] = 0;
             }

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -132,7 +132,9 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
     double soundspeed_i;
     const double fac_mu = pow(All.cf.a, 3 * (GAMMA - 1) / 2) / All.cf.a;
     /*Compute predicted velocity*/
-    sph_VelPred(place, input->Vel);
+    input->Vel[0] = SPHP(place).VelPred[0];
+    input->Vel[1] = SPHP(place).VelPred[1];
+    input->Vel[2] = SPHP(place).VelPred[2];
     input->Hsml = P[place].Hsml;
     input->Mass = P[place].Mass;
     input->Density = SPHP(place).Density;
@@ -239,9 +241,8 @@ hydro_ngbiter(
 
         double dv[3];
         int d;
-        sph_VelPred(other, dv);
         for(d = 0; d < 3; d++) {
-            dv[d] = I->Vel[d] - dv[d];
+            dv[d] = I->Vel[d] - SPHP(other).VelPred[d];
         }
 
         double vdotr = dotproduct(dist, dv);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -110,10 +110,6 @@ void hydro_force(void)
 
     walltime_measure("/Misc");
 
-    /* allocate buffers to arrange communication */
-
-    walltime_measure("/SPH/Hydro/Init");
-
     treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     /* collect some timing information */

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -73,7 +73,7 @@ void begrun(int RestartSnapNum)
 
     petaio_read_header(RestartSnapNum);
 
-    slots_init();
+    slots_init(All.SlotsIncreaseFactor);
     /* Enable the slots: stars and BHs are allocated if there are some,
      * or if some will form*/
     if(All.NTotalInit[0] > 0)

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -434,20 +434,16 @@ cooling_direct(int i) {
 
     SPHP(i).Ne = ne;
 
-    if(P[i].TimeBin)	/* upon start-up, we need to protect against dt==0 */
+    /* upon start-up, we need to protect against dt==0 */
+    if(dloga > 0)
     {
         /* note: the adiabatic rate has been already added in ! */
+        SPHP(i).DtEntropy = (unew * GAMMA_MINUS1 /
+                pow(SPHP(i).EOMDensity * All.cf.a3inv,
+                    GAMMA_MINUS1) - SPHP(i).Entropy) / dloga;
 
-        if(dloga > 0)
-        {
-
-            SPHP(i).DtEntropy = (unew * GAMMA_MINUS1 /
-                    pow(SPHP(i).EOMDensity * All.cf.a3inv,
-                        GAMMA_MINUS1) - SPHP(i).Entropy) / dloga;
-
-            if(SPHP(i).DtEntropy < -0.5 * SPHP(i).Entropy / dloga)
-                SPHP(i).DtEntropy = -0.5 * SPHP(i).Entropy / dloga;
-        }
+        if(SPHP(i).DtEntropy < -0.5 * SPHP(i).Entropy / dloga)
+            SPHP(i).DtEntropy = -0.5 * SPHP(i).Entropy / dloga;
     }
 }
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -217,7 +217,7 @@ sfr_cool_postprocess(int i, TreeWalk * tw)
         flag = get_sfr_condition(i);
 
         /* normal implicit isochoric cooling */
-        if(flag == 1 || All.QuickLymanAlphaProbability > 0) {
+        if(flag == 1 || (All.QuickLymanAlphaProbability > 0 && All.QuickLymanAlphaProbability < 1)) {
             cooling_direct(i);
         }
         if(flag == 0) {

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -45,8 +45,6 @@ sfr_cooling_haswork(int target, TreeWalk * tw)
 }
 
 #ifdef SFR
-static double u_to_temp_fac; /* assuming very hot !*/
-
 /* these guys really shall be local to cooling_and_starformation, but
  * I am too lazy to pass them around to subroutines.
  */
@@ -232,9 +230,6 @@ sfr_cool_postprocess(int i, TreeWalk * tw)
 void cooling_and_starformation(void)
     /* cooling routine when star formation is enabled */
 {
-    u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1
-        * All.UnitEnergy_in_cgs / All.UnitMass_in_g;
-
     walltime_measure("/Misc");
 
     /*When we switch to OpenMP 4.5, which supports array reduction,
@@ -335,7 +330,7 @@ void cooling_and_starformation(void)
          * because we need to compute the normalization before the feedback . */
         tw->visit = NULL;
         tw->haswork = (TreeWalkHasWorkFunction) sfr_wind_feedback_haswork;
-        tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_preprocess; 
+        tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_preprocess;
         treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
         tw->haswork = sfr_wind_weight_haswork;
@@ -420,6 +415,9 @@ cooling_direct(int i) {
         }
 
         unew += SPHP(i).Injected_BH_Energy / P[i].Mass;
+        const double u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1
+        * All.UnitEnergy_in_cgs / All.UnitMass_in_g;
+
         double temp = u_to_temp_fac * unew;
 
 
@@ -483,6 +481,9 @@ static int get_sfr_condition(int i) {
         double unew = DMAX(All.MinEgySpec,
                 (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
                 GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+
+        const double u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1
+        * All.UnitEnergy_in_cgs / All.UnitMass_in_g;
 
         double temp = u_to_temp_fac * unew;
 
@@ -754,6 +755,9 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
         struct UVBG uvbg;
         GetParticleUVBG(i, &uvbg);
         egycurrent += SPHP(i).Injected_BH_Energy / P[i].Mass;
+
+        const double u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1
+        * All.UnitEnergy_in_cgs / All.UnitMass_in_g;
 
         double temp = u_to_temp_fac * egycurrent;
 

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -106,13 +106,10 @@ slots_convert(int parent, int ptype)
 int
 slots_fork(int parent, int ptype)
 {
-    if(PartManager->NumPart >= PartManager->MaxPart)
-    {
-        endrun(8888, "Tried to spawn: NumPart=%d MaxPart = %d. Sorry, no space left.\n",
-                PartManager->NumPart, PartManager->MaxPart);
-    }
-    /*This is all racy if ActiveParticle or P is accessed from another thread*/
     int child = atomic_fetch_and_add(&PartManager->NumPart, 1);
+
+    if(child >= PartManager->MaxPart)
+        endrun(8888, "Tried to spawn: NumPart=%d MaxPart = %d. Sorry, no space left.\n", child, PartManager->MaxPart);
 
     P[parent].Generation ++;
     uint64_t g = P[parent].Generation;

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -501,11 +501,7 @@ slots_reserve(int where, int atleast[6])
         }
     }
 
-    /* FIXME: change 0.01 to a parameter. The experience is
-     * this works out fine, since the number of time steps increases
-     * (hence the number of growth increases
-     * when the star formation rate does)*/
-    int add = 0.01 * PartManager->MaxPart;
+    int add = SlotsManager->increase * PartManager->MaxPart;
     if (add < 128) add = 128;
 
     /* FIXME: allow shrinking; need to tweak the memmove later. */
@@ -565,12 +561,13 @@ slots_reserve(int where, int atleast[6])
 }
 
 void
-slots_init()
+slots_init(double increase)
 {
     memset(SlotsManager, 0, sizeof(SlotsManager[0]));
 
     MPI_Type_contiguous(sizeof(struct particle_data), MPI_BYTE, &MPI_TYPE_PARTICLE);
     MPI_Type_commit(&MPI_TYPE_PARTICLE);
+    SlotsManager->increase = increase;
 }
 
 void

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -15,6 +15,8 @@ extern struct slots_manager_type {
         size_t elsize; /* itemsize */
         int enabled;
     } info[6];
+    double increase; /* Percentage amount to increase
+                      * slot reservation by when requested.*/
 } SlotsManager[1];
 
 /* Slot particle data structures: first the base extension slot, then black holes,
@@ -132,7 +134,7 @@ extern MPI_Datatype MPI_TYPE_SLOT[6];
 #define BASESLOT_PI(PI, ptype) ((struct particle_data_ext *)(SlotsManager->info[ptype].ptr + SlotsManager->info[ptype].elsize * (PI)))
 #define BASESLOT(i) BASESLOT_PI(P[i].PI, P[i].Type)
 
-void slots_init(void);
+void slots_init(double increase);
 /*Enable a slot on type ptype. All slots are disabled after slots_init().*/
 void slots_set_enabled(int ptype, size_t elsize);
 void slots_free();

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -87,6 +87,12 @@ struct sph_particle_data
 #define DhsmlEOMDensityFactor DhsmlDensityFactor
 #endif
     MyFloat EntVarPred;         /*!< Predicted entropy at current particle drift time for SPH computation*/
+    /* VelPred can always be derived from the current time and acceleration.
+     * However, doing so makes the SPH and hydro code much (a factor of two)
+     * slower. It requires computing get_gravkick_factor twice with different arguments,
+     * which defeats the lookup cache in timefac.c. Because VelPred is used multiple times,
+     * it is much quicker to compute it once and re-use this*/
+    MyFloat VelPred[3];            /*!< Predicted velocity at current particle drift time for SPH*/
     MyFloat Metallicity;		/*!< metallicity of gas particle */
     MyFloat Entropy;		/*!< Entropy (actually entropic function) at kick time of particle */
     MyFloat MaxSignalVel;           /*!< maximum signal velocity */

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -41,7 +41,7 @@ setup_particles(int NType[6])
     P = (struct particle_data *) mymalloc("P", PartManager->MaxPart * sizeof(struct particle_data));
     memset(P, 0, sizeof(struct particle_data) * PartManager->MaxPart);
 
-    slots_init();
+    slots_init(0.01);
     slots_set_enabled(0, sizeof(struct sph_particle_data));
     slots_set_enabled(4, sizeof(struct star_particle_data));
     slots_set_enabled(5, sizeof(struct bh_particle_data));

--- a/libgadget/tests/test_slotsmanager.c
+++ b/libgadget/tests/test_slotsmanager.c
@@ -29,7 +29,7 @@ setup_particles(void ** state)
     PartManager->Base = (struct particle_data *) mymalloc("P", PartManager->MaxPart* sizeof(struct particle_data));
     memset(PartManager->Base, 0, sizeof(struct particle_data) * PartManager->MaxPart);
 
-    slots_init();
+    slots_init(0.01);
     int ptype;
     slots_set_enabled(0, sizeof(struct sph_particle_data));
     slots_set_enabled(4, sizeof(struct star_particle_data));

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -21,14 +21,8 @@
  *  momentum space and assigning new timesteps
  */
 
-/* variables for organizing PM steps of discrete timeline */
-typedef struct {
-    inttime_t length; /*!< Duration of the current PM integer timestep*/
-    inttime_t start;           /* current start point of the PM step*/
-    inttime_t Ti_kick;  /* current inttime of PM Kick (velocity) */
-} TimeSpan;
-
-static TimeSpan PM;
+/*PM timesteps*/
+TimeSpan PM;
 
 /*Get the dti from the timebin*/
 static inline inttime_t dti_from_timebin(int bin) {
@@ -375,24 +369,6 @@ do_the_short_range_kick(int i, inttime_t tistart, inttime_t tiend)
             SPHP(i).DtEntropy = -0.5 * SPHP(i).Entropy / dt_entr_next;
     }
 
-}
-
-/*Get the predicted velocity for a particle
- * at the Force computation time, which always coincides with the Drift inttime.
- * for gravity and hydro forces.
- * This is mostly used for artificial viscosity.*/
-void
-sph_VelPred(int i, double * VelPred)
-{
-    const int ti = P[i].Ti_drift;
-    const double Fgravkick2 = get_gravkick_factor(P[i].Ti_kick, ti);
-    const double Fhydrokick2 = get_hydrokick_factor(P[i].Ti_kick, ti);
-    const double FgravkickB = get_gravkick_factor(PM.Ti_kick, ti);
-    int j;
-    for(j = 0; j < 3; j++) {
-        VelPred[j] = P[i].Vel[j] + Fgravkick2 * P[i].GravAccel[j]
-            + P[i].GravPM[j] * FgravkickB + Fhydrokick2 * SPHP(i).HydroAccel[j];
-    }
 }
 
 double

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -7,6 +7,15 @@ set in rebuild_activelist.*/
 extern int NumActiveParticle;
 extern int *ActiveParticle;
 
+/* variables for organizing PM steps of discrete timeline */
+typedef struct {
+    inttime_t length; /*!< Duration of the current PM integer timestep*/
+    inttime_t start;           /* current start point of the PM step*/
+    inttime_t Ti_kick;  /* current inttime of PM Kick (velocity) */
+} TimeSpan;
+
+extern TimeSpan PM;
+
 int rebuild_activelist(inttime_t ti_current, int NumCurrentTiStep);
 void free_activelist(void);
 void set_global_time(double newtime);
@@ -16,8 +25,6 @@ void apply_PM_half_kick(void);
 
 int is_timebin_active(int i, inttime_t current);
 void set_timebin_active(binmask_t mask);
-
-void sph_VelPred(int i, double * VelPred);
 
 inttime_t find_next_kick(inttime_t Ti_Current, int minTimeBin);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -162,8 +162,9 @@ ev_begin(TreeWalk * tw, int * active_set, int size)
     DataNodeList =
         (struct data_nodelist *) mymalloc("DataNodeList", tw->BunchSize * sizeof(struct data_nodelist));
 
+#ifdef DEBUG
     memset(DataNodeList, -1, sizeof(struct data_nodelist) * tw->BunchSize);
-
+#endif
     tw->currentIndex = ta_malloc("currentIndexPerThread", int,  All.NumThreads);
     tw->currentEnd = ta_malloc("currentEndPerThread", int, All.NumThreads);
 

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -5,6 +5,7 @@ OPTIMIZE =  -fPIC -fopenmp -O0 -g
 GSL_INCL = 
 GSL_LIBS = -lgsl -lgslcblas
 
+SHELL = /bin/bash
 
 # on travis we run with debug mode
 OPT += -DDEBUG


### PR DESCRIPTION
This series corrects three pessimizations I introduced earlier: 

9ac4abe removes a needless memset, which was taking a lot of time (20% of runtime!) since I made the buffer in question use all available memory.
9e5d93f avoids cooling dense particles that will become stars when using the quick lyman alpha star formation. This can be expensive since DoCooling is slow for dense particles.
1864109 replaces the function calls to sph_VelPred scattered around the hydro code with a variable in SPHP. I made it a function to save memory but it was very expensive! This saves about 20% of total runtime, and almost 50% of the SPH time!

While I was going I removed a few atomic variables, fixed a race condition that would never matter in practice and fixed a fixme by making the factor to expand slot memory configurable.