### PR TITLE
Threadmem

### DIFF
--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -140,6 +140,7 @@ void check_omega(void)
     double mass = 0, masstot, omega;
     int i;
 
+    #pragma omp parallel for reduction(+: mass)
     for(i = 0; i < PartManager->NumPart; i++)
         mass += P[i].Mass;
 
@@ -163,8 +164,10 @@ void check_omega(void)
  */
 void check_positions(void)
 {
-    int i,j;
+    int i;
+    #pragma omp parallel for
     for(i=0; i< PartManager->NumPart; i++){
+        int j;
         for(j=0; j<3; j++) {
             if(P[i].Pos[j] < 0 || P[i].Pos[j] > All.BoxSize)
                 endrun(0,"Particle %d is outside the box (L=%g) at (%g %g %g)\n",i,All.BoxSize, P[i].Pos[0], P[i].Pos[1], P[i].Pos[2]);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -122,6 +122,8 @@ void init(int RestartSnapNum)
 #endif
     }
 
+    walltime_measure("/Init");
+
     domain_decompose_full();	/* do initial domain decomposition (gives equal numbers of particles) */
 
     /*At the first time step all particles should be active*/

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -683,6 +683,9 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
 {
     int i;
 
+    /*Since we use a static schedule, only need NumPart/NumThreads elements per thread.*/
+    int narr = PartManager->NumPart / All.NumThreads + 2;
+
     /*We know all particles are active on a PM timestep*/
     if(is_PM_timestep(Ti_Current)) {
         ActiveParticle = NULL;
@@ -690,7 +693,7 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
     }
     else {
         /*Need space for more particles than we have, because of star formation*/
-        ActiveParticle = (int *) mymalloc("ActiveParticle", PartManager->NumPart * All.NumThreads * sizeof(int));
+        ActiveParticle = (int *) mymalloc("ActiveParticle", narr * All.NumThreads * sizeof(int));
         NumActiveParticle = 0;
     }
 
@@ -700,7 +703,7 @@ int rebuild_activelist(inttime_t Ti_Current, int NumCurrentTiStep)
     /*We want a lockless algorithm which preserves the ordering of the particle list.*/
     size_t *NActiveThread = ta_malloc("NActiveThread", size_t, All.NumThreads);
     int **ActivePartSets = ta_malloc("ActivePartSets", int *, All.NumThreads);
-    gadget_setup_thread_arrays(ActiveParticle, ActivePartSets, NActiveThread, PartManager->NumPart, All.NumThreads);
+    gadget_setup_thread_arrays(ActiveParticle, ActivePartSets, NActiveThread, narr, All.NumThreads);
 
     /* We enforce schedule static to ensure that each thread executes on contiguous particles.
      * chunk size is not specified and so is the largest possible.*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -308,7 +308,10 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
         return;
     }
 
-    tw->WorkSet = mymalloc("ActiveQueue", size * sizeof(int) * All.NumThreads);
+    /* Since we use a static schedule below we only need size / All.NumThreads elements per thread.
+     * Add 2 for non-integer parts.*/
+    int tsize = size / All.NumThreads + 2;
+    tw->WorkSet = mymalloc("ActiveQueue", tsize * sizeof(int) * All.NumThreads);
     tw->work_set_stolen_from_active = 0;
 
     int * queue = tw->WorkSet;
@@ -318,7 +321,7 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const int size, int may_ha
     size_t *nqthr = ta_malloc("nqthr", size_t, All.NumThreads);
     int **thrqueue = ta_malloc("thrqueue", int *, All.NumThreads);
 
-    gadget_setup_thread_arrays(queue, thrqueue, nqthr, size, All.NumThreads);
+    gadget_setup_thread_arrays(queue, thrqueue, nqthr, tsize, All.NumThreads);
 
     /* We enforce schedule static to ensure that each thread executes on contiguous particles.*/
     #pragma omp parallel for schedule(static)


### PR DESCRIPTION
Following our discussion in the last pull, I noticed that most gadget_setup_thread_array calls were used with a schedule(static) which means they were allocating way more memory than they needed at high thread counts. Fix this.