### PR TITLE
Vecadvise

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -317,10 +317,10 @@ density_ngbiter(
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
         return;
     }
-    int other = iter->base.other;
-    double r = iter->base.r;
-    double r2 = iter->base.r2;
-    double * dist = iter->base.dist;
+    const int other = iter->base.other;
+    const double r = iter->base.r;
+    const double r2 = iter->base.r2;
+    const double * dist = iter->base.dist;
 
     if(All.WindOn && HAS(All.WindModel, WIND_DECOUPLE_SPH)) {
         if(SPHP(other).DelayTime > 0)	/* partner is a wind particle */
@@ -336,11 +336,11 @@ density_ngbiter(
     if(r2 < iter->kernel.HH)
     {
 
-        double u = r * iter->kernel.Hinv;
-        double wk = density_kernel_wk(&iter->kernel, u);
-        double dwk = density_kernel_dwk(&iter->kernel, u);
+        const double u = r * iter->kernel.Hinv;
+        const double wk = density_kernel_wk(&iter->kernel, u);
+        const double dwk = density_kernel_dwk(&iter->kernel, u);
 
-        double mass_j = P[other].Mass;
+        const double mass_j = P[other].Mass;
 
         O->Rho += (mass_j * wk);
         O->Ngb += wk * iter->kernel_volume;

--- a/libgadget/densitykernel.h
+++ b/libgadget/densitykernel.h
@@ -43,7 +43,7 @@ density_kernel_dW(DensityKernel * kernel, double u, double wk, double dwk)
 }
 
 static inline double
-dotproduct(double v1[3], double v2[3])
+dotproduct(const double v1[3], const double v2[3])
 {
     double r =0;
     int d;
@@ -53,18 +53,16 @@ dotproduct(double v1[3], double v2[3])
     return r;
 }
 
-static inline void crossproduct(double v1[3], double v2[3], double out[3])
+static inline void crossproduct(const double v1[3], const double v2[3], double out[3])
 {
-    static int D2[3] = {1, 2, 0};
-    static int D3[3] = {2, 0, 1};
+    static const int D2[3] = {1, 2, 0};
+    static const int D3[3] = {2, 0, 1};
 
-    int d1, d2, d3;
-
+    int d1;
     for(d1 = 0; d1 < 3; d1++)
     {
-        d2 = D2[d1];
-        d3 = D3[d1];
-
+        const int d2 = D2[d1];
+        const int d3 = D3[d1];
         out[d1] = (v1[d2] * v2[d3] -  v2[d2] * v1[d3]);
     }
 }

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -503,10 +503,12 @@ static void ev_secondary(TreeWalk * tw)
             TreeWalkQueryBase * input = (TreeWalkQueryBase*) (tw->dataget + j * tw->query_type_elsize);
             TreeWalkResultBase * output = (TreeWalkResultBase*)(tw->dataresult + j * tw->result_type_elsize);
             treewalk_init_result(tw, output, input);
+#ifdef DEBUG
             if(!tw->UseNodeList) {
-                if(input->NodeList[0] != RootNode) abort(); /* root node */
-                if(input->NodeList[1] != -1) abort(); /* terminate immediately */
+                if(input->NodeList[0] != RootNode || input->NodeList[1] != -1)
+                     endrun(2, "Improper NodeList\n");
             }
+#endif
             lv->target = -1;
             tw->visit(input, output, lv);
         }

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -43,7 +43,7 @@ static struct data_index *DataIndexTable;	/*!< the particles to be exported are 
 					   results to be disentangled again and to be
 					   assigned to the correct particle */
 
-static void ev_init_thread(TreeWalk * tw, LocalTreeWalk * lv);
+static void ev_init_thread(TreeWalk * tw, LocalTreeWalk * lv, const int NTask);
 static void ev_begin(TreeWalk * tw, int * active_set, int size);
 static void ev_finish(TreeWalk * tw);
 static int ev_primary(TreeWalk * tw);
@@ -103,7 +103,7 @@ static int data_index_compare(const void *a, const void *b)
 static TreeWalk * GDB_current_ev = NULL;
 
 static void
-ev_init_thread(TreeWalk * tw, LocalTreeWalk * lv)
+ev_init_thread(TreeWalk * tw, LocalTreeWalk * lv, const int NTask)
 {
     int thread_id = omp_get_thread_num();
     int j;
@@ -228,7 +228,7 @@ static void real_ev(TreeWalk * tw, int * ninter, int * nnodes) {
     int i;
     LocalTreeWalk lv[1];
 
-    ev_init_thread(tw, lv);
+    ev_init_thread(tw, lv, NTask);
     lv->mode = 0;
 
     /* Note: exportflag is local to each thread */
@@ -496,7 +496,7 @@ static void ev_secondary(TreeWalk * tw)
         int j;
         LocalTreeWalk lv[1];
 
-        ev_init_thread(tw, lv);
+        ev_init_thread(tw, lv, NTask);
         lv->mode = 1;
 #pragma omp for
         for(j = 0; j < tw->Nimport; j++) {


### PR DESCRIPTION
Small changes suggested by the vectorization part of intel's compiler. These give a 1% speedup on a small pure-threads problem, which is not large, but not nothing either. They made me tempted to remove the global NTasks and All.NumThreads entirely, replacing them with local const variables, but it was too much effort right now.

Vectorization advisor also made other suggestions which turned out to be not helpful or counter-productive.