### PR TITLE
Fof threading fix

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -15,6 +15,7 @@
 #include <libgadget/checkpoint.h>
 #include <libgadget/config.h>
 #include <libgadget/fof.h>
+#include <libgadget/forcetree.h>
 
 #include <libgadget/utils.h>
 
@@ -111,6 +112,8 @@ int main(int argc, char **argv)
     switch(RestartFlag) {
         case 3:
             begrun(RestartSnapNum);
+            /*FoF needs a tree*/
+            force_tree_rebuild();
             fof_fof();
             fof_save_groups(RestartSnapNum);
             fof_finish();

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -434,26 +434,23 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
     }
     int other = iter->base.other;
 
-/* #pragma omp critical (_fofp_merge_) */
-    {
-        if(lv->mode == 0) {
-            /* Local FOF */
-            if(lv->target <= other) {
-                // printf("locked merge %d %d by %d\n", lv->target, other, omp_get_thread_num());
-                fofp_merge(lv->target, other, tw);
-            }
-        } else /* mode is 1, target is a ghost */
-        {
-//            printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
-            lock_particle(other);
-            if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
-            {
-                HaloLabel[HEAD(other, tw)].MinID = I->MinID;
-                HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
-            }
-//            printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
-            unlock_particle(other);
+    if(lv->mode == 0) {
+        /* Local FOF */
+        if(lv->target <= other) {
+            // printf("locked merge %d %d by %d\n", lv->target, other, omp_get_thread_num());
+            fofp_merge(lv->target, other, tw);
         }
+    } else /* mode is 1, target is a ghost */
+    {
+//        printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
+        lock_particle(other);
+        if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
+        {
+            HaloLabel[HEAD(other, tw)].MinID = I->MinID;
+            HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
+        }
+//        printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
+        unlock_particle(other);
     }
 }
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -591,7 +591,7 @@ void
 treewalk_run(TreeWalk * tw, int * active_set, int size)
 {
     if(!force_tree_allocated()) {
-        endrun(0, "Tree has been freed before this treewalk.");
+        endrun(0, "Tree has been freed before this treewalk.\n");
     }
 
     GDB_current_ev = tw;


### PR DESCRIPTION
This branch fixes a deadlock in the FoF threading code, as well as generating FoF tables by using RestartFlag==3. The deadlock happens because we lock two particles at once, without any requirement on their ordering. The changes lock only one particle at a time. The double-locking ensured that no cycles occurred in the FoF tree: this is now ensured by merging trees always from the higher numbered one into the lower.

I tested that this works, does not deadlock, and gives the same answer as the master branch, but the code is a bit tricky, so you might want to give it a careful look-over.