### PR TITLE
Fofthreadingfix2

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -15,6 +15,7 @@
 #include <libgadget/checkpoint.h>
 #include <libgadget/config.h>
 #include <libgadget/fof.h>
+#include <libgadget/forcetree.h>
 
 #include <libgadget/utils.h>
 
@@ -111,6 +112,8 @@ int main(int argc, char **argv)
     switch(RestartFlag) {
         case 3:
             begrun(RestartSnapNum);
+            /*FoF needs a tree*/
+            force_tree_rebuild();
             fof_fof();
             fof_save_groups(RestartSnapNum);
             fof_finish();

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -298,11 +298,10 @@ update_root(int i, const int r, int * Head)
     int t = i;
     do {
         i = t;
-        #pragma omp atomic capture
-        {
-            t = Head[i];
-            Head[i]= r;
-        }
+        #pragma omp atomic read
+        t = Head[i];
+        #pragma omp atomic write
+        Head[i]= r;
     } while(t != i);
 }
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -231,6 +231,25 @@ struct FOFPrimaryPriv {
 };
 #define FOF_PRIMARY_GET_PRIV(tw) ((struct FOFPrimaryPriv *) (tw->priv))
 
+/* This function walks the particle tree starting at particle i until it reaches
+ * a particle which has Head[i] = i, the root node (particles are initialised in
+ * this state, so this is equivalent to finding a particle which has yet to be merged).
+ * Each particle is locked along the way, and unlocked once it is clear that it is not a root.
+ * Once it reaches a root, it returns that particle number with the lock still held.
+ * There are two other arguments:
+ *
+ * stop: When this particle is reached, return -1. We use this to find an already merged tree.
+ *
+ * locked: This particle is already locked (setting locked = -1 means no other locks are taken).
+ *         When we try to lock a particle locked by another thread, the code checks whether
+ *         it can safely take a second lock. If it cannot, it returns -2, with the expectation
+ *         that the first lock is released before a retry.
+ *
+ * Returns:
+ *      root particle if found
+ *      -1 if stop particle reached
+ *      -2 if locking might have deadlocked.
+ */
 static int
 HEADl(int stop, int i, int locked, int * Head)
 {

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -434,26 +434,23 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
     }
     int other = iter->base.other;
 
-/* #pragma omp critical (_fofp_merge_) */
-    {
-        if(lv->mode == 0) {
-            /* Local FOF */
-            if(lv->target <= other) {
-                // printf("locked merge %d %d by %d\n", lv->target, other, omp_get_thread_num());
-                fofp_merge(lv->target, other, tw);
-            }
-        } else /* mode is 1, target is a ghost */
-        {
-//            printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
-            lock_particle(other);
-            if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
-            {
-                HaloLabel[HEAD(other, tw)].MinID = I->MinID;
-                HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
-            }
-//            printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
-            unlock_particle(other);
+    if(lv->mode == 0) {
+        /* Local FOF */
+        if(lv->target <= other) {
+            // printf("locked merge %d %d by %d\n", lv->target, other, omp_get_thread_num());
+            fofp_merge(lv->target, other, tw);
         }
+    } else /* mode is 1, target is a ghost */
+    {
+//        printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
+        lock_particle(other);
+        if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
+        {
+            HaloLabel[HEAD(other, tw)].MinID = I->MinID;
+            HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
+        }
+//        printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
+        unlock_particle(other);
     }
 }
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -591,7 +591,7 @@ void
 treewalk_run(TreeWalk * tw, int * active_set, int size)
 {
     if(!force_tree_allocated()) {
-        endrun(0, "Tree has been freed before this treewalk.");
+        endrun(0, "Tree has been freed before this treewalk.\n");
     }
 
     GDB_current_ev = tw;


### PR DESCRIPTION
This implements the double compare and swap algorithm suggested in: 

https://github.com/MP-Gadget/MP-Gadget/pull/245#discussion_r250711455

Fixes the deadlock, passes the tests!

I like this algorithm much better - I was also unsure about the corner cases in the last one. I think I found one when testing this, in fact.

One thing I am unsure about is whether we need to take the lock in update_root. I think we do not need to if the write is atomic, because the head is preserved. But then I think we might need an omp atomic write annotation.