### PR TITLE
Do not use huge bunchsizes that causes overflow.

### DIFF
--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -152,7 +152,7 @@ void domain_decompose_full(void)
 
     domain_free();
 
-    message(0, "domain decomposition... (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
+    message(0, "domain decomposition... (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     t0 = second();
 
@@ -330,7 +330,7 @@ domain_attempt_decompose(DomainDecompositionPolicy * policy)
     all_bytes += bytes;
 
     message(0, "use of %g MB of temporary storage for domain decomposition... (presently allocated=%g MB)\n",
-             all_bytes / (1024.0 * 1024.0), AllocatedBytes / (1024.0 * 1024.0));
+             all_bytes / (1024.0 * 1024.0), mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     report_memory_usage("DOMAIN");
 

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -386,7 +386,7 @@ static int
 domain_find_iter_space(ExchangePlan * plan)
 {
     int n, ptype;
-    size_t nlimit = FreeBytes;
+    size_t nlimit = mymalloc_freebytes();
 
     if (nlimit <  4096 * 2 + NTask * 2 * sizeof(MPI_Request))
         endrun(1, "Not enough memory free to store requests!\n");

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -136,7 +136,7 @@ void fof_fof(void)
     MPI_Type_commit(&MPI_TYPE_GROUP);
 
     message(0, "Begin to compute FoF group catalogues. (allocated: %g MB)\n",
-            AllocatedBytes / (1024.0 * 1024.0));
+            mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     walltime_measure("/Misc");
 
@@ -203,7 +203,7 @@ void fof_fof(void)
     walltime_measure("/FOF/Prop");
 
     message(0, "group properties are now allocated.. (presently allocated=%g MB)\n",
-            AllocatedBytes / (1024.0 * 1024.0));
+            mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     message(0, "computation of group properties took = %g sec\n", timediff(t0, t1));
 
@@ -217,7 +217,7 @@ fof_finish()
     myfree(Group);
 
     message(0, "Finished computing FoF groups.  (presently allocated=%g MB)\n",
-            AllocatedBytes / (1024.0 * 1024.0));
+            mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     walltime_measure("/FOF/MISC");
 
@@ -345,7 +345,7 @@ void fof_label_primary(void)
     int64_t link_across_tot;
     double t0, t1;
 
-    message(0, "Start linking particles (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
+    message(0, "Start linking particles (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     TreeWalk tw[1] = {{0}};
     tw->ev_label = "FOF_FIND_GROUPS";
@@ -1118,7 +1118,7 @@ static void fof_label_secondary(void)
     tw->priv = priv;
 
     message(0, "Start finding nearest dm-particle (presently allocated=%g MB)\n",
-            AllocatedBytes / (1024.0 * 1024.0));
+            mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     FOF_SECONDARY_GET_PRIV(tw)->distance = (float *) mymalloc("FOF_SECONDARY->distance", sizeof(float) * PartManager->NumPart);
     FOF_SECONDARY_GET_PRIV(tw)->hsml = (float *) mymalloc("FOF_SECONDARY->hsml", sizeof(float) * PartManager->NumPart);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -98,7 +98,7 @@ force_tree_allocated()
 void
 force_tree_rebuild()
 {
-    message(0, "Tree construction.  (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
+    message(0, "Tree construction.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     if(force_tree_allocated()) {
         force_tree_free();
@@ -1158,7 +1158,7 @@ struct TreeBuilder force_treeallocate(int maxnodes, int maxpart, int first_node_
     allbytes += bytes;
     message(0, "Allocated %g MByte for BH-tree, (presently allocated %g MB)\n",
          allbytes / (1024.0 * 1024.0),
-         AllocatedBytes / (1024.0 * 1024.0));
+         mymalloc_usedbytes() / (1024.0 * 1024.0));
     return tb;
 }
 

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -92,7 +92,7 @@ void grav_short_tree_old(void)
     walltime_measure("/Misc");
 
     /* allocate buffers to arrange communication */
-    message(0, "Begin tree force.  (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
+    message(0, "Begin tree force.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     walltime_measure("/Misc");
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -67,7 +67,7 @@ void grav_short_tree(void)
     walltime_measure("/Misc");
 
     /* allocate buffers to arrange communication */
-    message(0, "Begin tree force.  (presently allocated=%g MB)\n", AllocatedBytes / (1024.0 * 1024.0));
+    message(0, "Begin tree force.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     walltime_measure("/Misc");
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -164,7 +164,12 @@ ev_begin(TreeWalk * tw, int * active_set, const int size)
      * not seen this happen, but provide a parameter to boost the memory for Nimport just in case.*/
     bytesperbuffer += ImportBufferBoost * (tw->query_type_elsize + tw->result_type_elsize);
     /*Use all free bytes for the tree buffer, as in exchange. Leave some free memory for array overhead.*/
-    tw->BunchSize = FreeBytes / bytesperbuffer - 4096 * 10;
+    size_t freebytes = FreeBytes;
+    if(freebytes > 1 * 1024 * 1024 * 1024) freebytes =  1024 * 1024 * 1024;
+    tw->BunchSize = freebytes / bytesperbuffer - 4096 * 10;
+    if(tw->BunchSize <= 0) {
+        endrun(1231245, "Not enough memory for communicator\n");
+    }
     DataIndexTable =
         (struct data_index *) mymalloc("DataIndexTable", tw->BunchSize * sizeof(struct data_index));
     DataNodeList =

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -164,11 +164,14 @@ ev_begin(TreeWalk * tw, int * active_set, const int size)
      * not seen this happen, but provide a parameter to boost the memory for Nimport just in case.*/
     bytesperbuffer += ImportBufferBoost * (tw->query_type_elsize + tw->result_type_elsize);
     /*Use all free bytes for the tree buffer, as in exchange. Leave some free memory for array overhead.*/
-    size_t freebytes = FreeBytes;
-    if(freebytes > 1 * 1024 * 1024 * 1024) freebytes =  1024 * 1024 * 1024;
+    size_t freebytes = mymalloc_freebytes();
+    /* if freebytes is greater than 2GB we run into issues computing BunchSize.
+     * It is probable not a good idea to send too many particles around in one bunch anyways. */
+    if(freebytes > 1024 * 1024 * 1024) freebytes =  1024 * 1024 * 1024;
+
     tw->BunchSize = freebytes / bytesperbuffer - 4096 * 10;
     if(tw->BunchSize <= 0) {
-        endrun(1231245, "Not enough memory for communicator\n");
+        endrun(1231245, "Not enough memory for exporting any particles. \n");
     }
     DataIndexTable =
         (struct data_index *) mymalloc("DataIndexTable", tw->BunchSize * sizeof(struct data_index));

--- a/libgadget/utils/mymalloc.h
+++ b/libgadget/utils/mymalloc.h
@@ -25,7 +25,7 @@ void report_detailed_memory_usage(const char *label, const char * fmt, ...);
 #define  ta_free(p) allocator_free(p)
 
 #define  report_memory_usage(x)    report_detailed_memory_usage(x, "%s:%d", __FILE__, __LINE__)
-#define  FreeBytes                 allocator_get_free_size(A_MAIN)
-#define  AllocatedBytes            allocator_get_used_size(A_MAIN, ALLOC_DIR_BOTH)
+#define  mymalloc_freebytes()       allocator_get_free_size(A_MAIN)
+#define  mymalloc_usedbytes()       allocator_get_used_size(A_MAIN, ALLOC_DIR_BOTH)
 
 #endif


### PR DESCRIPTION
This fixes a crash when I am running with a single rank on a machine
with 16GB of memory.