### PR TITLE
Fix Entropy reload

### DIFF
--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -725,7 +725,7 @@ SIMPLE_PROPERTY(SmoothingLength, P[i].Hsml, float, 1)
 SIMPLE_PROPERTY(Density, SPHP(i).Density, float, 1)
 #ifdef DENSITY_INDEPENDENT_SPH
 SIMPLE_PROPERTY(EgyWtDensity, SPHP(i).EgyWtDensity, float, 1)
-SIMPLE_PROPERTY(Entropy, SPHP(i).Entropy, float, 1)
+SIMPLE_GETTER(GTEntropy, SPHP(i).Entropy, float, 1)
 #endif
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 4, STARP(i).FormationTime, float, 1)
@@ -764,6 +764,10 @@ static void GTNeutralHydrogenFraction(int i, float * out) {
 static void GTInternalEnergy(int i, float * out) {
     *out = DMAX(All.MinEgySpec,
         SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+}
+
+static void STInternalEnergy(int i, float * out) {
+    SPHP(i).Entropy = *out;
 }
 
 static void GTJUV(int i, float * out) {
@@ -807,13 +811,15 @@ static void register_io_blocks() {
     IO_REG(Density,          "f4", 1, 0);
 #ifdef DENSITY_INDEPENDENT_SPH
     IO_REG(EgyWtDensity,          "f4", 1, 0);
-    IO_REG(Entropy,          "f4", 1, 0);
+    IO_REG_WRONLY(Entropy,          "f4", 1, 0);
 #endif
+
+    /*On reload this sets the Entropy variable, and then we transform it later.*/
+    IO_REG(InternalEnergy,   "f4", 1, 0);
 
     /* Cooling */
     IO_REG(ElectronAbundance,       "f4", 1, 0);
     IO_REG_WRONLY(NeutralHydrogenFraction, "f4", 1, 0);
-    IO_REG_WRONLY(InternalEnergy,   "f4", 1, 0);
     IO_REG_WRONLY(JUV,   "f4", 1, 0);
 
     /* SF */

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -243,8 +243,10 @@ void run(void)
 
         /* more steps to go. */
 
-        /* assign new timesteps to the active particles, now that we know they have synched TiKick and TiDrift */
-        find_timesteps(&minTimeBin);
+        /* assign new timesteps to the active particles,
+         * now that we know they have synched TiKick and TiDrift,
+         * and advance the PM timestep.*/
+        minTimeBin = find_timesteps(All.Ti_Current);
 
         /* Update velocity to the new step, with the newly computed step size */
         apply_half_kick();

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -19,7 +19,14 @@ extern TimeSpan PM;
 int rebuild_activelist(inttime_t ti_current, int NumCurrentTiStep);
 void free_activelist(void);
 void set_global_time(double newtime);
-int find_timesteps(int * MinTimeBin);
+
+/* This function assigns new short-range timesteps to particles.
+ * It will also advance the PM timestep and set the new timestep length.
+ * Returns the minimum timestep found.*/
+int find_timesteps(inttime_t Ti_Current);
+
+/* Apply half a kick to the particles: short-range and long-range.
+ * These functions sync drift and kick times.*/
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 


### PR DESCRIPTION
This fixes #251 by correctly initialising Entropy when restarting from a snapshot with DENSITY_INDEPENDENT_SPH off. We load it from the InternalEnergy array both with and without the compile flag to reduce regressions in future.

The SFR after a restart is still not exactly the same as not restarting (differs by about 0.1%) but it's close enough. I don't think we can get bit-exact equivalence because the act of forming stars changes the local density. Tested that it does fix #251 . This is an argument for removing the DENSITY_INDEPENDENT_SPH compile flag in the future.

Also a small refactoring of find_timestep that I did when I thought that was the problem.