### PR TITLE
follow up #254

### DIFF
--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -303,7 +303,7 @@ setup_smoothinglengths(int RestartSnapNum)
         #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++) {
             if(P[i].Type == 0) {
-                SPHP(i).Entropy = u_init;
+                SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EOMDensity/a3 , GAMMA_MINUS1);
             }
         }
     }
@@ -314,7 +314,6 @@ setup_smoothinglengths(int RestartSnapNum)
     for(i = 0; i < PartManager->NumPart; i++) {
         if(P[i].Type == 0) {
             /* Convert from energy read in by the snapshot to entropy.*/
-            SPHP(i).Entropy = GAMMA_MINUS1 * SPHP(i).Entropy / pow(SPHP(i).EOMDensity/a3 , GAMMA_MINUS1);
             SPHP(i).EntVarPred = pow(SPHP(i).Entropy, 1./GAMMA);
         }
     }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -812,10 +812,11 @@ static void register_io_blocks() {
     IO_REG(Density,          "f4", 1, 0);
 #ifdef DENSITY_INDEPENDENT_SPH
     IO_REG(EgyWtDensity,          "f4", 1, 0);
-    IO_REG_WRONLY(Entropy,          "f4", 1, 0);
 #endif
 
-    /*On reload this sets the Entropy variable, and then we transform it later.*/
+    /* On reload this sets the Entropy variable, need the densities.
+     * Register this after Density and EgyWtDensity will ensure density is read
+     * before this. */
     IO_REG(InternalEnergy,   "f4", 1, 0);
 
     /* Cooling */

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -680,6 +680,7 @@ void io_register_io_block(char * name,
         ) {
     IOTableEntry * ent = &IOTable.ent[IOTable.used];
     strcpy(ent->name, name);
+    ent->zorder = IOTable.used;
     ent->ptype = ptype;
     strcpy(ent->dtype, dtype);
     ent->getter = getter;
@@ -786,6 +787,11 @@ static int order_by_type(const void *a, const void *b)
         return -1;
     if(pa->ptype > pb->ptype)
         return +1;
+    if(pa->zorder < pb->zorder)
+        return -1;
+    if(pa->zorder > pb->zorder)
+        return 1;
+
     return 0;
 }
 
@@ -844,7 +850,7 @@ static void register_io_blocks() {
     if(All.SnapshotWithFOF)
         fof_register_io_blocks();
 
-    /*Sort IO blocks so similar types are together*/
+    /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
     qsort_openmp(IOTable.ent, IOTable.used, sizeof(struct IOTableEntry), order_by_type);
 }
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -726,7 +726,6 @@ SIMPLE_PROPERTY(SmoothingLength, P[i].Hsml, float, 1)
 SIMPLE_PROPERTY(Density, SPHP(i).Density, float, 1)
 #ifdef DENSITY_INDEPENDENT_SPH
 SIMPLE_PROPERTY(EgyWtDensity, SPHP(i).EgyWtDensity, float, 1)
-SIMPLE_GETTER(GTEntropy, SPHP(i).Entropy, float, 1)
 #endif
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 4, STARP(i).FormationTime, float, 1)

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -767,7 +767,8 @@ static void GTInternalEnergy(int i, float * out) {
 }
 
 static void STInternalEnergy(int i, float * out) {
-    SPHP(i).Entropy = *out;
+    float u = *out;
+    SPHP(i).Entropy = GAMMA_MINUS1 * u / pow(SPHP(i).EOMDensity * All.cf.a3inv , GAMMA_MINUS1);
 }
 
 static void GTJUV(int i, float * out) {

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -8,6 +8,7 @@ typedef void (*property_setter) (int i, void * target);
 typedef int (*petaio_selection) (int i);
 
 typedef struct IOTableEntry {
+    int zorder;
     char name[64];
     int ptype;
     char dtype[8];


### PR DESCRIPTION
I think this was the source of my difficult with 254.

I'm OK with using InternalEnergy as the primary thermal state variable. 

But why scattering the conversion in both init.c and petaio when we can do the conversion one next to the other?