### PR TITLE
Modular tree

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
         case 3:
             begrun(RestartSnapNum);
             /*FoF needs a tree*/
-            struct OctTree Tree = {0};
+            ForceTree Tree = {0};
             force_tree_rebuild(&Tree);
             fof_fof(&Tree);
             force_tree_free(&Tree);

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -114,8 +114,10 @@ int main(int argc, char **argv)
         case 3:
             begrun(RestartSnapNum);
             /*FoF needs a tree*/
-            force_tree_rebuild();
-            fof_fof();
+            struct OctTree Tree = {0};
+            force_tree_rebuild(&Tree);
+            fof_fof(&Tree);
+            force_tree_free(&Tree);
             fof_save_groups(RestartSnapNum);
             fof_finish();
             break;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -140,7 +140,7 @@ static double blackhole_soundspeed(double entropy, double pressure, double rho) 
     return cs;
 }
 
-void blackhole(struct OctTree * tree)
+void blackhole(ForceTree * tree)
 {
     if(!All.BlackHoleOn) return;
     int i;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -140,7 +140,7 @@ static double blackhole_soundspeed(double entropy, double pressure, double rho) 
     return cs;
 }
 
-void blackhole(void)
+void blackhole(struct OctTree * tree)
 {
     if(!All.BlackHoleOn) return;
     int i;
@@ -160,6 +160,7 @@ void blackhole(void)
     tw_accretion->UseNodeList = 1;
     tw_accretion->query_type_elsize = sizeof(TreeWalkQueryBHAccretion);
     tw_accretion->result_type_elsize = sizeof(TreeWalkResultBHAccretion);
+    tw_accretion->tree = tree;
 
     TreeWalk tw_feedback[1] = {{0}};
     tw_feedback->ev_label = "BH_FEEDBACK";
@@ -174,6 +175,7 @@ void blackhole(void)
     tw_feedback->UseNodeList = 1;
     tw_feedback->query_type_elsize = sizeof(TreeWalkQueryBHFeedback);
     tw_feedback->result_type_elsize = sizeof(TreeWalkResultBHFeedback);
+    tw_feedback->tree = tree;
 
     message(0, "Beginning black-hole accretion\n");
 
@@ -231,7 +233,7 @@ void blackhole(void)
     if(All.Time >= All.TimeNextSeedingCheck)
     {
         /* Seeding */
-        fof_fof();
+        fof_fof(tree);
         fof_seed();
         fof_finish();
         All.TimeNextSeedingCheck *= All.TimeBetweenSeedingSearch;

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -1,7 +1,7 @@
 #ifndef __BLACKHOLE_H
 #define __BLACKHOLE_H
 
-void blackhole(void);
+void blackhole(struct OctTree * tree);
 void blackhole_make_one(int index);
 
 #endif

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -1,7 +1,7 @@
 #ifndef __BLACKHOLE_H
 #define __BLACKHOLE_H
 
-void blackhole(struct OctTree * tree);
+void blackhole(ForceTree * tree);
 void blackhole_make_one(int index);
 
 #endif

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -24,7 +24,7 @@ static void
 write_snapshot(int num);
 
 void
-write_checkpoint(int WriteSnapshot, int WriteFOF)
+write_checkpoint(int WriteSnapshot, int WriteFOF, struct OctTree * tree)
 {
     if(!WriteSnapshot && !WriteFOF) return;
 
@@ -40,7 +40,9 @@ write_checkpoint(int WriteSnapshot, int WriteFOF)
         /* Compute and save FOF*/
         message(0, "computing group catalogue...\n");
 
-        fof_fof();
+        fof_fof(tree);
+        /* Tree is invalid now because of the exchange in FoF.*/
+        force_tree_free(tree);
         fof_save_groups(snapnum);
         fof_finish();
 

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -24,7 +24,7 @@ static void
 write_snapshot(int num);
 
 void
-write_checkpoint(int WriteSnapshot, int WriteFOF, struct OctTree * tree)
+write_checkpoint(int WriteSnapshot, int WriteFOF, ForceTree * tree)
 {
     if(!WriteSnapshot && !WriteFOF) return;
 

--- a/libgadget/checkpoint.h
+++ b/libgadget/checkpoint.h
@@ -1,4 +1,10 @@
-void write_checkpoint(int write_snapshot, int write_fof);
+#ifndef CHECKPOINT_H
+#define CHECKPOINT_H
+
+#include "forcetree.h"
+
+void write_checkpoint(int WriteSnapshot, int WriteFOF, struct OctTree * tree);
 void dump_snapshot(void);
 int find_last_snapnum();
 
+#endif

--- a/libgadget/checkpoint.h
+++ b/libgadget/checkpoint.h
@@ -3,7 +3,7 @@
 
 #include "forcetree.h"
 
-void write_checkpoint(int WriteSnapshot, int WriteFOF, struct OctTree * tree);
+void write_checkpoint(int WriteSnapshot, int WriteFOF, ForceTree * tree);
 void dump_snapshot(void);
 int find_last_snapnum();
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -98,24 +98,24 @@ static void density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw);
  */
 
 static void
-density_internal(int update_hsml, struct OctTree * tree);
+density_internal(int update_hsml, ForceTree * tree);
 
 void
-density(struct OctTree * tree)
+density(ForceTree * tree)
 {
     /* recompute hsml and pre hydro quantities */
     density_internal(1, tree);
 }
 
 void
-density_update(struct OctTree * tree)
+density_update(ForceTree * tree)
 {
     /* recompute pre hydro quantities without computing hsml */
     density_internal(0, tree);
 }
 
 static void
-density_internal(int update_hsml, struct OctTree * tree)
+density_internal(int update_hsml, ForceTree * tree)
 {
     if(!All.DensityOn)
 	return;

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -98,24 +98,24 @@ static void density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw);
  */
 
 static void
-density_internal(int update_hsml);
+density_internal(int update_hsml, struct OctTree * tree);
 
 void
-density(void)
+density(struct OctTree * tree)
 {
     /* recompute hsml and pre hydro quantities */
-    density_internal(1);
+    density_internal(1, tree);
 }
 
 void
-density_update(void)
+density_update(struct OctTree * tree)
 {
     /* recompute pre hydro quantities without computing hsml */
-    density_internal(0);
+    density_internal(0, tree);
 }
 
 static void
-density_internal(int update_hsml)
+density_internal(int update_hsml, struct OctTree * tree)
 {
     if(!All.DensityOn)
 	return;
@@ -135,6 +135,7 @@ density_internal(int update_hsml)
     tw->query_type_elsize = sizeof(TreeWalkQueryDensity);
     tw->result_type_elsize = sizeof(TreeWalkResultDensity);
     tw->priv = priv;
+    tw->tree = tree;
 
     int i;
     int64_t ntot = 0;

--- a/libgadget/density.h
+++ b/libgadget/density.h
@@ -1,2 +1,10 @@
-void density(void);
-void density_update(void);
+#ifndef DENSITY_H
+#define DENSITY_H
+
+#include "forcetree.h"
+
+void density(struct OctTree * tree);
+
+void density_update(struct OctTree * tree);
+
+#endif

--- a/libgadget/density.h
+++ b/libgadget/density.h
@@ -3,8 +3,8 @@
 
 #include "forcetree.h"
 
-void density(struct OctTree * tree);
+void density(ForceTree * tree);
 
-void density_update(struct OctTree * tree);
+void density_update(ForceTree * tree);
 
 #endif

--- a/libgadget/domain.h
+++ b/libgadget/domain.h
@@ -25,8 +25,6 @@ extern struct task_data {
     int EndLeaf;
 } * Tasks;
 
-extern int MaxTopNodes;	        /*!< Maximum number of nodes in the top-level tree used for domain decomposition */
-
 extern int NTopNodes, NTopLeaves;
 
 void domain_decompose_full(void);

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -61,7 +61,7 @@ static double fof_periodic_wrap(double x)
     return x;
 }
 
-static void fof_label_secondary(struct OctTree * tree);
+static void fof_label_secondary(ForceTree * tree);
 static int fof_compare_HaloLabel_MinID(const void *a, const void *b);
 static int fof_compare_Group_MinIDTask(const void *a, const void *b);
 static int fof_compare_Group_OriginalIndex(const void *a, const void *b);
@@ -83,7 +83,7 @@ fof_alloc_group(const struct BaseGroup * base, const int NgroupsExt);
 
 static void fof_assign_grnr(struct BaseGroup * base);
 
-void fof_label_primary(struct OctTree * tree);
+void fof_label_primary(ForceTree * tree);
 extern void fof_save_particles(int num);
 
 /* Ngroups and NgroupsExt are both maximally NumPart,
@@ -127,7 +127,7 @@ static MPI_Datatype MPI_TYPE_GROUP;
  *
  **/
 
-void fof_fof(struct OctTree * tree)
+void fof_fof(ForceTree * tree)
 {
     int i;
     double t0, t1;
@@ -337,7 +337,7 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
         TreeWalkNgbIterFOF * iter,
         LocalTreeWalk * lv);
 
-void fof_label_primary(struct OctTree * tree)
+void fof_label_primary(ForceTree * tree)
 {
     int i;
     int64_t link_across;
@@ -1093,7 +1093,7 @@ fof_secondary_postprocess(int p, TreeWalk * tw)
         }
     }
 }
-static void fof_label_secondary(struct OctTree * tree)
+static void fof_label_secondary(ForceTree * tree)
 {
     int n, iter;
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -1025,7 +1025,7 @@ fof_save_groups(int num)
     double t0, t1;
 
     /* no longer need the tree */
-    force_tree_free();
+    force_tree_free(&TreeNodes);
 
     message(0, "start global sorting of group catalogues\n");
 

--- a/libgadget/fof.h
+++ b/libgadget/fof.h
@@ -7,7 +7,7 @@
 void fof_init(void);
 
 /*Computes the Group structure, saved as a global array below*/
-void fof_fof(struct OctTree * tree);
+void fof_fof(ForceTree * tree);
 
 /*Frees the Group structure*/
 void

--- a/libgadget/fof.h
+++ b/libgadget/fof.h
@@ -2,11 +2,12 @@
 #define FOF_H
 
 #include "allvars.h"
+#include "forcetree.h"
 
 void fof_init(void);
 
 /*Computes the Group structure, saved as a global array below*/
-void fof_fof(void);
+void fof_fof(struct OctTree * tree);
 
 /*Frees the Group structure*/
 void

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1038,14 +1038,11 @@ void force_update_hmax(int * activeset, int size)
     /* At most NTopLeaves are dirty, since we are only concerned with TOPLEVEL nodes */
     DirtyTopLevelNodes = (struct dirty_node_data*) mymalloc("DirtyTopLevelNodes", NTopLeaves * sizeof(DirtyTopLevelNodes[0]));
 
-    /* FIXME: This can be made a struct flag*/
-    char * NodeIsDirty = (char *) mymalloc("NodeIsDirty", MaxNodes * sizeof(char));
-
     /* FIXME: actually only TOPLEVEL nodes contains the local mass can potentially be dirty,
      *  we may want to save a list of them to speed this up.
      * */
-    for(i = 0; i < MaxNodes; i ++) {
-        NodeIsDirty[i] = 0;
+    for(i = RootNode; i < RootNode + NumNodes; i ++) {
+        Nodes[i].f.NodeIsDirty = 0;
     }
 
     for(i = 0; i < size; i++)
@@ -1065,8 +1062,8 @@ void force_update_hmax(int * activeset, int size)
 
             if(Nodes[no].f.TopLevel) /* we reached a top-level node */
             {
-                if (!NodeIsDirty[no - RootNode]) {
-                    NodeIsDirty[no - RootNode] = 1;
+                if (!Nodes[no].f.NodeIsDirty) {
+                    Nodes[no].f.NodeIsDirty = 1;
                     DirtyTopLevelNodes[NumDirtyTopLevelNodes].treenode = no;
                     DirtyTopLevelNodes[NumDirtyTopLevelNodes].hmax = Nodes[no].u.d.hmax;
                     NumDirtyTopLevelNodes ++;
@@ -1125,7 +1122,6 @@ void force_update_hmax(int * activeset, int size)
 
     myfree(offsets);
     myfree(counts);
-    myfree(NodeIsDirty);
     myfree(DirtyTopLevelNodes);
 
     walltime_measure("/Tree/HmaxUpdate");

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -49,20 +49,20 @@ static int tree_allocated_flag = 0;
 static int force_tree_build(int npart);
 
 static int
-force_tree_build_single(const struct TreeBuilder tb, const int npart);
+force_tree_build_single(const struct OctTree tb, const int npart);
 
 /*Next three are not static as tested.*/
 int
-force_tree_create_nodes(const struct TreeBuilder tb, const int npart);
+force_tree_create_nodes(const struct OctTree tb, const int npart);
 
-struct TreeBuilder
+struct OctTree
 force_treeallocate(int maxnodes, int maxpart, int first_node_offset);
 
 int
-force_update_node_parallel(const struct TreeBuilder tb);
+force_update_node_parallel(const struct OctTree tb);
 
 static void
-force_treeupdate_pseudos(int no, const struct TreeBuilder tb);
+force_treeupdate_pseudos(int no, const struct OctTree tb);
 
 static void
 force_create_node_for_topnode(int no, int topnode, int bits, int x, int y, int z, int *nextfree, const int lastnode);
@@ -71,7 +71,7 @@ static void
 force_exchange_pseudodata(void);
 
 static void
-force_insert_pseudo_particles(const struct TreeBuilder tb);
+force_insert_pseudo_particles(const struct OctTree tb);
 
 static int
 force_tree_eh_slots_fork(EIBase * event, void * userdata)
@@ -121,7 +121,7 @@ int force_tree_build(int npart)
     int Numnodestree;
     int flag;
     int maxnodes;
-    struct TreeBuilder tb;
+    struct OctTree tb;
 
     do
     {
@@ -240,7 +240,7 @@ int get_freenode(int * nnext, struct NodeCache *nc)
  * Parent is assumed to be locked.*/
 int
 modify_internal_node(int parent, int subnode, int p_child, int p_toplace,
-        const struct TreeBuilder tb, int *nnext, struct NodeCache *nc, double minlen, int *closepairs)
+        const struct OctTree tb, int *nnext, struct NodeCache *nc, double minlen, int *closepairs)
 {
     int ret = 0;
     int ninsert;
@@ -329,7 +329,7 @@ modify_internal_node(int parent, int subnode, int p_child, int p_toplace,
 
 /*! Does initial creation of the nodes for the gravitational oct-tree.
  **/
-int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
+int force_tree_create_nodes(const struct OctTree tb, const int npart)
 {
     int i;
     int nnext = tb.firstnode;		/* index of first free node */
@@ -477,7 +477,7 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
  *  different CPUs. If such a node needs to be opened, the corresponding
  *  particle must be exported to that CPU. */
 static int
-force_tree_build_single(const struct TreeBuilder tb, const int npart)
+force_tree_build_single(const struct OctTree tb, const int npart)
 {
     int nnext = force_tree_create_nodes(tb, npart);
     if(nnext >= tb.lastnode - tb.firstnode)
@@ -561,7 +561,7 @@ void force_create_node_for_topnode(int no, int topnode, int bits, int x, int y, 
  *  updated later on.
  */
 static void
-force_insert_pseudo_particles(const struct TreeBuilder tb)
+force_insert_pseudo_particles(const struct OctTree tb)
 {
     int i, index;
     const int firstpseudo = tb.lastnode;
@@ -578,7 +578,7 @@ force_insert_pseudo_particles(const struct TreeBuilder tb)
 }
 
 int
-force_get_next_node(int no, const struct TreeBuilder tb)
+force_get_next_node(int no, const struct OctTree tb)
 {
     if(no >= tb.firstnode && no < tb.lastnode) {
         /* internal node */
@@ -595,7 +595,7 @@ force_get_next_node(int no, const struct TreeBuilder tb)
 }
 
 int
-force_set_next_node(int no, int next, const struct TreeBuilder tb)
+force_set_next_node(int no, int next, const struct OctTree tb)
 {
     if(no < 0) return next;
     if(no >= tb.firstnode && no < tb.lastnode) {
@@ -615,7 +615,7 @@ force_set_next_node(int no, int next, const struct TreeBuilder tb)
 }
 
 int
-force_get_prev_node(int no, const struct TreeBuilder tb)
+force_get_prev_node(int no, const struct OctTree tb)
 {
     if(node_is_particle(no)) {
         /* Particle */
@@ -703,7 +703,7 @@ force_get_sibling(const int sib, const int j, const int * suns)
  *
  */
 static int
-force_update_node_recursive(int no, int sib, int level, const struct TreeBuilder tb)
+force_update_node_recursive(int no, int sib, int level, const struct OctTree tb)
 {
     /*Last value of tails is the return value of this function*/
     int j, suns[8], tails[8];
@@ -850,7 +850,7 @@ force_update_node_recursive(int no, int sib, int level, const struct TreeBuilder
  * searches the list of pre-computed tail values to set the next node as if it had recursed and continues.
  */
 int
-force_update_node_parallel(const struct TreeBuilder tb)
+force_update_node_parallel(const struct OctTree tb)
 {
     int tail;
 #pragma omp parallel
@@ -952,7 +952,7 @@ void force_exchange_pseudodata(void)
 /*! This function updates the top-level tree after the multipole moments of
  *  the pseudo-particles have been updated.
  */
-void force_treeupdate_pseudos(int no, const struct TreeBuilder tb)
+void force_treeupdate_pseudos(int no, const struct OctTree tb)
 {
     int j, p;
     MyFloat hmax;
@@ -1132,11 +1132,11 @@ void force_update_hmax(int * activeset, int size)
  *  maxnodes approximately equal to 0.7*maxpart is sufficient to store the
  *  tree for up to maxpart particles.
  */
-struct TreeBuilder force_treeallocate(int maxnodes, int maxpart, int first_node_offset)
+struct OctTree force_treeallocate(int maxnodes, int maxpart, int first_node_offset)
 {
     size_t bytes;
     size_t allbytes = 0;
-    struct TreeBuilder tb;
+    struct OctTree tb;
 
     tree_allocated_flag = 1;
     MaxNodes = maxnodes;

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -35,6 +35,7 @@
 struct NODE *Nodes_base,	/*!< points to the actual memory allocated for the nodes */
  *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[RootNode]
 				   gives the first allocated node */
+struct OctTree TreeNodes;
 
 int MaxNodes;                  /*!< maximum allowed number of internal nodes */
 int NumNodes;                  /*!< Currently used number of internal nodes */
@@ -158,6 +159,12 @@ int force_tree_build(int npart)
     force_treeupdate_pseudos(PartManager->MaxPart, tb);
 
     myrealloc(Nodes_base, (Numnodestree +1) * sizeof(struct NODE));
+
+    /*Update the oct-tree struct so it knows about the memory change*/
+    tb.numnodes = Numnodestree;
+
+    /*Update global oct-tree struct*/
+    TreeNodes = tb;
 
     event_listen(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
     return Numnodestree;
@@ -1146,10 +1153,12 @@ struct OctTree force_treeallocate(int maxnodes, int maxpart, int first_node_offs
     Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));
     allbytes += bytes;
     Nodes_base = (struct NODE *) mymalloc("Nodes_base", bytes = (MaxNodes + 1) * sizeof(struct NODE));
+    tb.Nodes_base = Nodes_base;
     allbytes += bytes;
     Nodes = Nodes_base - first_node_offset;
     tb.firstnode = first_node_offset;
     tb.lastnode = first_node_offset + maxnodes;
+    tb.numnodes = MaxNodes;
     tb.Nodes = Nodes_base - first_node_offset;
     allbytes += bytes;
     message(0, "Allocated %g MByte for BH-tree, (presently allocated %g MB)\n",

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -39,15 +39,13 @@ struct NODE *Nodes_base,	/*!< points to the actual memory allocated for the node
 struct OctTree TreeNodes;
 
 int MaxNodes;                  /*!< maximum allowed number of internal nodes */
-int NumNodes;                  /*!< Currently used number of internal nodes */
-
 
 int *Nextnode;			/*!< gives next node in tree walk  (nodes array) */
 int *Father;			/*!< gives parent node in tree (nodes array) */
 
 static int tree_allocated_flag = 0;
 
-static int force_tree_build(int npart);
+static struct OctTree force_tree_build(int npart);
 
 static int
 force_tree_build_single(const struct OctTree tb, const int npart);
@@ -106,7 +104,7 @@ force_tree_rebuild()
     }
     walltime_measure("/Misc");
 
-    NumNodes = force_tree_build(PartManager->NumPart);
+    TreeNodes = force_tree_build(PartManager->NumPart);
 
     walltime_measure("/Tree/Build");
 
@@ -117,7 +115,7 @@ force_tree_rebuild()
 /*! This function is a driver routine for constructing the gravitational
  *  oct-tree, which is done by calling a small number of other functions.
  */
-int force_tree_build(int npart)
+struct OctTree force_tree_build(int npart)
 {
     int Numnodestree;
     int flag;
@@ -163,11 +161,8 @@ int force_tree_build(int npart)
     /*Update the oct-tree struct so it knows about the memory change*/
     tb.numnodes = Numnodestree;
 
-    /*Update global oct-tree struct*/
-    TreeNodes = tb;
-
     event_listen(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
-    return Numnodestree;
+    return tb;
 }
 
 /* Get the subnode for a given particle and parent node.

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -28,18 +28,18 @@
  */
 
 /*The node index is an integer with unusual properties:
- * no = 0..RootNode (firstnode in internal functions) corresponds to a particle.
- * no = RootNode..RootNode + MaxNodes (firstnode..lastnode) corresponds to actual tree nodes,
- * and is the only memory allocated in Nodes_base.
- * no > RootNode + MaxNodes (lastnode) means a pseudo particle on another processor*/
+ * no = 0..OctTree.firstnode  corresponds to a particle.
+ * no = OctTree.firstnode..OctTree.lastnode corresponds to actual tree nodes,
+ * and is the only memory allocated in Nodes_base. After the tree is built this becomes
+ * no = OctTree.firstnode..OctTree.numnodes which is the only allocated memory.
+ * no > OctTree.lastnode means a pseudo particle on another processor*/
 struct NODE *Nodes_base,	/*!< points to the actual memory allocated for the nodes */
- *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[RootNode]
+ *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
 				   gives the first allocated node */
 struct OctTree TreeNodes;
 
 int MaxNodes;                  /*!< maximum allowed number of internal nodes */
 int NumNodes;                  /*!< Currently used number of internal nodes */
-int RootNode;                  /*!< Index of the first node */
 
 
 int *Nextnode;			/*!< gives next node in tree walk  (nodes array) */
@@ -1147,7 +1147,6 @@ struct OctTree force_treeallocate(int maxnodes, int maxpart, int first_node_offs
 
     tree_allocated_flag = 1;
     MaxNodes = maxnodes;
-    RootNode = first_node_offset;
     message(0, "Allocating memory for %d tree-nodes (MaxPart=%d).\n", maxnodes, maxpart);
     Nextnode = (int *) mymalloc("Nextnode", bytes = (maxpart + NTopNodes) * sizeof(int));
     Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -27,14 +27,6 @@
  *  reconstruct the tree every timestep.
  */
 
-/*The node index is an integer with unusual properties:
- * no = 0..OctTree.firstnode  corresponds to a particle.
- * no = OctTree.firstnode..OctTree.lastnode corresponds to actual tree nodes,
- * and is the only memory allocated in OctTree.Nodes_base. After the tree is built this becomes
- * no = OctTree.firstnode..OctTree.numnodes which is the only allocated memory.
- * no > OctTree.lastnode means a pseudo particle on another processor*/
-struct OctTree TreeNodes;
-
 static struct OctTree
 force_tree_build(int npart);
 
@@ -87,18 +79,18 @@ force_tree_allocated(const struct OctTree * tt)
 }
 
 void
-force_tree_rebuild(void)
+force_tree_rebuild(struct OctTree * tree)
 {
     message(0, "Tree construction.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
-    if(force_tree_allocated(&TreeNodes)) {
-        force_tree_free(&TreeNodes);
+    if(force_tree_allocated(tree)) {
+        force_tree_free(tree);
     }
     walltime_measure("/Misc");
 
-    TreeNodes = force_tree_build(PartManager->NumPart);
+    *tree = force_tree_build(PartManager->NumPart);
 
-    event_listen(&EventSlotsFork, force_tree_eh_slots_fork, &TreeNodes);
+    event_listen(&EventSlotsFork, force_tree_eh_slots_fork, tree);
 
     walltime_measure("/Tree/Build");
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1027,7 +1027,7 @@ void force_treeupdate_pseudos(int no, const struct OctTree tb)
  *  out just before the hydrodynamical SPH forces are computed, i.e. after
  *  density().
  */
-void force_update_hmax(int * activeset, int size)
+void force_update_hmax(int * activeset, int size, struct OctTree * tt)
 {
     int i, ta;
     int *counts, *offsets;
@@ -1048,8 +1048,8 @@ void force_update_hmax(int * activeset, int size)
     /* FIXME: actually only TOPLEVEL nodes contains the local mass can potentially be dirty,
      *  we may want to save a list of them to speed this up.
      * */
-    for(i = RootNode; i < RootNode + NumNodes; i ++) {
-        Nodes[i].f.NodeIsDirty = 0;
+    for(i = tt->firstnode; i < tt->firstnode + tt->numnodes; i ++) {
+        tt->Nodes[i].f.NodeIsDirty = 0;
     }
 
     for(i = 0; i < size; i++)
@@ -1063,22 +1063,22 @@ void force_update_hmax(int * activeset, int size)
 
         while(no >= 0)
         {
-            if(P[p_i].Hsml <= Nodes[no].u.d.hmax) break;
+            if(P[p_i].Hsml <= tt->Nodes[no].u.d.hmax) break;
 
-            Nodes[no].u.d.hmax = P[p_i].Hsml;
+            tt->Nodes[no].u.d.hmax = P[p_i].Hsml;
 
-            if(Nodes[no].f.TopLevel) /* we reached a top-level node */
+            if(tt->Nodes[no].f.TopLevel) /* we reached a top-level node */
             {
-                if (!Nodes[no].f.NodeIsDirty) {
-                    Nodes[no].f.NodeIsDirty = 1;
+                if (!tt->Nodes[no].f.NodeIsDirty) {
+                    tt->Nodes[no].f.NodeIsDirty = 1;
                     DirtyTopLevelNodes[NumDirtyTopLevelNodes].treenode = no;
-                    DirtyTopLevelNodes[NumDirtyTopLevelNodes].hmax = Nodes[no].u.d.hmax;
+                    DirtyTopLevelNodes[NumDirtyTopLevelNodes].hmax = tt->Nodes[no].u.d.hmax;
                     NumDirtyTopLevelNodes ++;
                 }
                 break;
             }
 
-            no = Nodes[no].father;
+            no = tt->Nodes[no].father;
         }
     }
 
@@ -1114,16 +1114,16 @@ void force_update_hmax(int * activeset, int size)
 
         /* FIXME: why does this matter? The logic is simpler if we just blindly update them all.
             ::: to avoid that the hmax is updated twice :::*/
-        if(Nodes[no].f.DependsOnLocalMass)
-            no = Nodes[no].father;
+        if(tt->Nodes[no].f.DependsOnLocalMass)
+            no = tt->Nodes[no].father;
 
         while(no >= 0)
         {
-            if(DirtyTopLevelNodes[i].hmax <= Nodes[no].u.d.hmax) break;
+            if(DirtyTopLevelNodes[i].hmax <= tt->Nodes[no].u.d.hmax) break;
 
-            Nodes[no].u.d.hmax = DirtyTopLevelNodes[i].hmax;
+            tt->Nodes[no].u.d.hmax = DirtyTopLevelNodes[i].hmax;
 
-            no = Nodes[no].father;
+            no = tt->Nodes[no].father;
         }
     }
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -84,7 +84,7 @@ force_tree_eh_slots_fork(EIBase * event, void * userdata)
 }
 
 int
-force_tree_allocated(struct OctTree * tt)
+force_tree_allocated(const struct OctTree * tt)
 {
     return tt->tree_allocated_flag;
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -624,7 +624,7 @@ force_set_next_node(int no, int next, const struct OctTree tb)
 int
 force_get_prev_node(int no, const struct OctTree tb)
 {
-    if(node_is_particle(no)) {
+    if(node_is_particle(no, tb)) {
         /* Particle */
         int t = Father[no];
         int next = force_get_next_node(t, tb);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -35,9 +35,6 @@
  * no > OctTree.lastnode means a pseudo particle on another processor*/
 struct OctTree TreeNodes;
 
-/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode] gives the first allocated node */
-struct NODE * Nodes;
-
 static struct OctTree
 force_tree_build(int npart);
 
@@ -157,7 +154,6 @@ struct OctTree force_tree_build(int npart)
     /*Update the oct-tree struct so it knows about the memory change*/
     tb.numnodes = Numnodestree;
     tb.Nodes = tb.Nodes_base - tb.firstnode;
-    Nodes = tb.Nodes;
 
     return tb;
 }

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -44,15 +44,19 @@ extern struct NODE
                       gives the first allocated node */
 
 /*Structure containing the Node pointer, and the first and last entries*/
-struct OctTree {
+extern struct OctTree {
     /*Index of first internal node*/
     int firstnode;
     /*Index of first pseudo-particle node*/
     int lastnode;
+    /* Number of actually allocated nodes*/
+    int numnodes;
     /*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
      *   gives the first allocated node */
-    struct NODE *Nodes; 
-};
+    struct NODE *Nodes;
+    /*This points to the actual memory allocated for the nodes*/
+    struct NODE * Nodes_base;
+} TreeNodes;
 
 extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
 extern int NumNodes;      /*!< Currently used number of internal nodes*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -80,21 +80,21 @@ void   force_tree_free(struct OctTree * tt);
 void   dump_particles(void);
 
 static inline int
-node_is_pseudo_particle(int no, const struct OctTree * tt)
+node_is_pseudo_particle(int no, const struct OctTree * tree)
 {
-    return no >= tt->lastnode;
+    return no >= tree->lastnode;
 }
 
 static inline int
-node_is_particle(int no, const struct OctTree * tt)
+node_is_particle(int no, const struct OctTree * tree)
 {
-    return no < tt->firstnode;
+    return no < tree->firstnode;
 }
 
 static inline int
-node_is_node(int no, const struct OctTree * tt)
+node_is_node(int no, const struct OctTree * tree)
 {
-    return (no >= tt->firstnode) && (no < tt->lastnode);
+    return (no >= tree->firstnode) && (no < tree->lastnode);
 }
 
 int

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -39,8 +39,7 @@ extern struct NODE
     }
     u;
 }
-*Nodes_base,			/*!< points to the actual memory allocated for the nodes */
-    *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
+*Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
                       gives the first allocated node */
 
 /*Structure containing the Node pointer, and the first and last entries*/
@@ -68,7 +67,8 @@ int force_tree_allocated();
 void force_update_hmax(int * activeset, int size, struct OctTree * tt);
 void force_tree_rebuild();
 
-void   force_tree_free(void);
+/*Free the memory associated with the tree*/
+void   force_tree_free(struct OctTree * tt);
 void   dump_particles(void);
 
 static inline int

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -45,7 +45,7 @@ extern struct NODE
 
 /*Structure containing the Node pointer, and the first and last entries*/
 extern struct OctTree {
-    /*Index of first internal node*/
+    /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
     int firstnode;
     /*Index of first pseudo-particle node*/
     int lastnode;
@@ -60,7 +60,6 @@ extern struct OctTree {
 
 extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
 extern int NumNodes;      /*!< Currently used number of internal nodes*/
-extern int RootNode;      /*!< Index of the first node. Difference between Nodes and Nodes_base. == MaxPart*/
 
 /*Used in domain.c*/
 extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -40,7 +40,7 @@ extern struct NODE
     u;
 }
 *Nodes_base,			/*!< points to the actual memory allocated for the nodes */
-    *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[RootNode]
+    *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
                       gives the first allocated node */
 
 /*Structure containing the Node pointer, and the first and last entries*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -44,7 +44,7 @@ extern struct NODE
                       gives the first allocated node */
 
 /*Structure containing the Node pointer, and the first and last entries*/
-struct TreeBuilder {
+struct OctTree {
     /*Index of first internal node*/
     int firstnode;
     /*Index of first pseudo-particle node*/
@@ -89,13 +89,13 @@ node_is_node(int no)
 }
 
 int
-force_get_prev_node(int no, const struct TreeBuilder tb);
+force_get_prev_node(int no, const struct OctTree tb);
 
 int
-force_get_next_node(int no, const struct TreeBuilder tb);
+force_get_next_node(int no, const struct OctTree tb);
 
 int
-force_set_next_node(int no, int next, const struct TreeBuilder tb);
+force_set_next_node(int no, int next, const struct OctTree tb);
 
 #endif
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -7,8 +7,7 @@
  * ------------------
  */
 
-/*Used in treewalk.c*/
-extern struct NODE
+struct NODE
 {
     MyFloat len;			/*!< sidelength of treenode */
     MyFloat center[3];		/*!< geometrical center of node */
@@ -38,9 +37,7 @@ extern struct NODE
         d;
     }
     u;
-}
-*Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
-                      gives the first allocated node */
+};
 
 /*Structure containing the Node pointer, and the first and last entries*/
 extern struct OctTree {

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -44,6 +44,8 @@ extern struct NODE
 
 /*Structure containing the Node pointer, and the first and last entries*/
 extern struct OctTree {
+    /*Is 1 if the tree is allocated*/
+    int tree_allocated_flag;
     /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
     int firstnode;
     /*Index of first pseudo-particle node*/
@@ -61,7 +63,7 @@ extern struct OctTree {
 extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */
 extern int *Father;		/*!< gives parent node in tree (Prenodes array) */
 
-int force_tree_allocated();
+int force_tree_allocated(struct OctTree * tt);
 
 /* This function propagates changed SPH smoothing lengths up the tree*/
 void force_update_hmax(int * activeset, int size, struct OctTree * tt);

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -41,12 +41,12 @@ struct NODE
 
 /*Structure containing the Node pointer, and various Tree metadata.*/
 /*The node index is an integer with unusual properties:
- * no = 0..OctTree.firstnode  corresponds to a particle.
- * no = OctTree.firstnode..OctTree.lastnode corresponds to actual tree nodes,
- * and is the only memory allocated in OctTree.Nodes_base. After the tree is built this becomes
- * no = OctTree.firstnode..OctTree.numnodes which is the only allocated memory.
- * no > OctTree.lastnode means a pseudo particle on another processor*/
-struct OctTree {
+ * no = 0..ForceTree.firstnode  corresponds to a particle.
+ * no = ForceTree.firstnode..ForceTree.lastnode corresponds to actual tree nodes,
+ * and is the only memory allocated in ForceTree.Nodes_base. After the tree is built this becomes
+ * no = ForceTree.firstnode..ForceTree.numnodes which is the only allocated memory.
+ * no > ForceTree.lastnode means a pseudo particle on another processor*/
+typedef struct ForceTree {
     /*Is 1 if the tree is allocated*/
     int tree_allocated_flag;
     /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
@@ -65,49 +65,49 @@ struct OctTree {
     int * Nextnode;
     /*!< gives parent node in tree for every particle */
     int *Father;
-};
+} ForceTree;
 
-int force_tree_allocated(const struct OctTree * tt);
+int force_tree_allocated(const ForceTree * tt);
 
 /* This function propagates changed SPH smoothing lengths up the tree*/
-void force_update_hmax(int * activeset, int size, struct OctTree * tt);
+void force_update_hmax(int * activeset, int size, ForceTree * tt);
 
 /*This is the main constructor for the tree structure. Pass in something empty.*/
-void force_tree_rebuild(struct OctTree * tree);
+void force_tree_rebuild(ForceTree * tree);
 
 /*Free the memory associated with the tree*/
-void   force_tree_free(struct OctTree * tt);
+void   force_tree_free(ForceTree * tt);
 void   dump_particles(void);
 
 static inline int
-node_is_pseudo_particle(int no, const struct OctTree * tree)
+node_is_pseudo_particle(int no, const ForceTree * tree)
 {
     return no >= tree->lastnode;
 }
 
 static inline int
-node_is_particle(int no, const struct OctTree * tree)
+node_is_particle(int no, const ForceTree * tree)
 {
     return no < tree->firstnode;
 }
 
 static inline int
-node_is_node(int no, const struct OctTree * tree)
+node_is_node(int no, const ForceTree * tree)
 {
     return (no >= tree->firstnode) && (no < tree->lastnode);
 }
 
 int
-force_get_prev_node(int no, const struct OctTree * tb);
+force_get_prev_node(int no, const ForceTree * tb);
 
 int
-force_get_next_node(int no, const struct OctTree * tb);
+force_get_next_node(int no, const ForceTree * tb);
 
 int
-force_set_next_node(int no, int next, const struct OctTree * tb);
+force_set_next_node(int no, int next, const ForceTree * tb);
 
 int
-force_get_father(int no, const struct OctTree * tt);
+force_get_father(int no, const ForceTree * tt);
 
 #endif
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -75,21 +75,21 @@ void   force_tree_free(void);
 void   dump_particles(void);
 
 static inline int
-node_is_pseudo_particle(int no)
+node_is_pseudo_particle(int no, const struct OctTree tt)
 {
-    return no >= RootNode + MaxNodes;
+    return no >= tt.lastnode;
 }
 
 static inline int
-node_is_particle(int no)
+node_is_particle(int no, const struct OctTree tt)
 {
-    return no < RootNode;
+    return no < tt.firstnode;
 }
 
 static inline int
-node_is_node(int no)
+node_is_node(int no, const struct OctTree tt)
 {
-    return (no >= RootNode) && (no < RootNode + MaxNodes);
+    return (no >= tt.firstnode) && (no < tt.lastnode);
 }
 
 int

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -57,11 +57,12 @@ extern struct OctTree {
     struct NODE *Nodes;
     /*This points to the actual memory allocated for the nodes*/
     struct NODE * Nodes_base;
+    /* Gives next node in the tree walk for particles and pseudo particles.
+     * next node for the actual nodes is stored in Nodes*/
+    int * Nextnode;
+    /*!< gives parent node in tree for every particle */
+    int *Father;
 } TreeNodes;
-
-/*Used in domain.c*/
-extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */
-extern int *Father;		/*!< gives parent node in tree (Prenodes array) */
 
 int force_tree_allocated(struct OctTree * tt);
 
@@ -99,6 +100,9 @@ force_get_next_node(int no, const struct OctTree tb);
 
 int
 force_set_next_node(int no, int next, const struct OctTree tb);
+
+int
+force_get_father(int no, const struct OctTree tt);
 
 #endif
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -39,8 +39,14 @@ struct NODE
     u;
 };
 
-/*Structure containing the Node pointer, and the first and last entries*/
-extern struct OctTree {
+/*Structure containing the Node pointer, and various Tree metadata.*/
+/*The node index is an integer with unusual properties:
+ * no = 0..OctTree.firstnode  corresponds to a particle.
+ * no = OctTree.firstnode..OctTree.lastnode corresponds to actual tree nodes,
+ * and is the only memory allocated in OctTree.Nodes_base. After the tree is built this becomes
+ * no = OctTree.firstnode..OctTree.numnodes which is the only allocated memory.
+ * no > OctTree.lastnode means a pseudo particle on another processor*/
+struct OctTree {
     /*Is 1 if the tree is allocated*/
     int tree_allocated_flag;
     /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
@@ -59,13 +65,15 @@ extern struct OctTree {
     int * Nextnode;
     /*!< gives parent node in tree for every particle */
     int *Father;
-} TreeNodes;
+};
 
 int force_tree_allocated(const struct OctTree * tt);
 
 /* This function propagates changed SPH smoothing lengths up the tree*/
 void force_update_hmax(int * activeset, int size, struct OctTree * tt);
-void force_tree_rebuild();
+
+/*This is the main constructor for the tree structure. Pass in something empty.*/
+void force_tree_rebuild(struct OctTree * tree);
 
 /*Free the memory associated with the tree*/
 void   force_tree_free(struct OctTree * tt);

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -75,34 +75,34 @@ void   force_tree_free(struct OctTree * tt);
 void   dump_particles(void);
 
 static inline int
-node_is_pseudo_particle(int no, const struct OctTree tt)
+node_is_pseudo_particle(int no, const struct OctTree * tt)
 {
-    return no >= tt.lastnode;
+    return no >= tt->lastnode;
 }
 
 static inline int
-node_is_particle(int no, const struct OctTree tt)
+node_is_particle(int no, const struct OctTree * tt)
 {
-    return no < tt.firstnode;
+    return no < tt->firstnode;
 }
 
 static inline int
-node_is_node(int no, const struct OctTree tt)
+node_is_node(int no, const struct OctTree * tt)
 {
-    return (no >= tt.firstnode) && (no < tt.lastnode);
+    return (no >= tt->firstnode) && (no < tt->lastnode);
 }
 
 int
-force_get_prev_node(int no, const struct OctTree tb);
+force_get_prev_node(int no, const struct OctTree * tb);
 
 int
-force_get_next_node(int no, const struct OctTree tb);
+force_get_next_node(int no, const struct OctTree * tb);
 
 int
-force_set_next_node(int no, int next, const struct OctTree tb);
+force_set_next_node(int no, int next, const struct OctTree * tb);
 
 int
-force_get_father(int no, const struct OctTree tt);
+force_get_father(int no, const struct OctTree * tt);
 
 #endif
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -64,7 +64,7 @@ extern struct OctTree {
     int *Father;
 } TreeNodes;
 
-int force_tree_allocated(struct OctTree * tt);
+int force_tree_allocated(const struct OctTree * tt);
 
 /* This function propagates changed SPH smoothing lengths up the tree*/
 void force_update_hmax(int * activeset, int size, struct OctTree * tt);

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -19,6 +19,7 @@ extern struct NODE
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
+        unsigned int NodeIsDirty :1; /*Node is a toplevel node containing local mass, and its moments need updating*/
     } f;
     union
     {

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -58,8 +58,6 @@ extern struct OctTree {
     struct NODE * Nodes_base;
 } TreeNodes;
 
-extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
-
 /*Used in domain.c*/
 extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */
 extern int *Father;		/*!< gives parent node in tree (Prenodes array) */

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -59,7 +59,6 @@ extern struct OctTree {
 } TreeNodes;
 
 extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
-extern int NumNodes;      /*!< Currently used number of internal nodes*/
 
 /*Used in domain.c*/
 extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -47,7 +47,7 @@ struct NODE
  * no = ForceTree.firstnode..ForceTree.numnodes which is the only allocated memory.
  * no > ForceTree.lastnode means a pseudo particle on another processor*/
 typedef struct ForceTree {
-    /*Is 1 if the tree is allocated*/
+    /*Is 1 if the tree is allocated. Only used inside force_tree_allocated() and when allocating.*/
     int tree_allocated_flag;
     /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
     int firstnode;
@@ -58,7 +58,9 @@ typedef struct ForceTree {
     /*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
      *   gives the first allocated node */
     struct NODE *Nodes;
-    /*This points to the actual memory allocated for the nodes*/
+    /* The following pointers should only be used via accessors or inside of forcetree.c.
+     * The exception is the crazy memory shifting done in sfr_eff.c*/
+    /*This points to the actual memory allocated for the nodes.*/
     struct NODE * Nodes_base;
     /* Gives next node in the tree walk for particles and pseudo particles.
      * next node for the actual nodes is stored in Nodes*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -67,7 +67,8 @@ extern int *Father;		/*!< gives parent node in tree (Prenodes array) */
 
 int force_tree_allocated();
 
-void force_update_hmax(int * activeset, int size);
+/* This function propagates changed SPH smoothing lengths up the tree*/
+void force_update_hmax(int * activeset, int size, struct OctTree * tt);
 void force_tree_rebuild();
 
 void   force_tree_free(void);

--- a/libgadget/gravity.h
+++ b/libgadget/gravity.h
@@ -1,13 +1,16 @@
 #ifndef LONGRANGE_H
 #define LONGRANGE_H
 
+#include "forcetree.h"
+
 void grav_init(void);
 
 int
 grav_apply_short_range_window(double r, double * fac, double * pot);
 
-void gravpm_force(void);
+/*Note: tree is rebuilt during this function*/
+void gravpm_force(struct OctTree * tree);
 
-void grav_short_pair(void);
-void grav_short_tree(void);
+void grav_short_pair(struct OctTree * tree);
+void grav_short_tree(struct OctTree * tree);
 #endif

--- a/libgadget/gravity.h
+++ b/libgadget/gravity.h
@@ -9,8 +9,8 @@ int
 grav_apply_short_range_window(double r, double * fac, double * pot);
 
 /*Note: tree is rebuilt during this function*/
-void gravpm_force(struct OctTree * tree);
+void gravpm_force(ForceTree * tree);
 
-void grav_short_pair(struct OctTree * tree);
-void grav_short_tree(struct OctTree * tree);
+void grav_short_pair(ForceTree * tree);
+void grav_short_tree(ForceTree * tree);
 #endif

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -191,7 +191,7 @@ static int pm_mark_region_for_node(int startno, int rid) {
     int endno = Nodes[startno].u.d.sibling;
     while(no >= 0 && no != endno)
     {
-        if(node_is_particle(no))	/* single particle */
+        if(node_is_particle(no, TreeNodes))	/* single particle */
         {
             p = no;
             no = Nextnode[no];
@@ -232,7 +232,7 @@ static int pm_mark_region_for_node(int startno, int rid) {
         }
         else
         {
-            if(node_is_pseudo_particle(no))	/* pseudo particle */
+            if(node_is_pseudo_particle(no, TreeNodes))	/* pseudo particle */
             {
                 /* skip pseudo particles */
                 no = Nextnode[no - MaxNodes];

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -120,7 +120,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
 
     int r = 0;
 
-    int no = RootNode; /* start with the root */
+    int no = TreeNodes.firstnode; /* start with the root */
     while(no >= 0) {
 
         if(!(Nodes[no].f.DependsOnLocalMass)) {

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -18,7 +18,7 @@
 /*Global variable to store power spectrum*/
 struct _powerspectrum PowerSpectrum;
 
-static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tt);
+static int pm_mark_region_for_node(int startno, int rid, const ForceTree * tt);
 static void convert_node_to_region(PetaPMRegion * r, struct NODE * Nodes);
 
 static int hybrid_nu_gravpm_is_active(int i);
@@ -58,7 +58,7 @@ void gravpm_init_periodic() {
 
 /* Computes the gravitational force on the PM grid
  * and saves the total matter power spectrum.*/
-void gravpm_force(struct OctTree * tree) {
+void gravpm_force(ForceTree * tree) {
     PetaPMParticleStruct pstruct = {
         P,
         sizeof(P[0]),
@@ -118,7 +118,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
      * NTopLeaves is sufficient */
     PetaPMRegion * regions = mymalloc2("Regions", sizeof(PetaPMRegion) * NTopLeaves);
 
-    struct OctTree * tree = (struct OctTree *) userdata;
+    ForceTree * tree = (ForceTree *) userdata;
     int r = 0;
 
     int no = tree->firstnode; /* start with the root */
@@ -185,7 +185,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
     return regions;
 }
 
-static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tree) {
+static int pm_mark_region_for_node(int startno, int rid, const ForceTree * tree) {
     int numpart = 0;
     int no = startno;
     int endno = tree->Nodes[startno].u.d.sibling;

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -186,15 +186,13 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
 
 static int pm_mark_region_for_node(int startno, int rid) {
     int numpart = 0;
-    int p;
     int no = startno;
     int endno = Nodes[startno].u.d.sibling;
     while(no >= 0 && no != endno)
     {
         if(node_is_particle(no, TreeNodes))	/* single particle */
         {
-            p = no;
-            no = Nextnode[no];
+            int p = no;
             /* when we are in PM, all particles must have been synced. */
             if (P[p].Ti_drift != All.Ti_Current) {
                 abort();
@@ -230,17 +228,8 @@ static int pm_mark_region_for_node(int startno, int rid) {
             }
             numpart ++;
         }
-        else
-        {
-            if(node_is_pseudo_particle(no, TreeNodes))	/* pseudo particle */
-            {
-                /* skip pseudo particles */
-                no = Nextnode[no - MaxNodes];
-                continue;
-            }
 
-            no = Nodes[no].u.d.nextnode;	/* ok, we need to open the node */
-        }
+        no = force_get_next_node(no, TreeNodes);
     }
     return numpart;
 }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -175,7 +175,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
         convert_node_to_region(&regions[r]);
     }
     /*This is done to conserve memory during the PM step*/
-    if(force_tree_allocated()) force_tree_free(&TreeNodes);
+    if(force_tree_allocated(&TreeNodes)) force_tree_free(&TreeNodes);
 
     /*Allocate memory for a power spectrum*/
     powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads, All.MassiveNuLinRespOn);

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -185,13 +185,13 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
     return regions;
 }
 
-static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tt) {
+static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tree) {
     int numpart = 0;
     int no = startno;
-    int endno = tt->Nodes[startno].u.d.sibling;
+    int endno = tree->Nodes[startno].u.d.sibling;
     while(no >= 0 && no != endno)
     {
-        if(node_is_particle(no, tt))	/* single particle */
+        if(node_is_particle(no, tree))	/* single particle */
         {
             int p = no;
             /* when we are in PM, all particles must have been synced. */
@@ -212,7 +212,7 @@ static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * 
              * */
             int k;
             for(k = 0; k < 3; k ++) {
-                double l = P[p].Pos[k] - tt->Nodes[startno].center[k];
+                double l = P[p].Pos[k] - tree->Nodes[startno].center[k];
                 if (l < - 0.5 * All.BoxSize) {
                     l += All.BoxSize;
                 }
@@ -220,17 +220,17 @@ static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * 
                     l -= All.BoxSize;
                 }
                 l = fabs(l * 2);
-                if (l > tt->Nodes[startno].len) {
-                    if(l > tt->Nodes[startno].len * (1+ 1e-7))
+                if (l > tree->Nodes[startno].len) {
+                    if(l > tree->Nodes[startno].len * (1+ 1e-7))
                     message(1, "enlarging node size from %g to %g, due to particle of type %d at %g %g %g id=%ld\n",
-                        tt->Nodes[startno].len, l, P[p].Type, P[p].Pos[0], P[p].Pos[1], P[p].Pos[2], P[p].ID);
-                    tt->Nodes[startno].len = l;
+                        tree->Nodes[startno].len, l, P[p].Type, P[p].Pos[0], P[p].Pos[1], P[p].Pos[2], P[p].ID);
+                    tree->Nodes[startno].len = l;
                 }
             }
             numpart ++;
         }
 
-        no = force_get_next_node(no, tt);
+        no = force_get_next_node(no, tree);
     }
     return numpart;
 }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -175,7 +175,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
         convert_node_to_region(&regions[r]);
     }
     /*This is done to conserve memory during the PM step*/
-    if(force_tree_allocated()) force_tree_free();
+    if(force_tree_allocated()) force_tree_free(&TreeNodes);
 
     /*Allocate memory for a power spectrum*/
     powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads, All.MassiveNuLinRespOn);

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -190,7 +190,7 @@ static int pm_mark_region_for_node(int startno, int rid) {
     int endno = Nodes[startno].u.d.sibling;
     while(no >= 0 && no != endno)
     {
-        if(node_is_particle(no, TreeNodes))	/* single particle */
+        if(node_is_particle(no, &TreeNodes))	/* single particle */
         {
             int p = no;
             /* when we are in PM, all particles must have been synced. */
@@ -229,7 +229,7 @@ static int pm_mark_region_for_node(int startno, int rid) {
             numpart ++;
         }
 
-        no = force_get_next_node(no, TreeNodes);
+        no = force_get_next_node(no, &TreeNodes);
     }
     return numpart;
 }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -18,8 +18,8 @@
 /*Global variable to store power spectrum*/
 struct _powerspectrum PowerSpectrum;
 
-static int pm_mark_region_for_node(int startno, int rid);
-static void convert_node_to_region(PetaPMRegion * r);
+static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tt);
+static void convert_node_to_region(PetaPMRegion * r, struct NODE * Nodes);
 
 static int hybrid_nu_gravpm_is_active(int i);
 static void potential_transfer(int64_t k2, int kpos[3], pfft_complex * value);
@@ -118,31 +118,32 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
      * NTopLeaves is sufficient */
     PetaPMRegion * regions = mymalloc2("Regions", sizeof(PetaPMRegion) * NTopLeaves);
 
+    struct OctTree * tree = &TreeNodes;
     int r = 0;
 
-    int no = TreeNodes.firstnode; /* start with the root */
+    int no = tree->firstnode; /* start with the root */
     while(no >= 0) {
 
-        if(!(Nodes[no].f.DependsOnLocalMass)) {
+        if(!(tree->Nodes[no].f.DependsOnLocalMass)) {
             /* node doesn't contain particles on this process, do not open */
-            no = Nodes[no].u.d.sibling;
+            no = tree->Nodes[no].u.d.sibling;
             continue;
         }
         if(
             /* node is large */
-           (Nodes[no].len <= All.BoxSize / All.Nmesh * 24)
+           (tree->Nodes[no].len <= All.BoxSize / All.Nmesh * 24)
            ||
             /* node is a top leaf */
-            ( !Nodes[no].f.InternalTopLevel && (Nodes[no].f.TopLevel) )
+            ( !tree->Nodes[no].f.InternalTopLevel && (tree->Nodes[no].f.TopLevel) )
                 ) {
             regions[r].no = no;
             r ++;
             /* do not open */
-            no = Nodes[no].u.d.sibling;
+            no = tree->Nodes[no].u.d.sibling;
             continue;
         }
         /* open */
-        no = Nodes[no].u.d.nextnode;
+        no = tree->Nodes[no].u.d.nextnode;
     }
 
     *Nregions = r;
@@ -159,7 +160,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
     int numpart = 0;
 #pragma omp parallel for reduction(+: numpart)
     for(r = 0; r < *Nregions; r++) {
-        regions[r].numpart = pm_mark_region_for_node(regions[r].no, r);
+        regions[r].numpart = pm_mark_region_for_node(regions[r].no, r, &TreeNodes);
         numpart += regions[r].numpart;
     }
     for(i =0; i < PartManager->NumPart; i ++) {
@@ -172,10 +173,10 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
         endrun(1, "Processed only %d particles out of %d\n", numpart, PartManager->NumPart);
     }
     for(r =0; r < *Nregions; r++) {
-        convert_node_to_region(&regions[r]);
+        convert_node_to_region(&regions[r], tree->Nodes);
     }
     /*This is done to conserve memory during the PM step*/
-    if(force_tree_allocated(&TreeNodes)) force_tree_free(&TreeNodes);
+    if(force_tree_allocated(tree)) force_tree_free(tree);
 
     /*Allocate memory for a power spectrum*/
     powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads, All.MassiveNuLinRespOn);
@@ -184,13 +185,13 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
     return regions;
 }
 
-static int pm_mark_region_for_node(int startno, int rid) {
+static int pm_mark_region_for_node(int startno, int rid, const struct OctTree * tt) {
     int numpart = 0;
     int no = startno;
-    int endno = Nodes[startno].u.d.sibling;
+    int endno = tt->Nodes[startno].u.d.sibling;
     while(no >= 0 && no != endno)
     {
-        if(node_is_particle(no, &TreeNodes))	/* single particle */
+        if(node_is_particle(no, tt))	/* single particle */
         {
             int p = no;
             /* when we are in PM, all particles must have been synced. */
@@ -211,7 +212,7 @@ static int pm_mark_region_for_node(int startno, int rid) {
              * */
             int k;
             for(k = 0; k < 3; k ++) {
-                double l = P[p].Pos[k] - Nodes[startno].center[k];
+                double l = P[p].Pos[k] - tt->Nodes[startno].center[k];
                 if (l < - 0.5 * All.BoxSize) {
                     l += All.BoxSize;
                 }
@@ -219,23 +220,23 @@ static int pm_mark_region_for_node(int startno, int rid) {
                     l -= All.BoxSize;
                 }
                 l = fabs(l * 2);
-                if (l > Nodes[startno].len) {
-                    if(l > Nodes[startno].len * (1+ 1e-7))
+                if (l > tt->Nodes[startno].len) {
+                    if(l > tt->Nodes[startno].len * (1+ 1e-7))
                     message(1, "enlarging node size from %g to %g, due to particle of type %d at %g %g %g id=%ld\n",
-                        Nodes[startno].len, l, P[p].Type, P[p].Pos[0], P[p].Pos[1], P[p].Pos[2], P[p].ID);
-                    Nodes[startno].len = l;
+                        tt->Nodes[startno].len, l, P[p].Type, P[p].Pos[0], P[p].Pos[1], P[p].Pos[2], P[p].ID);
+                    tt->Nodes[startno].len = l;
                 }
             }
             numpart ++;
         }
 
-        no = force_get_next_node(no, &TreeNodes);
+        no = force_get_next_node(no, tt);
     }
     return numpart;
 }
 
 
-static void convert_node_to_region(PetaPMRegion * r) {
+static void convert_node_to_region(PetaPMRegion * r, struct NODE * Nodes) {
     int k;
     double cellsize = All.BoxSize / All.Nmesh;
     int no = r->no;

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -22,7 +22,7 @@ grav_short_pair_ngbiter(
         TreeWalkNgbIterGravShort * iter,
         LocalTreeWalk * lv);
 
-void grav_short_pair(void)
+void grav_short_pair(struct OctTree * tree)
 {
     TreeWalk tw[1] = {{0}};
 
@@ -40,6 +40,7 @@ void grav_short_pair(void)
     tw->UseNodeList = 1;
     tw->query_type_elsize = sizeof(TreeWalkQueryGravShort);
     tw->result_type_elsize = sizeof(TreeWalkResultGravShort);
+    tw->tree = tree;
 
     walltime_measure("/Misc");
 

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -22,7 +22,7 @@ grav_short_pair_ngbiter(
         TreeWalkNgbIterGravShort * iter,
         LocalTreeWalk * lv);
 
-void grav_short_pair(struct OctTree * tree)
+void grav_short_pair(ForceTree * tree)
 {
     TreeWalk tw[1] = {{0}};
 

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -190,7 +190,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
 
     no = input->base.NodeList[0];
     listindex ++;
-    no = Nodes[no].u.d.nextnode;	/* open it */
+    no = TreeNodes.Nodes[no].u.d.nextnode;	/* open it */
 
     pos_x = input->base.Pos[0];
     pos_y = input->base.Pos[1];
@@ -279,7 +279,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                     h = All.ForceSoftening[P[no].Type];
 #endif
 #endif
-                no = force_get_next_node(no, TreeNodes);
+                no = force_get_next_node(no, &TreeNodes);
             }
             else			/* we have an  internal node */
             {
@@ -290,11 +290,11 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = force_get_next_node(no, TreeNodes);
+                    no = force_get_next_node(no, &TreeNodes);
                     continue;
                 }
 
-                nop = &Nodes[no];
+                nop = &TreeNodes.Nodes[no];
 
                 if(lv->mode == 1)
                 {
@@ -572,7 +572,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
             no = input->base.NodeList[listindex];
             if(no >= 0)
             {
-                no = Nodes[no].u.d.nextnode;	/* open it */
+                no = TreeNodes.Nodes[no].u.d.nextnode;	/* open it */
                 nnodesinlist++;
                 listindex++;
             }

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -65,7 +65,7 @@ static int force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
  *  tree is used.  Particles are only exported to other processors when really
  *  needed, thereby allowing a good use of the communication buffer.
  */
-void grav_short_tree_old(struct OctTree * tree)
+void grav_short_tree_old(ForceTree * tree)
 {
     double timeall = 0;
     double timetree, timewait, timecomm;

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -279,7 +279,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                     h = All.ForceSoftening[P[no].Type];
 #endif
 #endif
-                no = Nextnode[no];
+                no = force_get_next_node(no, TreeNodes);
             }
             else			/* we have an  internal node */
             {
@@ -290,7 +290,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = Nextnode[no - MaxNodes];
+                    no = force_get_next_node(no, TreeNodes);
                     continue;
                 }
 

--- a/libgadget/gravshort-tree-old.c
+++ b/libgadget/gravshort-tree-old.c
@@ -65,7 +65,7 @@ static int force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
  *  tree is used.  Particles are only exported to other processors when really
  *  needed, thereby allowing a good use of the communication buffer.
  */
-void grav_short_tree_old(void)
+void grav_short_tree_old(struct OctTree * tree)
 {
     double timeall = 0;
     double timetree, timewait, timecomm;
@@ -84,6 +84,7 @@ void grav_short_tree_old(void)
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;
     tw->UseNodeList = 1;
+    tw->tree = tree;
 
     tw->query_type_elsize = sizeof(TreeWalkQueryGravShort);
     tw->result_type_elsize = sizeof(TreeWalkResultGravShort);
@@ -190,7 +191,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
 
     no = input->base.NodeList[0];
     listindex ++;
-    no = TreeNodes.Nodes[no].u.d.nextnode;	/* open it */
+    no = lv->tw->tree->Nodes[no].u.d.nextnode;	/* open it */
 
     pos_x = input->base.Pos[0];
     pos_y = input->base.Pos[1];
@@ -279,7 +280,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                     h = All.ForceSoftening[P[no].Type];
 #endif
 #endif
-                no = force_get_next_node(no, &TreeNodes);
+                no = force_get_next_node(no, lv->tw->tree);
             }
             else			/* we have an  internal node */
             {
@@ -290,11 +291,11 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = force_get_next_node(no, &TreeNodes);
+                    no = force_get_next_node(no, lv->tw->tree);
                     continue;
                 }
 
-                nop = &TreeNodes.Nodes[no];
+                nop = &lv->tw->tree->Nodes[no];
 
                 if(lv->mode == 1)
                 {
@@ -572,7 +573,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
             no = input->base.NodeList[listindex];
             if(no >= 0)
             {
-                no = TreeNodes.Nodes[no].u.d.nextnode;	/* open it */
+                no = lv->tw->tree->Nodes[no].u.d.nextnode;	/* open it */
                 nnodesinlist++;
                 listindex++;
             }

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -121,6 +121,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     MyDouble acc_x = 0;
     MyDouble acc_y = 0;
     MyDouble acc_z = 0;
+    const struct OctTree * tree = &TreeNodes;
 
     /*Hybrid particle neutrinos do not gravitate at early times*/
     const int NeutrinoTracer = All.HybridNeutrinosOn && (All.Time <= All.HybridNuPartTime);
@@ -137,7 +138,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     /*Start the tree walk*/
     int no = input->base.NodeList[0];
     int listindex = 1;
-    no = Nodes[no].u.d.nextnode;	/* open it */
+    no = tree->Nodes[no].u.d.nextnode;	/* open it */
 
     while(no >= 0)
     {
@@ -145,13 +146,13 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
         {
             double mass, r2, h;
             double dx, dy, dz;
-            if(node_is_particle(no, &TreeNodes))
+            if(node_is_particle(no, tree))
             {
                 if(NeutrinoTracer)
                 {
                     if(P[no].Type == All.FastParticleType)
                     {
-                        no = force_get_next_node(no, &TreeNodes);
+                        no = force_get_next_node(no, tree);
                         continue;
                     }
                 }
@@ -168,23 +169,23 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 const double otherh = FORCE_SOFTENING(no);
                 if(h < otherh)
                     h = otherh;
-                no = force_get_next_node(no, &TreeNodes);
+                no = force_get_next_node(no, tree);
             }
             else			/* we have an  internal node */
             {
                 struct NODE *nop;
-                if(node_is_pseudo_particle(no, &TreeNodes))	/* pseudo particle */
+                if(node_is_pseudo_particle(no, tree))	/* pseudo particle */
                 {
                     if(lv->mode == 0)
                     {
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = force_get_next_node(no, &TreeNodes);
+                    no = force_get_next_node(no, tree);
                     continue;
                 }
 
-                nop = &Nodes[no];
+                nop = &tree->Nodes[no];
 
                 if(lv->mode == 1)
                 {
@@ -304,7 +305,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             no = input->base.NodeList[listindex];
             if(no >= 0)
             {
-                no = Nodes[no].u.d.nextnode;	/* open it */
+                no = tree->Nodes[no].u.d.nextnode;	/* open it */
                 nnodesinlist++;
                 listindex++;
             }

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -43,7 +43,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
  *  tree is used.  Particles are only exported to other processors when really
  *  needed, thereby allowing a good use of the communication buffer.
  */
-void grav_short_tree(struct OctTree * tree)
+void grav_short_tree(ForceTree * tree)
 {
     double timeall = 0;
     double timetree, timewait, timecomm;
@@ -122,7 +122,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     MyDouble acc_x = 0;
     MyDouble acc_y = 0;
     MyDouble acc_z = 0;
-    const struct OctTree * tree = lv->tw->tree;
+    const ForceTree * tree = lv->tw->tree;
 
     /*Hybrid particle neutrinos do not gravitate at early times*/
     const int NeutrinoTracer = All.HybridNeutrinosOn && (All.Time <= All.HybridNuPartTime);

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -43,7 +43,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
  *  tree is used.  Particles are only exported to other processors when really
  *  needed, thereby allowing a good use of the communication buffer.
  */
-void grav_short_tree(void)
+void grav_short_tree(struct OctTree * tree)
 {
     double timeall = 0;
     double timetree, timewait, timecomm;
@@ -63,6 +63,7 @@ void grav_short_tree(void)
     tw->query_type_elsize = sizeof(TreeWalkQueryGravShort);
     tw->result_type_elsize = sizeof(TreeWalkResultGravShort);
     tw->fill = (TreeWalkFillQueryFunction) grav_short_copy;
+    tw->tree = tree;
 
     walltime_measure("/Misc");
 
@@ -121,7 +122,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     MyDouble acc_x = 0;
     MyDouble acc_y = 0;
     MyDouble acc_z = 0;
-    const struct OctTree * tree = &TreeNodes;
+    const struct OctTree * tree = lv->tw->tree;
 
     /*Hybrid particle neutrinos do not gravitate at early times*/
     const int NeutrinoTracer = All.HybridNeutrinosOn && (All.Time <= All.HybridNuPartTime);

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -145,7 +145,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
         {
             double mass, r2, h;
             double dx, dy, dz;
-            if(node_is_particle(no))
+            if(node_is_particle(no, TreeNodes))
             {
                 if(NeutrinoTracer)
                 {
@@ -173,7 +173,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             else			/* we have an  internal node */
             {
                 struct NODE *nop;
-                if(node_is_pseudo_particle(no))	/* pseudo particle */
+                if(node_is_pseudo_particle(no, TreeNodes))	/* pseudo particle */
                 {
                     if(lv->mode == 0)
                     {

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -168,7 +168,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 const double otherh = FORCE_SOFTENING(no);
                 if(h < otherh)
                     h = otherh;
-                no = Nextnode[no];
+                no = force_get_next_node(no, TreeNodes);
             }
             else			/* we have an  internal node */
             {
@@ -180,7 +180,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = Nextnode[no - MaxNodes];
+                    no = force_get_next_node(no, TreeNodes);
                     continue;
                 }
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -145,13 +145,13 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
         {
             double mass, r2, h;
             double dx, dy, dz;
-            if(node_is_particle(no, TreeNodes))
+            if(node_is_particle(no, &TreeNodes))
             {
                 if(NeutrinoTracer)
                 {
                     if(P[no].Type == All.FastParticleType)
                     {
-                        no = force_get_next_node(no, TreeNodes);
+                        no = force_get_next_node(no, &TreeNodes);
                         continue;
                     }
                 }
@@ -168,19 +168,19 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 const double otherh = FORCE_SOFTENING(no);
                 if(h < otherh)
                     h = otherh;
-                no = force_get_next_node(no, TreeNodes);
+                no = force_get_next_node(no, &TreeNodes);
             }
             else			/* we have an  internal node */
             {
                 struct NODE *nop;
-                if(node_is_pseudo_particle(no, TreeNodes))	/* pseudo particle */
+                if(node_is_pseudo_particle(no, &TreeNodes))	/* pseudo particle */
                 {
                     if(lv->mode == 0)
                     {
                         if(-1 == treewalk_export_particle(lv, no))
                             return -1;
                     }
-                    no = force_get_next_node(no, TreeNodes);
+                    no = force_get_next_node(no, &TreeNodes);
                     continue;
                 }
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -151,7 +151,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 {
                     if(P[no].Type == All.FastParticleType)
                     {
-                        no = Nextnode[no];
+                        no = force_get_next_node(no, TreeNodes);
                         continue;
                     }
                 }

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -87,7 +87,7 @@ hydro_reduce(int place, TreeWalkResultHydro * result, enum TreeWalkReduceMode mo
  *  force and rate of change of entropy due to shock heating for all active
  *  particles .
  */
-void hydro_force(struct OctTree * tree)
+void hydro_force(ForceTree * tree)
 {
     if(!All.HydroOn)
         return;

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -87,7 +87,7 @@ hydro_reduce(int place, TreeWalkResultHydro * result, enum TreeWalkReduceMode mo
  *  force and rate of change of entropy due to shock heating for all active
  *  particles .
  */
-void hydro_force(void)
+void hydro_force(struct OctTree * tree)
 {
     if(!All.HydroOn)
         return;
@@ -104,6 +104,7 @@ void hydro_force(void)
     tw->UseNodeList = 0;
     tw->query_type_elsize = sizeof(TreeWalkQueryHydro);
     tw->result_type_elsize = sizeof(TreeWalkResultHydro);
+    tw->tree = tree;
 
     double timeall = 0, timenetwork = 0;
     double timecomp, timecomm, timewait;

--- a/libgadget/hydra.h
+++ b/libgadget/hydra.h
@@ -7,6 +7,6 @@
 double PressurePred(int i);
 
 /*Function to compute hydro accelerations and adiabatic entropy change*/
-void hydro_force(struct OctTree * tree);
+void hydro_force(ForceTree * tree);
 
 #endif

--- a/libgadget/hydra.h
+++ b/libgadget/hydra.h
@@ -1,10 +1,12 @@
 #ifndef HYDRA_H
 #define HYDRA_H
 
+#include "forcetree.h"
+
 /*Function to get the pressure from the entropy and the density*/
 double PressurePred(int i);
 
 /*Function to compute hydro accelerations and adiabatic entropy change*/
-void hydro_force(void);
+void hydro_force(struct OctTree * tree);
 
 #endif

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -195,7 +195,7 @@ setup_smoothinglengths(int RestartSnapNum)
 #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++)
         {
-            int no = force_get_father(i, TreeNodes);
+            int no = force_get_father(i, &TreeNodes);
             /* Don't need smoothing lengths for DM particles*/
             if(P[i].Type != 0 && P[i].Type != 4 && P[i].Type != 5)
                 continue;

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -190,12 +190,13 @@ setup_smoothinglengths(int RestartSnapNum)
     const double a3 = All.Time * All.Time * All.Time;
 
     force_tree_rebuild();
+    struct OctTree * tree = &TreeNodes;
     if(RestartSnapNum == -1)
     {
 #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++)
         {
-            int no = force_get_father(i, &TreeNodes);
+            int no = force_get_father(i, tree);
             /* Don't need smoothing lengths for DM particles*/
             if(P[i].Type != 0 && P[i].Type != 4 && P[i].Type != 5)
                 continue;
@@ -212,9 +213,9 @@ setup_smoothinglengths(int RestartSnapNum)
             } else {
                 massfactor = 1.0 - 0.04 / 0.26;
             }
-            while(10 * All.DesNumNgb * P[i].Mass > massfactor * Nodes[no].u.d.mass)
+            while(10 * All.DesNumNgb * P[i].Mass > massfactor * tree->Nodes[no].u.d.mass)
             {
-                int p = Nodes[no].father;
+                int p = force_get_father(no, tree);
 
                 if(p < 0)
                     break;
@@ -223,8 +224,8 @@ setup_smoothinglengths(int RestartSnapNum)
             }
 
             P[i].Hsml =
-                pow(3.0 / (4 * M_PI) * All.DesNumNgb * P[i].Mass / (massfactor * Nodes[no].u.d.mass),
-                        1.0 / 3) * Nodes[no].len;
+                pow(3.0 / (4 * M_PI) * All.DesNumNgb * P[i].Mass / (massfactor * tree->Nodes[no].u.d.mass),
+                        1.0 / 3) * tree->Nodes[no].len;
 
             /* recover from a poor initial guess */
             if(P[i].Hsml > 500.0 * All.MeanSeparation[0])

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -189,7 +189,7 @@ setup_smoothinglengths(int RestartSnapNum)
     int i;
     const double a3 = All.Time * All.Time * All.Time;
 
-    struct OctTree Tree = {0};
+    ForceTree Tree = {0};
     force_tree_rebuild(&Tree);
 
     if(RestartSnapNum == -1)

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -321,5 +321,5 @@ setup_smoothinglengths(int RestartSnapNum)
     density_update();
 #endif //DENSITY_INDEPENDENT_SPH
 
-    if(force_tree_allocated()) force_tree_free();
+    if(force_tree_allocated()) force_tree_free(&TreeNodes);
 }

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -195,7 +195,7 @@ setup_smoothinglengths(int RestartSnapNum)
 #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++)
         {
-            int no = Father[i];
+            int no = force_get_father(i, TreeNodes);
             /* Don't need smoothing lengths for DM particles*/
             if(P[i].Type != 0 && P[i].Type != 4 && P[i].Type != 5)
                 continue;

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -321,5 +321,5 @@ setup_smoothinglengths(int RestartSnapNum)
     density_update();
 #endif //DENSITY_INDEPENDENT_SPH
 
-    if(force_tree_allocated()) force_tree_free(&TreeNodes);
+    if(force_tree_allocated(&TreeNodes)) force_tree_free(&TreeNodes);
 }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -288,7 +288,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
         density();		/* computes density, and pressure */
 
         /***** update smoothing lengths in tree *****/
-        force_update_hmax(ActiveParticle, NumActiveParticle);
+        force_update_hmax(ActiveParticle, NumActiveParticle, &TreeNodes);
         /***** hydro forces *****/
         message(0, "Start hydro-force computation...\n");
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -234,7 +234,7 @@ void run(void)
         report_memory_usage("RUN");
 
         /*Note FoF will free the tree too*/
-        if(force_tree_allocated()) force_tree_free(&TreeNodes);
+        if(force_tree_allocated(&TreeNodes)) force_tree_free(&TreeNodes);
 
         if(!next_sync || stop) {
             /* out of sync points, or a requested stop, the run has finally finished! Yay.*/

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -37,7 +37,7 @@ void init(int snapnum); /* init.c only used here */
  * reached, when a `stop' file is found in the output directory, or
  * when the simulation ends because we arrived at TimeMax.
  */
-static void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, struct OctTree * tree);
+static void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, ForceTree * tree);
 static void write_cpu_log(int NumCurrentTiStep);
 
 /*! \file begrun.c
@@ -182,7 +182,7 @@ void run(void)
         set_random_numbers(All.RandomSeed + All.Ti_Current);
 
         /* Need to rebuild the force tree because all TopLeaves are out of date.*/
-        struct OctTree Tree = {0};
+        ForceTree Tree = {0};
         force_tree_rebuild(&Tree);
 
         /* update force to Ti_Current */
@@ -273,7 +273,7 @@ void run(void)
  * be outside the allowed bounds, it will be readjusted by the function ensure_neighbours(), and for those
  * particle, the densities are recomputed accordingly. Finally, the hydrodynamical forces are added.
  */
-void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, struct OctTree * tree)
+void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, ForceTree * tree)
 {
     message(0, "Begin force computation.\n");
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -234,7 +234,7 @@ void run(void)
         report_memory_usage("RUN");
 
         /*Note FoF will free the tree too*/
-        if(force_tree_allocated()) force_tree_free();
+        if(force_tree_allocated()) force_tree_free(&TreeNodes);
 
         if(!next_sync || stop) {
             /* out of sync points, or a requested stop, the run has finally finished! Yay.*/

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -37,7 +37,7 @@ void init(int snapnum); /* init.c only used here */
  * reached, when a `stop' file is found in the output directory, or
  * when the simulation ends because we arrived at TimeMax.
  */
-static void compute_accelerations(int is_PM, int FirstStep, int GasEnabled);
+static void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, struct OctTree * tree);
 static void write_cpu_log(int NumCurrentTiStep);
 
 /*! \file begrun.c
@@ -182,10 +182,11 @@ void run(void)
         set_random_numbers(All.RandomSeed + All.Ti_Current);
 
         /* Need to rebuild the force tree because all TopLeaves are out of date.*/
-        force_tree_rebuild();
+        struct OctTree Tree = {0};
+        force_tree_rebuild(&Tree);
 
         /* update force to Ti_Current */
-        compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled);
+        compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled, &Tree);
 
         /* Update velocity to Ti_Current; this synchonizes TiKick and TiDrift for the active particles */
 
@@ -220,12 +221,12 @@ void run(void)
             int compact[6] = {0};
 
             if(slots_gc(compact)) {
-                force_tree_rebuild();
+                force_tree_rebuild(&Tree);
                 NumActiveParticle = PartManager->NumPart;
             }
         }
 
-        write_checkpoint(WriteSnapshot, WriteFOF);
+        write_checkpoint(WriteSnapshot, WriteFOF, &Tree);
 
         write_cpu_log(NumCurrentTiStep);		/* produce some CPU usage info */
 
@@ -233,8 +234,8 @@ void run(void)
 
         report_memory_usage("RUN");
 
-        /*Note FoF will free the tree too*/
-        if(force_tree_allocated(&TreeNodes)) force_tree_free(&TreeNodes);
+        /*Note FoF may free the tree too*/
+        force_tree_free(&Tree);
 
         if(!next_sync || stop) {
             /* out of sync points, or a requested stop, the run has finally finished! Yay.*/
@@ -272,7 +273,7 @@ void run(void)
  * be outside the allowed bounds, it will be readjusted by the function ensure_neighbours(), and for those
  * particle, the densities are recomputed accordingly. Finally, the hydrodynamical forces are added.
  */
-void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
+void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, struct OctTree * tree)
 {
     message(0, "Begin force computation.\n");
 
@@ -285,14 +286,14 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
         /***** density *****/
         message(0, "Start density computation...\n");
 
-        density();		/* computes density, and pressure */
+        density(tree);  /* computes density, and pressure */
 
         /***** update smoothing lengths in tree *****/
-        force_update_hmax(ActiveParticle, NumActiveParticle, &TreeNodes);
+        force_update_hmax(ActiveParticle, NumActiveParticle, tree);
         /***** hydro forces *****/
         message(0, "Start hydro-force computation...\n");
 
-        hydro_force();		/* adds hydrodynamical accelerations  and computes du/dt  */
+        hydro_force(tree);		/* adds hydrodynamical accelerations  and computes du/dt  */
     }
 
     /* The opening criterion for the gravtree
@@ -303,7 +304,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
      * this timestep to GravPM. Note initially both
      * are zero and so the tree is opened maximally
      * on the first timestep.*/
-    grav_short_tree();
+    grav_short_tree(tree);
     /* TreeUseBH > 1 means use the BH criterion on the initial timestep only,
      * avoiding the fully open O(N^2) case.*/
     if(All.TreeUseBH > 1)
@@ -321,7 +322,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
 
     if(is_PM)
     {
-        gravpm_force();
+        gravpm_force(tree);
 
         /* compute and output energy statistics if desired. */
         if(All.OutputEnergyDebug)
@@ -335,7 +336,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
      * use the total acceleration for tree opening.
      */
     if(FirstStep && All.TreeUseBH == 0)
-        grav_short_tree();
+        grav_short_tree(tree);
 
     /* Note this must be after gravaccel and hydro,
      * because new star particles are not in the tree,
@@ -344,10 +345,10 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
     {
 #ifdef BLACK_HOLES
         /* Black hole accretion and feedback */
-        blackhole();
+        blackhole(tree);
 #endif
         /**** radiative cooling and star formation *****/
-        cooling_and_starformation();
+        cooling_and_starformation(tree);
     }
     message(0, "Forces computed.\n");
 }

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -17,8 +17,6 @@
 #include "domain.h"
 #include "timestep.h"
 
-void grav_short_pair(void);
-
 char * GDB_format_particle(int i);
 
 SIMPLE_PROPERTY(GravAccel, P[i].GravAccel[0], float, 3)
@@ -33,7 +31,9 @@ void runtests()
         IO_REG(GravPM,       "f4", 3, ptype);
     }
 
-    gravpm_force();
+    struct OctTree Tree = {0};
+    force_tree_rebuild(&Tree);
+    gravpm_force(&Tree);
 
     /* this produces a very imbalanced load to trigger Issue 86 */
     if(ThisTask == 0) {
@@ -44,15 +44,16 @@ void runtests()
     domain_decompose_full();	/* do domain decomposition */
     rebuild_activelist(All.Ti_Current, 0);
 
-    grav_short_pair();
+    grav_short_pair(&Tree);
     message(0, "GravShort Pairs %s\n", GDB_format_particle(0));
     petaio_save_snapshot("%s/PART-pairs-%03d-mpi", All.OutputDir, NTask);
 
-    grav_short_tree();  /* computes gravity accel. */
-    grav_short_tree();  /* computes gravity accel. */
-    grav_short_tree();  /* computes gravity accel. */
-    grav_short_tree();  /* computes gravity accel. */
+    grav_short_tree(&Tree);  /* computes gravity accel. */
+    grav_short_tree(&Tree);  /* computes gravity accel. */
+    grav_short_tree(&Tree);  /* computes gravity accel. */
+    grav_short_tree(&Tree);  /* computes gravity accel. */
     message(0, "GravShort Tree %s\n", GDB_format_particle(0));
+    force_tree_free(&Tree);
 
     petaio_save_snapshot("%s/PART-tree-%03d-mpi", All.OutputDir, NTask);
 

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -31,7 +31,7 @@ void runtests()
         IO_REG(GravPM,       "f4", 3, ptype);
     }
 
-    struct OctTree Tree = {0};
+    ForceTree Tree = {0};
     force_tree_rebuild(&Tree);
     gravpm_force(&Tree);
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -47,7 +47,7 @@ static int * sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * 
 
 
 /* cooling and star formation routine.*/
-void cooling_and_starformation(void)
+void cooling_and_starformation(struct OctTree * tree)
 {
     if(!All.CoolingOn)
         return;
@@ -150,7 +150,7 @@ void cooling_and_starformation(void)
     if(SlotsManager->info[4].size + NumNewStar >= SlotsManager->info[4].maxsize) {
         if(NewParents)
             NewParents = myrealloc(NewParents, sizeof(int) * NumNewStar);
-        NewStars = sfr_reserve_slots(NewStars, NumNewStar, &TreeNodes);
+        NewStars = sfr_reserve_slots(NewStars, NumNewStar, tree);
     }
     SlotsManager->info[4].size += NumNewStar;
 
@@ -207,7 +207,7 @@ void cooling_and_starformation(void)
     walltime_measure("/Cooling/StarFormation");
 
     /* Now apply the wind model using the list of new stars.*/
-    winds_and_feedback(NewStars, NumNewStar);
+    winds_and_feedback(NewStars, NumNewStar, tree);
 
     myfree(NewStars);
 }

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -240,11 +240,11 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
             memmove(nodes_base_tmp, tt->Nodes_base, tt->numnodes * sizeof(struct NODE));
             myfree(tt->Nodes_base);
             Father_tmp = mymalloc2("Father_tmp", PartManager->MaxPart * sizeof(int));
-            memmove(Father_tmp, Father, PartManager->MaxPart * sizeof(int));
-            myfree(Father);
+            memmove(Father_tmp, tt->Father, PartManager->MaxPart * sizeof(int));
+            myfree(tt->Father);
             Nextnode_tmp = mymalloc2("Nextnode_tmp", (PartManager->MaxPart + NTopNodes)* sizeof(int));
-            memmove(Nextnode_tmp, Nextnode, (PartManager->MaxPart + NTopNodes) * sizeof(int));
-            myfree(Nextnode);
+            memmove(Nextnode_tmp, tt->Nextnode, (PartManager->MaxPart + NTopNodes) * sizeof(int));
+            myfree(tt->Nextnode);
         }
         if(ActiveParticle) {
             ActiveParticle_tmp = mymalloc2("ActiveParticle_tmp", NumActiveParticle * sizeof(int));
@@ -266,11 +266,11 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
             myfree(ActiveParticle_tmp);
         }
         if(force_tree_allocated(tt)) {
-            Nextnode = mymalloc("Nextnode", (PartManager->MaxPart + NTopNodes)* sizeof(int));
-            memmove(Nextnode, Nextnode_tmp, (PartManager->MaxPart + NTopNodes) * sizeof(int));
+            tt->Nextnode = mymalloc("Nextnode", (PartManager->MaxPart + NTopNodes)* sizeof(int));
+            memmove(tt->Nextnode, Nextnode_tmp, (PartManager->MaxPart + NTopNodes) * sizeof(int));
             myfree(Nextnode_tmp);
-            Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
-            memmove(Father, Father_tmp, PartManager->MaxPart * sizeof(int));
+            tt->Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
+            memmove(tt->Father, Father_tmp, PartManager->MaxPart * sizeof(int));
             myfree(Father_tmp);
             tt->Nodes_base = mymalloc("Nodes_base", tt->numnodes * sizeof(struct NODE));
             memmove(tt->Nodes_base, nodes_base_tmp, tt->numnodes * sizeof(struct NODE));

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -277,7 +277,6 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
             myfree(nodes_base_tmp);
             /*Don't forget to update the Node pointer as well as Node_base!*/
             tt->Nodes = tt->Nodes_base - tt->firstnode;
-            Nodes = tt->Nodes;
         }
         if(new_star_tmp) {
             NewStars = mymalloc("NewStars", NumNewStar*sizeof(int));

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -276,7 +276,7 @@ sfr_reserve_slots(int * NewStars, int NumNewStar)
             memmove(Nodes_base, nodes_base_tmp, NumNodes * sizeof(struct NODE));
             myfree(nodes_base_tmp);
             /*Don't forget to update the Node pointer as well as Node_base!*/
-            Nodes = Nodes_base - RootNode;
+            Nodes = Nodes_base - TreeNodes.firstnode;
         }
         if(new_star_tmp) {
             NewStars = mymalloc("NewStars", NumNewStar*sizeof(int));

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -235,7 +235,7 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
         int *Nextnode_tmp=NULL;
         int *Father_tmp=NULL;
         int *ActiveParticle_tmp=NULL;
-        if(force_tree_allocated()) {
+        if(force_tree_allocated(tt)) {
             nodes_base_tmp = mymalloc2("nodesbasetmp", tt->numnodes * sizeof(struct NODE));
             memmove(nodes_base_tmp, tt->Nodes_base, tt->numnodes * sizeof(struct NODE));
             myfree(tt->Nodes_base);
@@ -265,7 +265,7 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
             memmove(ActiveParticle, ActiveParticle_tmp, NumActiveParticle * sizeof(int));
             myfree(ActiveParticle_tmp);
         }
-        if(force_tree_allocated()) {
+        if(force_tree_allocated(tt)) {
             Nextnode = mymalloc("Nextnode", (PartManager->MaxPart + NTopNodes)* sizeof(int));
             memmove(Nextnode, Nextnode_tmp, (PartManager->MaxPart + NTopNodes) * sizeof(int));
             myfree(Nextnode_tmp);

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -43,11 +43,11 @@ static double get_sfr_factor_due_to_h2(int i);
 static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyeff);
 static double find_star_mass(int i);
 /*Get enough memory for new star slots. This may be excessively slow! Don't do it too often.*/
-static int * sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt);
+static int * sfr_reserve_slots(int * NewStars, int NumNewStar, ForceTree * tt);
 
 
 /* cooling and star formation routine.*/
-void cooling_and_starformation(struct OctTree * tree)
+void cooling_and_starformation(ForceTree * tree)
 {
     if(!All.CoolingOn)
         return;
@@ -216,7 +216,7 @@ void cooling_and_starformation(struct OctTree * tree)
  * It is also not elegant, but I couldn't think of a better way. May be fragile and need updating
  * if memory allocation patterns change. */
 static int *
-sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tree)
+sfr_reserve_slots(int * NewStars, int NumNewStar, ForceTree * tree)
 {
         /* SlotsManager is below Nodes and ActiveParticleList,
          * so we need to move them out of the way before we extend Nodes.

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -236,8 +236,8 @@ sfr_reserve_slots(int * NewStars, int NumNewStar)
         int *Father_tmp=NULL;
         int *ActiveParticle_tmp=NULL;
         if(force_tree_allocated()) {
-            nodes_base_tmp = mymalloc2("nodesbasetmp", NumNodes * sizeof(struct NODE));
-            memmove(nodes_base_tmp, Nodes_base, NumNodes * sizeof(struct NODE));
+            nodes_base_tmp = mymalloc2("nodesbasetmp", TreeNodes.numnodes * sizeof(struct NODE));
+            memmove(nodes_base_tmp, Nodes_base, TreeNodes.numnodes * sizeof(struct NODE));
             myfree(Nodes_base);
             Father_tmp = mymalloc2("Father_tmp", PartManager->MaxPart * sizeof(int));
             memmove(Father_tmp, Father, PartManager->MaxPart * sizeof(int));
@@ -272,8 +272,8 @@ sfr_reserve_slots(int * NewStars, int NumNewStar)
             Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
             memmove(Father, Father_tmp, PartManager->MaxPart * sizeof(int));
             myfree(Father_tmp);
-            Nodes_base = mymalloc("Nodes_base", NumNodes * sizeof(struct NODE));
-            memmove(Nodes_base, nodes_base_tmp, NumNodes * sizeof(struct NODE));
+            Nodes_base = mymalloc("Nodes_base", TreeNodes.numnodes * sizeof(struct NODE));
+            memmove(Nodes_base, nodes_base_tmp, TreeNodes.numnodes * sizeof(struct NODE));
             myfree(nodes_base_tmp);
             /*Don't forget to update the Node pointer as well as Node_base!*/
             Nodes = Nodes_base - TreeNodes.firstnode;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -216,7 +216,7 @@ void cooling_and_starformation(struct OctTree * tree)
  * It is also not elegant, but I couldn't think of a better way. May be fragile and need updating
  * if memory allocation patterns change. */
 static int *
-sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
+sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tree)
 {
         /* SlotsManager is below Nodes and ActiveParticleList,
          * so we need to move them out of the way before we extend Nodes.
@@ -235,16 +235,16 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
         int *Nextnode_tmp=NULL;
         int *Father_tmp=NULL;
         int *ActiveParticle_tmp=NULL;
-        if(force_tree_allocated(tt)) {
-            nodes_base_tmp = mymalloc2("nodesbasetmp", tt->numnodes * sizeof(struct NODE));
-            memmove(nodes_base_tmp, tt->Nodes_base, tt->numnodes * sizeof(struct NODE));
-            myfree(tt->Nodes_base);
+        if(force_tree_allocated(tree)) {
+            nodes_base_tmp = mymalloc2("nodesbasetmp", tree->numnodes * sizeof(struct NODE));
+            memmove(nodes_base_tmp, tree->Nodes_base, tree->numnodes * sizeof(struct NODE));
+            myfree(tree->Nodes_base);
             Father_tmp = mymalloc2("Father_tmp", PartManager->MaxPart * sizeof(int));
-            memmove(Father_tmp, tt->Father, PartManager->MaxPart * sizeof(int));
-            myfree(tt->Father);
+            memmove(Father_tmp, tree->Father, PartManager->MaxPart * sizeof(int));
+            myfree(tree->Father);
             Nextnode_tmp = mymalloc2("Nextnode_tmp", (PartManager->MaxPart + NTopNodes)* sizeof(int));
-            memmove(Nextnode_tmp, tt->Nextnode, (PartManager->MaxPart + NTopNodes) * sizeof(int));
-            myfree(tt->Nextnode);
+            memmove(Nextnode_tmp, tree->Nextnode, (PartManager->MaxPart + NTopNodes) * sizeof(int));
+            myfree(tree->Nextnode);
         }
         if(ActiveParticle) {
             ActiveParticle_tmp = mymalloc2("ActiveParticle_tmp", NumActiveParticle * sizeof(int));
@@ -265,18 +265,18 @@ sfr_reserve_slots(int * NewStars, int NumNewStar, struct OctTree * tt)
             memmove(ActiveParticle, ActiveParticle_tmp, NumActiveParticle * sizeof(int));
             myfree(ActiveParticle_tmp);
         }
-        if(force_tree_allocated(tt)) {
-            tt->Nextnode = mymalloc("Nextnode", (PartManager->MaxPart + NTopNodes)* sizeof(int));
-            memmove(tt->Nextnode, Nextnode_tmp, (PartManager->MaxPart + NTopNodes) * sizeof(int));
+        if(force_tree_allocated(tree)) {
+            tree->Nextnode = mymalloc("Nextnode", (PartManager->MaxPart + NTopNodes)* sizeof(int));
+            memmove(tree->Nextnode, Nextnode_tmp, (PartManager->MaxPart + NTopNodes) * sizeof(int));
             myfree(Nextnode_tmp);
-            tt->Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
-            memmove(tt->Father, Father_tmp, PartManager->MaxPart * sizeof(int));
+            tree->Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
+            memmove(tree->Father, Father_tmp, PartManager->MaxPart * sizeof(int));
             myfree(Father_tmp);
-            tt->Nodes_base = mymalloc("Nodes_base", tt->numnodes * sizeof(struct NODE));
-            memmove(tt->Nodes_base, nodes_base_tmp, tt->numnodes * sizeof(struct NODE));
+            tree->Nodes_base = mymalloc("Nodes_base", tree->numnodes * sizeof(struct NODE));
+            memmove(tree->Nodes_base, nodes_base_tmp, tree->numnodes * sizeof(struct NODE));
             myfree(nodes_base_tmp);
             /*Don't forget to update the Node pointer as well as Node_base!*/
-            tt->Nodes = tt->Nodes_base - tt->firstnode;
+            tree->Nodes = tree->Nodes_base - tree->firstnode;
         }
         if(new_star_tmp) {
             NewStars = mymalloc("NewStars", NumNewStar*sizeof(int));

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -1,6 +1,8 @@
 #ifndef __SFR_H
 #define __SFR_H
 
+#include "forcetree.h"
+
 #ifndef  GENERATIONS
 #define  GENERATIONS     4	/*!< Number of star particles that may be created per gas particle */
 #endif
@@ -8,7 +10,8 @@
 #define  METAL_YIELD       0.02	/*!< effective metal yield for star formation */
 
 void init_cooling_and_star_formation(void);
-void cooling_and_starformation(void);
+/*Do the cooling and the star formation. The tree is required for the winds only.*/
+void cooling_and_starformation(struct OctTree * tree);
 double get_starformation_rate(int i);
 
 #endif

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -11,7 +11,7 @@
 
 void init_cooling_and_star_formation(void);
 /*Do the cooling and the star formation. The tree is required for the winds only.*/
-void cooling_and_starformation(struct OctTree * tree);
+void cooling_and_starformation(ForceTree * tree);
 double get_starformation_rate(int i);
 
 #endif

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -76,14 +76,6 @@ order_by_type_and_key(const void *a, const void *b)
 
 #define NODECACHE_SIZE 100
 
-int force_get_father(int no, int firstnode)
-{
-    if(no >= firstnode)
-        return Nodes[no].father;
-    else
-        return Father[no];
-}
-
 /*This checks that the moments of the force tree in Nodes are valid:
  * that it the mass and flags are correct.*/
 static int check_moments(const struct OctTree tb, const int numpart, const int nrealnode)
@@ -97,7 +89,7 @@ static int check_moments(const struct OctTree tb, const int numpart, const int n
 
     for(i=0; i<numpart; i++)
     {
-        int fnode = Father[i];
+        int fnode = force_get_father(i, tb);
         /*Subtract mass so that nothing is left.*/
         assert_true(fnode >= tb.firstnode && fnode < tb.lastnode);
         while(fnode > 0) {
@@ -209,8 +201,8 @@ static int check_tree(const struct OctTree tb, const int nnodes, const int numpa
                  * must be suffering from particle-coupling */
                 do {
                     P[child].PI += 1;
-                    if(Nextnode[child] > -1) {
-                        assert_int_equal(Father[child], Father[Nextnode[child]]);
+                    if(tb.Nextnode[child] > -1) {
+                        assert_int_equal(force_get_father(child, tb), force_get_father(tb.Nextnode[child], tb)]);
                     }
                     /*Check in right quadrant*/
                     int k;

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -25,7 +25,7 @@ struct OctTree
 force_treeallocate(int maxnodes, int maxpart, int first_node_offset);
 
 int
-force_update_node_parallel(const struct OctTree tb);
+force_update_node_parallel(const struct OctTree * tb);
 
 /*Used data from All and domain*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -262,7 +262,7 @@ static void do_tree_test(const int numpart, const struct OctTree tb)
     int nrealnode = check_tree(&tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
-    int tail = force_update_node_parallel(tb);
+    int tail = force_update_node_parallel(&tb);
     force_set_next_node(tail, -1, &tb);
 /*     assert_true(tail < nodes); */
     end = MPI_Wtime();
@@ -356,7 +356,7 @@ static void test_rebuild_random(void ** state) {
     TopLeaves[0].topnode = numpart;
     int maxnode = numpart;
     struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
-    assert_true(Nodes != NULL);
+    assert_true(tb.Nodes != NULL);
     P = malloc(numpart*sizeof(struct particle_data));
     int i;
     for(i=0; i<2; i++) {

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -31,7 +31,7 @@ force_update_node_parallel(const struct TreeBuilder tb);
 struct part_manager_type PartManager[1] = {{0}};
 struct global_data_all_processes All;
 
-int MaxTopNodes, NTopNodes, NTopLeaves, NTask, ThisTask;
+int NTopNodes, NTopLeaves, NTask, ThisTask;
 struct topleaf_data *TopLeaves;
 struct topnode_data *TopNodes;
 struct task_data *Tasks;
@@ -387,7 +387,6 @@ static int setup_tree(void **state) {
     /* The whole tree goes into one topnode.
      * Set up just enough of the TopNode structure that
      * domain_get_topleaf works*/
-    MaxTopNodes = 1;
     NTopNodes = NTopLeaves = 1;
     TopNodes = malloc(sizeof(struct topnode_data));
     TopNodes[0].Daughter = -1;

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -300,7 +300,7 @@ static void test_rebuild_flat(void ** state) {
     TopLeaves[0].topnode = numpart;
     struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
-    force_tree_free();
+    force_tree_free(&tb);
     free(P);
 }
 
@@ -321,7 +321,7 @@ static void test_rebuild_close(void ** state) {
     }
     struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
-    force_tree_free();
+    force_tree_free(&tb);
     free(P);
 }
 
@@ -370,7 +370,7 @@ static void test_rebuild_random(void ** state) {
     for(i=0; i<2; i++) {
         do_random_test(r, numpart, maxnode, tb);
     }
-    force_tree_free();
+    force_tree_free(&tb);
     free(P);
 }
 

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -19,13 +19,13 @@
 
 /*Defined in forcetree.c*/
 int
-force_tree_create_nodes(const struct OctTree tb, const int npart);
+force_tree_create_nodes(const ForceTree tb, const int npart);
 
-struct OctTree
+ForceTree
 force_treeallocate(int maxnodes, int maxpart, int first_node_offset);
 
 int
-force_update_node_parallel(const struct OctTree * tb);
+force_update_node_parallel(const ForceTree * tb);
 
 /*Used data from All and domain*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -78,7 +78,7 @@ order_by_type_and_key(const void *a, const void *b)
 
 /*This checks that the moments of the force tree in Nodes are valid:
  * that it the mass and flags are correct.*/
-static int check_moments(const struct OctTree * tb, const int numpart, const int nrealnode)
+static int check_moments(const ForceTree * tb, const int numpart, const int nrealnode)
 {
     double * oldmass = malloc(sizeof(double) * tb->numnodes);
     int i;
@@ -161,7 +161,7 @@ static int check_moments(const struct OctTree * tb, const int numpart, const int
 /*This checks that the force tree in Nodes is valid:
  * that it contains every particle and that each parent
  * node contains particles within the right subnode.*/
-static int check_tree(const struct OctTree * tb, const int nnodes, const int numpart)
+static int check_tree(const ForceTree * tb, const int nnodes, const int numpart)
 {
     const int firstnode = tb->firstnode;
     int tot_empty = 0, nrealnode = 0, sevens = 0;
@@ -235,7 +235,7 @@ static int check_tree(const struct OctTree * tb, const int nnodes, const int num
     return nrealnode;
 }
 
-static void do_tree_test(const int numpart, const struct OctTree tb)
+static void do_tree_test(const int numpart, const ForceTree tb)
 {
     /*Sort by peano key so this is more realistic*/
     int i;
@@ -290,7 +290,7 @@ static void test_rebuild_flat(void ** state) {
     /*Allocate tree*/
     /*Base pointer*/
     TopLeaves[0].topnode = numpart;
-    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
+    ForceTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
     force_tree_free(&tb);
     free(P);
@@ -311,13 +311,13 @@ static void test_rebuild_close(void ** state) {
         P[i].Pos[1] = 4. + ((i/ncbrt) % ncbrt) /close;
         P[i].Pos[2] = 4. + (i % ncbrt)/close;
     }
-    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
+    ForceTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
     force_tree_free(&tb);
     free(P);
 }
 
-void do_random_test(gsl_rng * r, const int numpart, const int maxnode, const struct OctTree tb)
+void do_random_test(gsl_rng * r, const int numpart, const int maxnode, const ForceTree tb)
 {
     /* Create a regular grid of particles, 8x8x8, all of type 1,
      * in a box 8 kpc across.*/
@@ -355,7 +355,7 @@ static void test_rebuild_random(void ** state) {
     /*Base pointer*/
     TopLeaves[0].topnode = numpart;
     int maxnode = numpart;
-    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
+    ForceTree tb = force_treeallocate(numpart, numpart, numpart);
     assert_true(tb.Nodes != NULL);
     P = malloc(numpart*sizeof(struct particle_data));
     int i;

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -88,11 +88,11 @@ int force_get_father(int no, int firstnode)
  * that it the mass and flags are correct.*/
 static int check_moments(const struct OctTree tb, const int numpart, const int nrealnode)
 {
-    double * oldmass = malloc(sizeof(double) * MaxNodes);
+    double * oldmass = malloc(sizeof(double) * tb.numnodes);
     int i;
 
-    for(i=tb.firstnode; i < tb.lastnode; i ++) {
-        oldmass[i - tb.firstnode] = Nodes[i].u.d.mass;
+    for(i=tb.firstnode; i < tb.numnodes + tb.firstnode; i ++) {
+        oldmass[i - tb.firstnode] = tb.Nodes[i].u.d.mass;
     }
 
     for(i=0; i<numpart; i++)
@@ -101,8 +101,8 @@ static int check_moments(const struct OctTree tb, const int numpart, const int n
         /*Subtract mass so that nothing is left.*/
         assert_true(fnode >= tb.firstnode && fnode < tb.lastnode);
         while(fnode > 0) {
-            Nodes[fnode].u.d.mass -= P[i].Mass;
-            fnode = Nodes[fnode].father;
+            tb.Nodes[fnode].u.d.mass -= P[i].Mass;
+            fnode = tb.Nodes[fnode].father;
             /*Validate father*/
             assert_true((fnode >= tb.firstnode && fnode < tb.lastnode) || fnode == -1);
         }
@@ -255,11 +255,10 @@ static void do_tree_test(const int numpart, const struct OctTree tb)
     qsort(P, numpart, sizeof(struct particle_data), order_by_type_and_key);
     int maxnode = numpart;
     PartManager->MaxPart = numpart;
-    MaxNodes = numpart;
-    assert_true(Nodes != NULL);
+    assert_true(tb.Nodes != NULL);
     /*So we know which nodes we have initialised*/
-    for(i=0; i< MaxNodes+1; i++)
-        Nodes_base[i].father = -2;
+    for(i=0; i< tb.numnodes+1; i++)
+        tb.Nodes_base[i].father = -2;
     /*Time creating the nodes*/
     double start, end;
     start = MPI_Wtime();
@@ -276,8 +275,8 @@ static void do_tree_test(const int numpart, const struct OctTree tb)
 /*     assert_true(tail < nodes); */
     end = MPI_Wtime();
     ms = (end - start)*1000;
-    printf("Updated moments in %.3g ms. Total mass: %g\n", ms, Nodes[numpart].u.d.mass);
-    assert_true(fabs(Nodes[numpart].u.d.mass - numpart) < 0.5);
+    printf("Updated moments in %.3g ms. Total mass: %g\n", ms, tb.Nodes[numpart].u.d.mass);
+    assert_true(fabs(tb.Nodes[numpart].u.d.mass - numpart) < 0.5);
     check_moments(tb, numpart, nrealnode);
 }
 

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -78,47 +78,47 @@ order_by_type_and_key(const void *a, const void *b)
 
 /*This checks that the moments of the force tree in Nodes are valid:
  * that it the mass and flags are correct.*/
-static int check_moments(const struct OctTree tb, const int numpart, const int nrealnode)
+static int check_moments(const struct OctTree * tb, const int numpart, const int nrealnode)
 {
-    double * oldmass = malloc(sizeof(double) * tb.numnodes);
+    double * oldmass = malloc(sizeof(double) * tb->numnodes);
     int i;
 
-    for(i=tb.firstnode; i < tb.numnodes + tb.firstnode; i ++) {
-        oldmass[i - tb.firstnode] = tb.Nodes[i].u.d.mass;
+    for(i=tb->firstnode; i < tb->numnodes + tb->firstnode; i ++) {
+        oldmass[i - tb->firstnode] = tb->Nodes[i].u.d.mass;
     }
 
     for(i=0; i<numpart; i++)
     {
         int fnode = force_get_father(i, tb);
         /*Subtract mass so that nothing is left.*/
-        assert_true(fnode >= tb.firstnode && fnode < tb.lastnode);
+        assert_true(fnode >= tb->firstnode && fnode < tb->lastnode);
         while(fnode > 0) {
-            tb.Nodes[fnode].u.d.mass -= P[i].Mass;
-            fnode = tb.Nodes[fnode].father;
+            tb->Nodes[fnode].u.d.mass -= P[i].Mass;
+            fnode = tb->Nodes[fnode].father;
             /*Validate father*/
-            assert_true((fnode >= tb.firstnode && fnode < tb.lastnode) || fnode == -1);
+            assert_true((fnode >= tb->firstnode && fnode < tb->lastnode) || fnode == -1);
         }
     }
-    int node = tb.firstnode;
+    int node = tb->firstnode;
     int counter = 0;
     int sibcntr = 0;
     while(node >= 0) {
-        assert_true(node >= -1 && node < tb.lastnode);
+        assert_true(node >= -1 && node < tb->lastnode);
         int next = force_get_next_node(node,tb);
         /*If a real node*/
-        if(node >= tb.firstnode) {
+        if(node >= tb->firstnode) {
             /*Check sibling*/
-            assert_true(Nodes[node].u.d.sibling >= -1 && Nodes[node].u.d.sibling < tb.lastnode);
-            int sib = Nodes[node].u.d.sibling;
-            int sfather = force_get_father(sib, tb.firstnode);
-            int father = force_get_father(node, tb.firstnode);
+            assert_true(tb->Nodes[node].u.d.sibling >= -1 && tb->Nodes[node].u.d.sibling < tb->lastnode);
+            int sib = tb->Nodes[node].u.d.sibling;
+            int sfather = force_get_father(sib, tb);
+            int father = force_get_father(node, tb);
             /* Our sibling should either be a true sibling, with the same father,
              * or should be the child of one of our ancestors*/
             if(sfather != father && sib != -1) {
                 int ances = father;
                 while(ances >= 0) {
-                    assert_true(ances >= tb.firstnode);
-                    ances = force_get_father(ances, tb.firstnode);
+                    assert_true(ances >= tb->firstnode);
+                    ances = force_get_father(ances, tb);
                     if(ances == sfather)
                         break;
                 }
@@ -128,25 +128,25 @@ static int check_moments(const struct OctTree tb, const int numpart, const int n
             else if(sib == -1)
                 sibcntr++;
 
-            if(!(Nodes[node].u.d.mass < 0.5 && Nodes[node].u.d.mass > -0.5)) {
+            if(!(tb->Nodes[node].u.d.mass < 0.5 && tb->Nodes[node].u.d.mass > -0.5)) {
                 printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g MSN %d ITL %d\n", 
-                    node, node - tb.firstnode, Nodes[node].u.d.mass, oldmass[node - tb.firstnode],
-                    Nodes[node].f.TopLevel,
-                    Nodes[node].f.DependsOnLocalMass,
-                    Nodes[node].u.d.MaxSoftening,
-                    Nodes[node].f.MixedSofteningsInNode,
-                    Nodes[node].f.InternalTopLevel
+                    node, node - tb->firstnode, tb->Nodes[node].u.d.mass, oldmass[node - tb->firstnode],
+                    tb->Nodes[node].f.TopLevel,
+                    tb->Nodes[node].f.DependsOnLocalMass,
+                    tb->Nodes[node].u.d.MaxSoftening,
+                    tb->Nodes[node].f.MixedSofteningsInNode,
+                    tb->Nodes[node].f.InternalTopLevel
                     );
                 int nn = force_get_next_node(node, tb);
-                while(nn < tb.firstnode) { /* something is wrong show the particles */
+                while(nn < tb->firstnode) { /* something is wrong show the particles */
                     printf("particles P[%d], Mass=%g\n", nn, P[nn].Mass);
                     nn = force_get_next_node(nn, tb);
                 }
             }
-            assert_true(Nodes[node].u.d.mass < 0.5 && Nodes[node].u.d.mass > -0.5);
+            assert_true(tb->Nodes[node].u.d.mass < 0.5 && tb->Nodes[node].u.d.mass > -0.5);
             /*Check center of mass moments*/
             for(i=0; i<3; i++)
-                assert_true(Nodes[node].u.d.s[i] <= All.BoxSize && Nodes[node].u.d.s[i] >= 0);
+                assert_true(tb->Nodes[node].u.d.s[i] <= All.BoxSize && tb->Nodes[node].u.d.s[i] >= 0);
             counter++;
         }
         node = next;
@@ -161,14 +161,14 @@ static int check_moments(const struct OctTree tb, const int numpart, const int n
 /*This checks that the force tree in Nodes is valid:
  * that it contains every particle and that each parent
  * node contains particles within the right subnode.*/
-static int check_tree(const struct OctTree tb, const int nnodes, const int numpart)
+static int check_tree(const struct OctTree * tb, const int nnodes, const int numpart)
 {
-    const int firstnode = tb.firstnode;
+    const int firstnode = tb->firstnode;
     int tot_empty = 0, nrealnode = 0, sevens = 0;
     int i;
     for(i=firstnode; i<nnodes+firstnode; i++)
     {
-        struct NODE * pNode = &Nodes[i];
+        struct NODE * pNode = &(tb->Nodes[i]);
         int empty = 0;
         /*Just reserved free space with nothing in it*/
         if(pNode->father < -1.5)
@@ -186,13 +186,13 @@ static int check_tree(const struct OctTree tb, const int nnodes, const int numpa
             assert_true(child >= 0);
             /*If an internal node*/
             if(child > firstnode) {
-                assert_true(fabs(Nodes[child].len/pNode->len - 0.5) < 1e-4);
+                assert_true(fabs(tb->Nodes[child].len/pNode->len - 0.5) < 1e-4);
                 int k;
                 for(k=0; k<3; k++) {
                     if(j & (1<<k))
-                        assert_true(Nodes[child].center[k] > pNode->center[k]);
+                        assert_true(tb->Nodes[child].center[k] > pNode->center[k]);
                     else
-                        assert_true(Nodes[child].center[k] <= pNode->center[k]);
+                        assert_true(tb->Nodes[child].center[k] <= pNode->center[k]);
                 }
             }
             /*Particle*/
@@ -201,8 +201,8 @@ static int check_tree(const struct OctTree tb, const int nnodes, const int numpa
                  * must be suffering from particle-coupling */
                 do {
                     P[child].PI += 1;
-                    if(tb.Nextnode[child] > -1) {
-                        assert_int_equal(force_get_father(child, tb), force_get_father(tb.Nextnode[child], tb)]);
+                    if(tb->Nextnode[child] > -1) {
+                        assert_int_equal(force_get_father(child, tb), force_get_father(tb->Nextnode[child], tb));
                     }
                     /*Check in right quadrant*/
                     int k;
@@ -259,17 +259,17 @@ static void do_tree_test(const int numpart, const struct OctTree tb)
     end = MPI_Wtime();
     double ms = (end - start)*1000;
     printf("Number of nodes used: %d. Built tree in %.3g ms\n", nodes,ms);
-    int nrealnode = check_tree(tb, nodes, numpart);
+    int nrealnode = check_tree(&tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
     int tail = force_update_node_parallel(tb);
-    force_set_next_node(tail, -1, tb);
+    force_set_next_node(tail, -1, &tb);
 /*     assert_true(tail < nodes); */
     end = MPI_Wtime();
     ms = (end - start)*1000;
     printf("Updated moments in %.3g ms. Total mass: %g\n", ms, tb.Nodes[numpart].u.d.mass);
     assert_true(fabs(tb.Nodes[numpart].u.d.mass - numpart) < 0.5);
-    check_moments(tb, numpart, nrealnode);
+    check_moments(&tb, numpart, nrealnode);
 }
 
 static void test_rebuild_flat(void ** state) {

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -19,13 +19,13 @@
 
 /*Defined in forcetree.c*/
 int
-force_tree_create_nodes(const struct TreeBuilder tb, const int npart);
+force_tree_create_nodes(const struct OctTree tb, const int npart);
 
-struct TreeBuilder
+struct OctTree
 force_treeallocate(int maxnodes, int maxpart, int first_node_offset);
 
 int
-force_update_node_parallel(const struct TreeBuilder tb);
+force_update_node_parallel(const struct OctTree tb);
 
 /*Used data from All and domain*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -86,7 +86,7 @@ int force_get_father(int no, int firstnode)
 
 /*This checks that the moments of the force tree in Nodes are valid:
  * that it the mass and flags are correct.*/
-static int check_moments(const struct TreeBuilder tb, const int numpart, const int nrealnode)
+static int check_moments(const struct OctTree tb, const int numpart, const int nrealnode)
 {
     double * oldmass = malloc(sizeof(double) * MaxNodes);
     int i;
@@ -169,7 +169,7 @@ static int check_moments(const struct TreeBuilder tb, const int numpart, const i
 /*This checks that the force tree in Nodes is valid:
  * that it contains every particle and that each parent
  * node contains particles within the right subnode.*/
-static int check_tree(const struct TreeBuilder tb, const int nnodes, const int numpart)
+static int check_tree(const struct OctTree tb, const int nnodes, const int numpart)
 {
     const int firstnode = tb.firstnode;
     int tot_empty = 0, nrealnode = 0, sevens = 0;
@@ -243,7 +243,7 @@ static int check_tree(const struct TreeBuilder tb, const int nnodes, const int n
     return nrealnode;
 }
 
-static void do_tree_test(const int numpart, const struct TreeBuilder tb)
+static void do_tree_test(const int numpart, const struct OctTree tb)
 {
     /*Sort by peano key so this is more realistic*/
     int i;
@@ -299,7 +299,7 @@ static void test_rebuild_flat(void ** state) {
     /*Allocate tree*/
     /*Base pointer*/
     TopLeaves[0].topnode = numpart;
-    struct TreeBuilder tb = force_treeallocate(numpart, numpart, numpart);
+    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
     force_tree_free();
     free(P);
@@ -320,13 +320,13 @@ static void test_rebuild_close(void ** state) {
         P[i].Pos[1] = 4. + ((i/ncbrt) % ncbrt) /close;
         P[i].Pos[2] = 4. + (i % ncbrt)/close;
     }
-    struct TreeBuilder tb = force_treeallocate(numpart, numpart, numpart);
+    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
     do_tree_test(numpart, tb);
     force_tree_free();
     free(P);
 }
 
-void do_random_test(gsl_rng * r, const int numpart, const int maxnode, const struct TreeBuilder tb)
+void do_random_test(gsl_rng * r, const int numpart, const int maxnode, const struct OctTree tb)
 {
     /* Create a regular grid of particles, 8x8x8, all of type 1,
      * in a box 8 kpc across.*/
@@ -364,7 +364,7 @@ static void test_rebuild_random(void ** state) {
     /*Base pointer*/
     TopLeaves[0].topnode = numpart;
     int maxnode = numpart;
-    struct TreeBuilder tb = force_treeallocate(numpart, numpart, numpart);
+    struct OctTree tb = force_treeallocate(numpart, numpart, numpart);
     assert_true(Nodes != NULL);
     P = malloc(numpart*sizeof(struct particle_data));
     int i;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -806,7 +806,7 @@ static void fill_task_queue (TreeWalk * tw, struct ev_task * tq, int * pq, int l
         int no = -1;
         /*
         if(0) {
-            no = Father[pq[i]];
+            no = force_get_father(pq[i], TreeNodes);
             while(no != -1) {
                 if(Nodes[no].f.TopLevel) {
                     break;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -220,7 +220,7 @@ treewalk_init_query(TreeWalk * tw, TreeWalkQueryBase * query, int i, int * NodeL
     if(NodeList) {
         memcpy(query->NodeList, NodeList, sizeof(int) * NODELISTLENGTH);
     } else {
-        query->NodeList[0] = RootNode; /* root node */
+        query->NodeList[0] = TreeNodes.firstnode; /* root node */
         query->NodeList[1] = -1; /* terminate immediately */
     }
 
@@ -515,7 +515,7 @@ static void ev_secondary(TreeWalk * tw)
             treewalk_init_result(tw, output, input);
 #ifdef DEBUG
             if(!tw->UseNodeList) {
-                if(input->NodeList[0] != RootNode || input->NodeList[1] != -1)
+                if(input->NodeList[0] != TreeNodes.firstnode || input->NodeList[1] != -1)
                      endrun(2, "Improper NodeList\n");
             }
 #endif
@@ -549,7 +549,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     TreeWalk * tw = lv->tw;
     int task;
 
-    task = TopLeaves[no - (RootNode + MaxNodes)].Task;
+    task = TopLeaves[no - TreeNodes.lastnode].Task;
 
     if(exportflag[task] != target)
     {
@@ -583,7 +583,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     if(tw->UseNodeList)
     {
         DataNodeList[exportindex[task]].NodeList[exportnodecount[task]++] =
-            TopLeaves[no - (RootNode + MaxNodes)].treenode;
+            TopLeaves[no - TreeNodes.lastnode].treenode;
 
         if(exportnodecount[task] < NODELISTLENGTH)
             DataNodeList[exportindex[task]].NodeList[exportnodecount[task]] = -1;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -975,16 +975,17 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
 
     while(no >= 0)
     {
-        if(node_is_particle(no))  /* single particle */ {
+        int nextnode = force_get_next_node(no, TreeNodes);
+        if(node_is_particle(no, TreeNodes))  /* single particle */ {
             lv->ngblist[numcand++] = no;
-            no = Nextnode[no];
+            no = nextnode;
             continue;
         }
-        if(node_is_pseudo_particle(no)) {
+        if(node_is_pseudo_particle(no, TreeNodes)) {
             /* pseudo particle */
             if(lv->mode == 1) {
                 if(!lv->tw->UseNodeList) {
-                    no = Nextnode[no - MaxNodes];
+                    no = nextnode;
                     continue;
                 } else {
                     endrun(12312, "Touching outside of my domain from a node list of a ghost. This shall not happen.");
@@ -994,7 +995,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                     return -1;
             }
 
-            no = Nextnode[no - MaxNodes];
+            no = nextnode;
             continue;
         }
 
@@ -1017,7 +1018,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
         }
 
         /* ok, we need to open the node */
-        no = current->u.d.nextnode;
+        no = nextnode;
         continue;
     }
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -600,7 +600,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
 void
 treewalk_run(TreeWalk * tw, int * active_set, int size)
 {
-    if(!force_tree_allocated()) {
+    if(!force_tree_allocated(&TreeNodes)) {
         endrun(0, "Tree has been freed before this treewalk.\n");
     }
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -975,13 +975,13 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
 
     while(no >= 0)
     {
-        int nextnode = force_get_next_node(no, TreeNodes);
-        if(node_is_particle(no, TreeNodes))  /* single particle */ {
+        int nextnode = force_get_next_node(no, &TreeNodes);
+        if(node_is_particle(no, &TreeNodes))  /* single particle */ {
             lv->ngblist[numcand++] = no;
             no = nextnode;
             continue;
         }
-        if(node_is_pseudo_particle(no, TreeNodes)) {
+        if(node_is_pseudo_particle(no, &TreeNodes)) {
             /* pseudo particle */
             if(lv->mode == 1) {
                 if(!lv->tw->UseNodeList) {

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -220,7 +220,7 @@ treewalk_init_query(TreeWalk * tw, TreeWalkQueryBase * query, int i, int * NodeL
     if(NodeList) {
         memcpy(query->NodeList, NodeList, sizeof(int) * NODELISTLENGTH);
     } else {
-        query->NodeList[0] = TreeNodes.firstnode; /* root node */
+        query->NodeList[0] = tw->tree->firstnode; /* root node */
         query->NodeList[1] = -1; /* terminate immediately */
     }
 
@@ -515,7 +515,7 @@ static void ev_secondary(TreeWalk * tw)
             treewalk_init_result(tw, output, input);
 #ifdef DEBUG
             if(!tw->UseNodeList) {
-                if(input->NodeList[0] != TreeNodes.firstnode || input->NodeList[1] != -1)
+                if(input->NodeList[0] != tw->tree->firstnode || input->NodeList[1] != -1)
                      endrun(2, "Improper NodeList\n");
             }
 #endif
@@ -549,7 +549,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     TreeWalk * tw = lv->tw;
     int task;
 
-    task = TopLeaves[no - TreeNodes.lastnode].Task;
+    task = TopLeaves[no - tw->tree->lastnode].Task;
 
     if(exportflag[task] != target)
     {
@@ -583,7 +583,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     if(tw->UseNodeList)
     {
         DataNodeList[exportindex[task]].NodeList[exportnodecount[task]++] =
-            TopLeaves[no - TreeNodes.lastnode].treenode;
+            TopLeaves[no - tw->tree->lastnode].treenode;
 
         if(exportnodecount[task] < NODELISTLENGTH)
             DataNodeList[exportindex[task]].NodeList[exportnodecount[task]] = -1;
@@ -600,7 +600,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
 void
 treewalk_run(TreeWalk * tw, int * active_set, int size)
 {
-    if(!force_tree_allocated(&TreeNodes)) {
+    if(!force_tree_allocated(tw->tree)) {
         endrun(0, "Tree has been freed before this treewalk.\n");
     }
 
@@ -806,12 +806,12 @@ static void fill_task_queue (TreeWalk * tw, struct ev_task * tq, int * pq, int l
         int no = -1;
         /*
         if(0) {
-            no = force_get_father(pq[i], TreeNodes);
+            no = force_get_father(pq[i], tw->tree);
             while(no != -1) {
-                if(TreeNodes.Nodes[no].f.TopLevel) {
+                if(tw->tree->Nodes[no].f.TopLevel) {
                     break;
                 }
-                no = TreeNodes.Nodes[no].father;
+                no = tw->tree->Nodes[no].father;
             }
         }
        */
@@ -855,7 +855,7 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
 
     for(inode = 0; inode < NODELISTLENGTH && I->NodeList[inode] >= 0; inode++)
     {
-        int startnode = TreeNodes.Nodes[I->NodeList[inode]].u.d.nextnode;  /* open it */
+        int startnode = lv->tw->tree->Nodes[I->NodeList[inode]].u.d.nextnode;  /* open it */
 
         int numcand = ngb_treefind_threads(I, O, iter, startnode, lv);
         /* Export buffer is full end prematurally */
@@ -971,7 +971,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
     int no;
     int numcand = 0;
 
-    const struct OctTree * tree = &TreeNodes;
+    const struct OctTree * tree = lv->tw->tree;
 
     no = startnode;
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -971,7 +971,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
     int no;
     int numcand = 0;
 
-    const struct OctTree * tree = lv->tw->tree;
+    const ForceTree * tree = lv->tw->tree;
 
     no = startnode;
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -808,10 +808,10 @@ static void fill_task_queue (TreeWalk * tw, struct ev_task * tq, int * pq, int l
         if(0) {
             no = force_get_father(pq[i], TreeNodes);
             while(no != -1) {
-                if(Nodes[no].f.TopLevel) {
+                if(TreeNodes.Nodes[no].f.TopLevel) {
                     break;
                 }
-                no = Nodes[no].father;
+                no = TreeNodes.Nodes[no].father;
             }
         }
        */
@@ -855,7 +855,7 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
 
     for(inode = 0; inode < NODELISTLENGTH && I->NodeList[inode] >= 0; inode++)
     {
-        int startnode = Nodes[I->NodeList[inode]].u.d.nextnode;  /* open it */
+        int startnode = TreeNodes.Nodes[I->NodeList[inode]].u.d.nextnode;  /* open it */
 
         int numcand = ngb_treefind_threads(I, O, iter, startnode, lv);
         /* Export buffer is full end prematurally */
@@ -971,17 +971,19 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
     int no;
     int numcand = 0;
 
+    const struct OctTree * tree = &TreeNodes;
+
     no = startnode;
 
     while(no >= 0)
     {
-        int nextnode = force_get_next_node(no, &TreeNodes);
-        if(node_is_particle(no, &TreeNodes))  /* single particle */ {
+        int nextnode = force_get_next_node(no, tree);
+        if(node_is_particle(no, tree))  /* single particle */ {
             lv->ngblist[numcand++] = no;
             no = nextnode;
             continue;
         }
-        if(node_is_pseudo_particle(no, &TreeNodes)) {
+        if(node_is_pseudo_particle(no, tree)) {
             /* pseudo particle */
             if(lv->mode == 1) {
                 if(!lv->tw->UseNodeList) {
@@ -999,7 +1001,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
             continue;
         }
 
-        struct NODE *current = &Nodes[no];
+        struct NODE *current = &tree->Nodes[no];
 
         if(lv->mode == 1) {
             if (lv->tw->UseNodeList) {

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "allvars.h"
 #include "utils/paramset.h"
+#include "forcetree.h"
 
 #define  NODELISTLENGTH      8
 
@@ -73,7 +74,7 @@ struct TreeWalk {
     void * priv;
 
     /* A pointer to the force tree structure to walk.*/
-    struct OctTree * tree;
+    ForceTree * tree;
 
     /* name of the evaluator (used in printing messages) */
     char * ev_label;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -72,6 +72,9 @@ enum TreeWalkType {
 struct TreeWalk {
     void * priv;
 
+    /* A pointer to the force tree structure to walk.*/
+    struct OctTree * tree;
+
     /* name of the evaluator (used in printing messages) */
     char * ev_label;
 

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -79,7 +79,7 @@ static int* NPLeft;
 
 /*Do a treewalk for the wind model. This only changes newly created star particles.*/
 void
-winds_and_feedback(int * NewStars, int NumNewStars, struct OctTree * tree)
+winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree)
 {
     if(!All.WindOn)
         return;

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -79,7 +79,7 @@ static int* NPLeft;
 
 /*Do a treewalk for the wind model. This only changes newly created star particles.*/
 void
-winds_and_feedback(int * NewStars, int NumNewStars)
+winds_and_feedback(int * NewStars, int NumNewStars, struct OctTree * tree)
 {
     if(!All.WindOn)
         return;
@@ -110,6 +110,7 @@ winds_and_feedback(int * NewStars, int NumNewStars)
     tw->UseNodeList = 1;
     tw->query_type_elsize = sizeof(TreeWalkQueryWind);
     tw->result_type_elsize = sizeof(TreeWalkResultWind);
+    tw->tree = tree;
 
     /* sum the total weight of surrounding gas */
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterWind);

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -7,7 +7,7 @@
 void wind_evolve(int i);
 
 /*do the treewalk for the wind model*/
-void winds_and_feedback(int * NewStars, int NumNewStars, struct OctTree * tree);
+void winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree);
 
 /*Make a particle a wind particle by changing DelayTime to a positive number*/
 int make_particle_wind(MyIDType ID, int i, double v, double vmean[3]);

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -7,7 +7,7 @@
 void wind_evolve(int i);
 
 /*do the treewalk for the wind model*/
-void winds_and_feedback(int * NewStars, int NumNewStars);
+void winds_and_feedback(int * NewStars, int NumNewStars, struct OctTree * tree);
 
 /*Make a particle a wind particle by changing DelayTime to a positive number*/
 int make_particle_wind(MyIDType ID, int i, double v, double vmean[3]);


### PR DESCRIPTION
This pull request is a pure cleanup. It removes all the mess of global variables in forcetree.c and replaces them with a single struct. Initially this is a global struct, but in the last commit it is passed around by all the functions using it. There are thus no longer any globals associated with the force tree.

I did this because I was trying to write tests for some of the tree walking routines (gravity and density) and the mess of globals was making it difficult. This PR also fixes runtests, which has been broken for ages because it didn't correctly initialize the tree.

For my next trick: the domain globals.