### PR TITLE
Cleanups to glass files and libGenIC globals

### DIFF
--- a/genic/main.c
+++ b/genic/main.c
@@ -88,6 +88,8 @@ int main(int argc, char **argv)
   }
 
   /*First compute and write CDM*/
+  int NumPart;
+  struct ic_part_data *ICP;
 
   if(!All2.MakeGlassCDM) {
       NumPart = setup_grid(All2.ProduceGas * shift_dm, All2.Ngrid, &ICP);

--- a/genic/main.c
+++ b/genic/main.c
@@ -90,12 +90,12 @@ int main(int argc, char **argv)
   /*First compute and write CDM*/
 
   if(!All2.MakeGlassCDM) {
-      setup_grid(All2.ProduceGas * shift_dm, All2.Ngrid);
+      NumPart = setup_grid(All2.ProduceGas * shift_dm, All2.Ngrid, &ICP);
   } else {
       setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed));
   }
 
-  displacement_fields(DMType, ICP);
+  displacement_fields(DMType, ICP, NumPart);
 
   /*Add a thermal velocity to WDM particles*/
   if(All2.WDM_therm_mass > 0){
@@ -124,31 +124,31 @@ int main(int argc, char **argv)
   }
 
   write_particle_data(1, &bf, 0, All2.Ngrid, ICP, NumPart);
-  free_ffts();
+  myfree(ICP);
 
   /*Now make the gas if required*/
   if(All2.ProduceGas) {
 
     if(!All2.MakeGlassBar) {
-        setup_grid(shift_gas, All2.Ngrid);
+        NumPart = setup_grid(shift_gas, All2.Ngrid, &ICP);
     } else {
         setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1));
     }
 
-    displacement_fields(GasType, ICP);
+    displacement_fields(GasType, ICP, NumPart);
     write_particle_data(0, &bf, TotNumPart, All2.Ngrid, ICP, NumPart);
-    free_ffts();
+    myfree(ICP);
   }
   /*Now add random velocity neutrino particles*/
   if(All2.NGridNu > 0) {
       int i;
       if(!All2.MakeGlassCDM) {
-        setup_grid(shift_nu, All2.NGridNu);
+        NumPart = setup_grid(shift_nu, All2.NGridNu, &ICP);
       } else {
         setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2));
       }
 
-      displacement_fields(NuType, ICP);
+      displacement_fields(NuType, ICP, NumPart);
       unsigned int * seedtable = init_rng(All2.Seed+2,All2.Ngrid);
       gsl_rng * g_rng = gsl_rng_alloc(gsl_rng_ranlxd1);
       /*Just in case*/
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
       myfree(seedtable);
 
       write_particle_data(2,&bf, 2*TotNumPart, All2.NGridNu, ICP, NumPart);
-      free_ffts();
+      myfree(ICP);
   }
 
   big_file_mpi_close(&bf, MPI_COMM_WORLD);

--- a/genic/main.c
+++ b/genic/main.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
       setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed));
   }
 
-  displacement_fields(DMType);
+  displacement_fields(DMType, ICP);
 
   /*Add a thermal velocity to WDM particles*/
   if(All2.WDM_therm_mass > 0){
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1));
     }
 
-    displacement_fields(GasType);
+    displacement_fields(GasType, ICP);
     write_particle_data(0, &bf, TotNumPart, All2.Ngrid);
     free_ffts();
   }
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
         setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2));
       }
 
-      displacement_fields(NuType);
+      displacement_fields(NuType, ICP);
       unsigned int * seedtable = init_rng(All2.Seed+2,All2.Ngrid);
       gsl_rng * g_rng = gsl_rng_alloc(gsl_rng_ranlxd1);
       /*Just in case*/

--- a/genic/main.c
+++ b/genic/main.c
@@ -89,10 +89,10 @@ int main(int argc, char **argv)
 
   /*First compute and write CDM*/
 
-  if(!All2.MakeGlass) {
+  if(!All2.MakeGlassCDM) {
       setup_grid(All2.ProduceGas * shift_dm, All2.Ngrid);
   } else {
-      setup_glass(All2.ProduceGas * shift_dm, All2.Ngrid, GLASS_SEED_HASH(All2.Seed));
+      setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed));
   }
 
   displacement_fields(DMType);
@@ -129,10 +129,10 @@ int main(int argc, char **argv)
   /*Now make the gas if required*/
   if(All2.ProduceGas) {
 
-    if(!All2.MakeGlass) {
+    if(!All2.MakeGlassBar) {
         setup_grid(shift_gas, All2.Ngrid);
     } else {
-        setup_glass(shift_gas, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1));
+        setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1));
     }
 
     displacement_fields(GasType);
@@ -142,10 +142,10 @@ int main(int argc, char **argv)
   /*Now add random velocity neutrino particles*/
   if(All2.NGridNu > 0) {
       int i;
-      if(!All2.MakeGlass) {
+      if(!All2.MakeGlassCDM) {
         setup_grid(shift_nu, All2.NGridNu);
       } else {
-        setup_glass(shift_nu, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2));
+        setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2));
       }
 
       displacement_fields(NuType);

--- a/genic/main.c
+++ b/genic/main.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
   /*Now make the gas if required*/
   if(All2.ProduceGas) {
 
-    if(!All2.MakeGlassBar) {
+    if(!All2.MakeGlassGas) {
         setup_grid(shift_gas, All2.Ngrid, NumPart, ICP);
     } else {
         setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1), NumPart, ICP);

--- a/genic/main.c
+++ b/genic/main.c
@@ -144,12 +144,7 @@ int main(int argc, char **argv)
   /*Now add random velocity neutrino particles*/
   if(All2.NGridNu > 0) {
       int i;
-      if(!All2.MakeGlassCDM) {
-        NumPart = setup_grid(shift_nu, All2.NGridNu, &ICP);
-      } else {
-        NumPart = setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2), &ICP);
-      }
-
+      NumPart = setup_grid(shift_nu, All2.NGridNu, &ICP);
       displacement_fields(NuType, ICP, NumPart);
       unsigned int * seedtable = init_rng(All2.Seed+2,All2.Ngrid);
       gsl_rng * g_rng = gsl_rng_alloc(gsl_rng_ranlxd1);

--- a/genic/main.c
+++ b/genic/main.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
       myfree(seedtable);
   }
 
-  write_particle_data(1, &bf, 0, All2.Ngrid);
+  write_particle_data(1, &bf, 0, All2.Ngrid, ICP, NumPart);
   free_ffts();
 
   /*Now make the gas if required*/
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
     }
 
     displacement_fields(GasType, ICP);
-    write_particle_data(0, &bf, TotNumPart, All2.Ngrid);
+    write_particle_data(0, &bf, TotNumPart, All2.Ngrid, ICP, NumPart);
     free_ffts();
   }
   /*Now add random velocity neutrino particles*/
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
       gsl_rng_free(g_rng);
       myfree(seedtable);
 
-      write_particle_data(2,&bf, 2*TotNumPart, All2.NGridNu);
+      write_particle_data(2,&bf, 2*TotNumPart, All2.NGridNu, ICP, NumPart);
       free_ffts();
   }
 

--- a/genic/main.c
+++ b/genic/main.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
   if(!All2.MakeGlassCDM) {
       NumPart = setup_grid(All2.ProduceGas * shift_dm, All2.Ngrid, &ICP);
   } else {
-      setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed));
+      NumPart = setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed), &ICP);
   }
 
   displacement_fields(DMType, ICP, NumPart);
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     if(!All2.MakeGlassBar) {
         NumPart = setup_grid(shift_gas, All2.Ngrid, &ICP);
     } else {
-        setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1));
+        NumPart = setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 1), &ICP);
     }
 
     displacement_fields(GasType, ICP, NumPart);
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
       if(!All2.MakeGlassCDM) {
         NumPart = setup_grid(shift_nu, All2.NGridNu, &ICP);
       } else {
-        setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2));
+        NumPart = setup_glass(0, All2.Ngrid, GLASS_SEED_HASH(All2.Seed + 2), &ICP);
       }
 
       displacement_fields(NuType, ICP, NumPart);

--- a/genic/params.c
+++ b/genic/params.c
@@ -31,7 +31,7 @@ create_parameters()
     param_declare_int(ps, "Ngrid", REQUIRED, 0, "Size of regular grid on which the undisplaced particles are created.");
     param_declare_int(ps, "NgridNu", OPTIONAL, 0, "Number of neutrino particles created for hybrid neutrinos.");
     param_declare_int(ps, "Seed", REQUIRED, 0, "");
-    param_declare_int(ps, "MakeGlassBar", OPTIONAL, 0, "Generate Glass IC for baryons instead of Grid IC.");
+    param_declare_int(ps, "MakeGlassGas", OPTIONAL, 0, "Generate Glass IC for gas instead of Grid IC.");
     param_declare_int(ps, "MakeGlassCDM", OPTIONAL, 0, "Generate Glass IC for CDM instead of Grid IC.");
 
     param_declare_int(ps, "UnitaryAmplitude", OPTIONAL, 0, "If non-zero, generate unitary gaussians where |g| == 1.0.");
@@ -152,7 +152,7 @@ void read_parameterfile(char *fname)
     All2.UnitaryAmplitude = param_get_int(ps, "UnitaryAmplitude");
     param_get_string2(ps, "OutputDir", All.OutputDir);
     param_get_string2(ps, "FileBase", All.InitCondFile);
-    All2.MakeGlassBar = param_get_int(ps, "MakeGlassBar");
+    All2.MakeGlassGas = param_get_int(ps, "MakeGlassGas");
     All2.MakeGlassCDM = param_get_int(ps, "MakeGlassCDM");
 
     int64_t NumPartPerFile = param_get_int(ps, "NumPartPerFile");

--- a/genic/params.c
+++ b/genic/params.c
@@ -31,7 +31,8 @@ create_parameters()
     param_declare_int(ps, "Ngrid", REQUIRED, 0, "Size of regular grid on which the undisplaced particles are created.");
     param_declare_int(ps, "NgridNu", OPTIONAL, 0, "Number of neutrino particles created for hybrid neutrinos.");
     param_declare_int(ps, "Seed", REQUIRED, 0, "");
-    param_declare_int(ps, "MakeGlass", OPTIONAL, 0, "Generate Glass IC instead of Grid IC.");
+    param_declare_int(ps, "MakeGlassBar", OPTIONAL, 0, "Generate Glass IC for baryons instead of Grid IC.");
+    param_declare_int(ps, "MakeGlassCDM", OPTIONAL, 0, "Generate Glass IC for CDM instead of Grid IC.");
 
     param_declare_int(ps, "UnitaryAmplitude", OPTIONAL, 0, "If non-zero, generate unitary gaussians where |g| == 1.0.");
     param_declare_int(ps, "WhichSpectrum", OPTIONAL, 2, "Type of spectrum, 2 for file ");
@@ -151,7 +152,8 @@ void read_parameterfile(char *fname)
     All2.UnitaryAmplitude = param_get_int(ps, "UnitaryAmplitude");
     param_get_string2(ps, "OutputDir", All.OutputDir);
     param_get_string2(ps, "FileBase", All.InitCondFile);
-    All2.MakeGlass = param_get_int(ps, "MakeGlass");
+    All2.MakeGlassBar = param_get_int(ps, "MakeGlassBar");
+    All2.MakeGlassCDM = param_get_int(ps, "MakeGlassCDM");
 
     int64_t NumPartPerFile = param_get_int(ps, "NumPartPerFile");
 

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -235,7 +235,6 @@ extern struct global_data_all_processes
     enum StarformationCriterion StarformationCriterion;  /*!< flags that star formation is enabled */
     enum WindModel WindModel;  /*!< flags that star formation is enabled */
 
-    int MakeGlassFile; /*!< flags that gravity is reversed and we are making a glass file*/
     int FastParticleType; /*!< flags a particle species to exclude timestep calculations.*/
     /* parameters determining output frequency */
 

--- a/libgenic/allvars.c
+++ b/libgenic/allvars.c
@@ -1,6 +1,3 @@
 #include <libgenic/allvars.h>
 
 struct genic_config All2;
-int NumPart;
-
-struct ic_part_data * ICP;

--- a/libgenic/allvars.h
+++ b/libgenic/allvars.h
@@ -3,7 +3,7 @@
 #include <libgadget/allvars.h>
 #include "power.h"
 
-extern struct ic_part_data
+struct ic_part_data
 {
   double Pos[3];
   float Vel[3];
@@ -11,8 +11,7 @@ extern struct ic_part_data
   float Density;
   float Mass;
   int RegionInd;
-} * ICP;
-extern int NumPart;
+};
 
 struct genic_config {
     int Ngrid, NGridNu;

--- a/libgenic/allvars.h
+++ b/libgenic/allvars.h
@@ -22,7 +22,7 @@ struct genic_config {
     int InvertPhase;
     double Max_nuvel;
     double WDM_therm_mass;
-    int MakeGlassBar;
+    int MakeGlassGas;
     int MakeGlassCDM;
     int  NumFiles;
     struct power_params PowerP;

--- a/libgenic/allvars.h
+++ b/libgenic/allvars.h
@@ -23,8 +23,8 @@ struct genic_config {
     int InvertPhase;
     double Max_nuvel;
     double WDM_therm_mass;
-    int MakeGlass;
-
+    int MakeGlassBar;
+    int MakeGlassCDM;
     int  NumFiles;
     struct power_params PowerP;
 } ;

--- a/libgenic/glass.c
+++ b/libgenic/glass.c
@@ -35,40 +35,20 @@ static PetaPMGlobalFunctions global_functions = {measure_power_spectrum, NULL, p
 
 static PetaPMRegion * _prepare(void * userdata, int * Nregions);
 
-/*Helper function to get size and offset of particles to the global grid.*/
-static int
-get_size_offset(int * size, int * offset, int Ngrid)
-{
-    int * ThisTask2d = petapm_get_thistask2d();
-    int * NTask2d = petapm_get_ntask2d();
-    int k;
-    int npart = 1;
-    for(k = 0; k < 2; k ++) {
-        offset[k] = (ThisTask2d[k]) * Ngrid / NTask2d[k];
-        size[k] = (ThisTask2d[k] + 1) * Ngrid / NTask2d[k];
-        size[k] -= offset[k];
-        npart *= size[k];
-    }
-    offset[2] = 0;
-    size[2] = Ngrid;
-    npart *= size[2];
-    return npart;
-}
+static void glass_force(double t_f, struct ic_part_data * ICP, const int NumPart);
+static void glass_stats(struct ic_part_data * ICP, int NumPart);
 
-static void glass_force(double);
-static void glass_stats(void);
-
-void
-setup_glass(double shift, int Ngrid, int seed)
+int
+setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP)
 {
     int size[3];
     int offset[3];
-    NumPart = get_size_offset(size, offset, Ngrid);
+    int NumPart = get_size_offset(size, offset, Ngrid);
 
     gsl_rng * rng = gsl_rng_alloc(gsl_rng_ranlxd1);
     gsl_rng_set(rng, seed + ThisTask);
 
-    ICP = (struct ic_part_data *) mymalloc("PartTable", NumPart*sizeof(struct ic_part_data));
+    struct ic_part_data * ICP = (struct ic_part_data *) mymalloc("PartTable", NumPart*sizeof(struct ic_part_data));
     memset(ICP, 0, NumPart*sizeof(struct ic_part_data));
 
     int i;
@@ -100,7 +80,7 @@ setup_glass(double shift, int Ngrid, int seed)
     /*Allocate memory for a power spectrum*/
     powerspectrum_alloc(&PowerSpectrum, All.Nmesh, All.NumThreads, 0);
 
-    glass_force(t_x);
+    glass_force(t_x, ICP, NumPart);
 
     /* Our pick of the units ensures there is an oscillation period of 2 * M_PI.
      *
@@ -139,7 +119,7 @@ setup_glass(double shift, int Ngrid, int seed)
         }
         t_v += dt;
 
-        glass_force(t_x);
+        glass_force(t_x, ICP, NumPart);
         t_f = t_x;
 
         /* Kick */
@@ -152,7 +132,7 @@ setup_glass(double shift, int Ngrid, int seed)
 
         t_x += hdt;
         message(0, "Generating glass, step = %d, t_f= %g, t_v = %g, t_x = %g\n", step, t_f / (2 * M_PI), t_v / (2 *M_PI), t_x / (2 * M_PI));
-        glass_stats();
+        glass_stats(ICP, NumPart);
 
         /*Now save the power spectrum*/
         if(ThisTask == 0) {
@@ -164,11 +144,13 @@ setup_glass(double shift, int Ngrid, int seed)
 
     /*We are done with the power spectrum, free it*/
     powerspectrum_free(&PowerSpectrum, 0);
+    *thisICP = ICP;
+    return NumPart;
 }
 
 
 static void
-glass_stats() {
+glass_stats(struct ic_part_data * ICP, int NumPart) {
     int i;
     double disp2 = 0;
     double vel2 = 0;
@@ -191,9 +173,17 @@ glass_stats() {
     message(0, "Force std = %g, vel std = %g\n", sqrt(disp2 / n), sqrt(vel2 / n));
 }
 
+struct ic_prep_data
+{
+    struct ic_part_data * curICP;
+    int NumPart;
+};
+/*Global to pass the particle data to the readout functions*/
+static struct ic_part_data * curICP;
+
 /* Computes the gravitational force on the PM grid
  * and saves the total matter power spectrum.*/
-static void glass_force(double t_f) {
+static void glass_force(double t_f, struct ic_part_data * ICP, const int NumPart) {
 
     PetaPMParticleStruct pstruct = {
         ICP,
@@ -204,6 +194,7 @@ static void glass_force(double t_f) {
         NULL,
         NumPart,
     };
+    curICP = ICP;
 
     int i;
     #pragma omp parallel for
@@ -214,12 +205,13 @@ static void glass_force(double t_f) {
 
     powerspectrum_zero(&PowerSpectrum);
 
+    struct ic_prep_data icprep = {ICP, NumPart};
     /*
      * we apply potential transfer immediately after the R2C transform,
      * Therefore the force transfer functions are based on the potential,
      * not the density.
      * */
-    petapm_force(_prepare, &global_functions, functions, &pstruct, NULL);
+    petapm_force(_prepare, &global_functions, functions, &pstruct, &icprep);
 
     powerspectrum_sum(&PowerSpectrum, All.BoxSize*All.UnitLength_in_cm);
     walltime_measure("/LongRange");
@@ -227,9 +219,13 @@ static void glass_force(double t_f) {
 
 static double pot_factor;
 
-static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
-
+static PetaPMRegion * _prepare(void * userdata, int * Nregions)
+{
+    struct ic_prep_data * icprep = (struct ic_prep_data *) userdata;
+    int NumPart = icprep->NumPart;
+    struct ic_part_data * ICP = icprep->curICP;
     int64_t ntot = NumPart;
+
     MPI_Allreduce(MPI_IN_PLACE, &ntot, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
 
     double nbar = ntot; /* 1 / pow(All.Nmesh, 3) is included by the FFT, screw it. */
@@ -416,11 +412,11 @@ static void force_z_transfer(int64_t k2, int kpos[3], pfft_complex * value) {
     force_transfer(kpos[2], value);
 }
 static void readout_force_x(int i, double * mesh, double weight) {
-    ICP[i].Disp[0] += weight * mesh[0];
+    curICP[i].Disp[0] += weight * mesh[0];
 }
 static void readout_force_y(int i, double * mesh, double weight) {
-    ICP[i].Disp[1] += weight * mesh[0];
+    curICP[i].Disp[1] += weight * mesh[0];
 }
 static void readout_force_z(int i, double * mesh, double weight) {
-    ICP[i].Disp[2] += weight * mesh[0];
+    curICP[i].Disp[2] += weight * mesh[0];
 }

--- a/libgenic/glass.c
+++ b/libgenic/glass.c
@@ -71,7 +71,14 @@ setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP)
 
     gsl_rng_free(rng);
 
+    evolve_glass(seed, ICP, NumPart);
+    *thisICP = ICP;
+    return NumPart;
+}
 
+void evolve_glass(int seed, struct ic_part_data * ICP, const int NumPart)
+{
+    int i;
     int step = 0;
     double t_x = 0;
     double t_v = 0;
@@ -144,8 +151,6 @@ setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP)
 
     /*We are done with the power spectrum, free it*/
     powerspectrum_free(&PowerSpectrum, 0);
-    *thisICP = ICP;
-    return NumPart;
 }
 
 

--- a/libgenic/glass.c
+++ b/libgenic/glass.c
@@ -39,16 +39,14 @@ static void glass_force(double t_f, struct ic_part_data * ICP, const int NumPart
 static void glass_stats(struct ic_part_data * ICP, int NumPart);
 
 int
-setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP)
+setup_glass(double shift, int Ngrid, int seed, int NumPart, struct ic_part_data * ICP)
 {
     int size[3];
     int offset[3];
-    int NumPart = get_size_offset(size, offset, Ngrid);
+    get_size_offset(size, offset, Ngrid);
 
     gsl_rng * rng = gsl_rng_alloc(gsl_rng_ranlxd1);
     gsl_rng_set(rng, seed + ThisTask);
-
-    struct ic_part_data * ICP = (struct ic_part_data *) mymalloc("PartTable", NumPart*sizeof(struct ic_part_data));
     memset(ICP, 0, NumPart*sizeof(struct ic_part_data));
 
     int i;
@@ -72,7 +70,6 @@ setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP)
     gsl_rng_free(rng);
 
     evolve_glass(seed, ICP, NumPart);
-    *thisICP = ICP;
     return NumPart;
 }
 

--- a/libgenic/glass.c
+++ b/libgenic/glass.c
@@ -69,11 +69,11 @@ setup_glass(double shift, int Ngrid, int seed, int NumPart, struct ic_part_data 
 
     gsl_rng_free(rng);
 
-    evolve_glass(seed, ICP, NumPart);
+    glass_evolve(seed, ICP, NumPart);
     return NumPart;
 }
 
-void evolve_glass(int seed, struct ic_part_data * ICP, const int NumPart)
+void glass_evolve(int seed, struct ic_part_data * ICP, const int NumPart)
 {
     int i;
     int step = 0;

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -7,6 +7,7 @@
 void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP, const int NumPart);
 int setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP);
 int setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP);
+void evolve_glass(int seed, struct ic_part_data * ICP, const int NumPart);
 
 int get_size_offset(int * size, int * offset, int Ngrid);
 uint64_t id_offset_from_index(const int i, const int Ngrid);

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -5,8 +5,8 @@
 #include "power.h"
 
 void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP, const int NumPart);
-int setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP);
-int setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP);
+int setup_grid(double shift, int Ngrid, int NumPart, struct ic_part_data * ICP);
+int setup_glass(double shift, int Ngrid, int seed, int NumPart, struct ic_part_data * ICP);
 void evolve_glass(int seed, struct ic_part_data * ICP, const int NumPart);
 
 int get_size_offset(int * size, int * offset, int Ngrid);

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -4,11 +4,10 @@
 #include <stdint.h>
 #include "power.h"
 
-void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP);
-void setup_grid(double shift, int Ngrid);
+void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP, const int NumPart);
+int setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP);
 void setup_glass(double shift, int Ngrid, int seed);
 uint64_t id_offset_from_index(const int i, const int Ngrid);
-void   free_ffts(void);
 
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);
 void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, const int Ngrid, struct ic_part_data * curICP, const int NumPart);

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "power.h"
 
-void   displacement_fields(enum TransferType Type);
+void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP);
 void setup_grid(double shift, int Ngrid);
 void setup_glass(double shift, int Ngrid, int seed);
 uint64_t id_offset_from_index(const int i, const int Ngrid);

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -11,7 +11,7 @@ uint64_t id_offset_from_index(const int i, const int Ngrid);
 void   free_ffts(void);
 
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);
-void  write_particle_data(const int Type, BigFile * bf,  const uint64_t FirstID, const int Ngrid);
+void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, const int Ngrid, struct ic_part_data * curICP, const int NumPart);
 
 void  read_parameterfile(char *fname);
 #endif

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -4,16 +4,32 @@
 #include <stdint.h>
 #include "power.h"
 
+/* Compute the displacement and velocity from the initial homogeneous particle distribution,
+ * using the cosmological transfer functions. */
 void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP, const int NumPart);
-int setup_grid(double shift, int Ngrid, int NumPart, struct ic_part_data * ICP);
-int setup_glass(double shift, int Ngrid, int seed, int NumPart, struct ic_part_data * ICP);
-void evolve_glass(int seed, struct ic_part_data * ICP, const int NumPart);
 
+/* Fill ICP with NumPart particles spaced on a regular 3D grid. */
+int setup_grid(double shift, int Ngrid, int NumPart, struct ic_part_data * ICP);
+
+/* Fill ICP with NumPart particles spaced out as a Lagrangian glass, calling glass_evolve
+ * to move the particles with reversed gravity. */
+int setup_glass(double shift, int Ngrid, int seed, int NumPart, struct ic_part_data * ICP);
+
+/* Evolve a distribution of particles with a reversed gravitational force. */
+void glass_evolve(int seed, struct ic_part_data * ICP, const int NumPart);
+
+/* Returns number of local particles and computes the local offsets in each dimension
+ * for Ngrid^3 particles*/
 int get_size_offset(int * size, int * offset, int Ngrid);
+
+/* Works out the id of a particle from its index and the processor number*/
 uint64_t id_offset_from_index(const int i, const int Ngrid);
 
+/* Save the header of the ICs. */
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);
+/* Save positions, velocities and IDs of a particle type to the ICs. */
 void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, const int Ngrid, struct ic_part_data * curICP, const int NumPart);
 
+/*Read a parameter file*/
 void  read_parameterfile(char *fname);
 #endif

--- a/libgenic/proto.h
+++ b/libgenic/proto.h
@@ -6,7 +6,9 @@
 
 void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP, const int NumPart);
 int setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP);
-void setup_glass(double shift, int Ngrid, int seed);
+int setup_glass(double shift, int Ngrid, int seed, struct ic_part_data ** thisICP);
+
+int get_size_offset(int * size, int * offset, int Ngrid);
 uint64_t id_offset_from_index(const int i, const int Ngrid);
 
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);

--- a/libgenic/save.c
+++ b/libgenic/save.c
@@ -45,7 +45,7 @@ void _bigfile_utils_create_block_from_c_array(BigFile * bf, void * baseptr, char
     }
 }
 
-static void saveblock(BigFile * bf, void * baseptr, int ptype, char * bname, char * dtype, int items_per_particle, ptrdiff_t elsize) {
+static void saveblock(BigFile * bf, void * baseptr, int ptype, char * bname, char * dtype, int items_per_particle, const int NumPart, ptrdiff_t elsize) {
     size_t dims[2];
     char name[128];
     snprintf(name, 128, "%d/%s", ptype, bname);
@@ -56,11 +56,11 @@ static void saveblock(BigFile * bf, void * baseptr, int ptype, char * bname, cha
 }
 
 
-void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, const int Ngrid) {
+void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, const int Ngrid, struct ic_part_data * curICP, const int NumPart) {
     /* Write particles */
-    saveblock(bf, &ICP[0].Density, Type, "ICDensity", "f4", 1, sizeof(ICP[0]));
-    saveblock(bf, &ICP[0].Pos, Type, "Position", "f8", 3, sizeof(ICP[0]));
-    saveblock(bf, &ICP[0].Vel, Type, "Velocity", "f4", 3, sizeof(ICP[0]));
+    saveblock(bf, &curICP[0].Density, Type, "ICDensity", "f4", 1, NumPart, sizeof(curICP[0]));
+    saveblock(bf, &curICP[0].Pos, Type, "Position", "f8", 3, NumPart, sizeof(curICP[0]));
+    saveblock(bf, &curICP[0].Vel, Type, "Velocity", "f4", 3, NumPart, sizeof(curICP[0]));
     /*Generate and write IDs*/
     uint64_t * ids = mymalloc("IDs", NumPart * sizeof(uint64_t));
     memset(ids, 0, NumPart * sizeof(uint64_t));
@@ -70,7 +70,7 @@ void write_particle_data(const int Type, BigFile * bf, const uint64_t FirstID, c
     {
         ids[i] = id_offset_from_index(i, Ngrid) + FirstID;
     }
-    saveblock(bf, ids, Type, "ID", "u8", 1, sizeof(uint64_t));
+    saveblock(bf, ids, Type, "ID", "u8", 1, NumPart, sizeof(uint64_t));
     myfree(ids);
     walltime_measure("/Write");
 }

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -140,16 +140,19 @@ static PetaPMRegion * makeregion(void * userdata, int * Nregions) {
 
 /*Global to pass type to *_transfer functions*/
 static enum TransferType ptype;
+/*Global to pass the particle data to the readout functions*/
+static struct ic_part_data * curICP;
 
-void displacement_fields(enum TransferType Type) {
+void displacement_fields(enum TransferType Type, struct ic_part_data * dispICP) {
     /*MUST set this before doing force.*/
     ptype = Type;
+    curICP = dispICP;
     PetaPMParticleStruct pstruct = {
-        ICP,
-        sizeof(ICP[0]),
-        ((char*) &ICP[0].Pos[0]) - (char*) ICP,
-        ((char*) &ICP[0].Mass) - (char*) ICP,
-        ((char*) &ICP[0].RegionInd) - (char*) ICP,
+        curICP,
+        sizeof(curICP[0]),
+        ((char*) &curICP[0].Pos[0]) - (char*) curICP,
+        ((char*) &curICP[0].Mass) - (char*) curICP,
+        ((char*) &curICP[0].RegionInd) - (char*) curICP,
         NULL,
         NumPart,
     };
@@ -158,9 +161,9 @@ void displacement_fields(enum TransferType Type) {
     #pragma omp parallel for
     for(i = 0; i < NumPart; i++)
     {
-        memset(&ICP[i].Disp[0], 0, sizeof(ICP[i].Disp));
-        memset(&ICP[i].Vel[0], 0, sizeof(ICP[i].Vel));
-        ICP[i].Density = 0;
+        memset(&curICP[i].Disp[0], 0, sizeof(curICP[i].Disp));
+        memset(&curICP[i].Vel[0], 0, sizeof(curICP[i].Vel));
+        curICP[i].Density = 0;
     }
 
 
@@ -225,17 +228,17 @@ void displacement_fields(enum TransferType Type) {
         double absv = 0;
         for(k = 0; k < 3; k++)
         {
-            double dis = ICP[i].Disp[k];
+            double dis = curICP[i].Disp[k];
             if(dis > maxdisp)
                 maxdisp = dis;
             /*Copy displacements to positions.*/
-            ICP[i].Pos[k] += ICP[i].Disp[k];
+            curICP[i].Pos[k] += curICP[i].Disp[k];
             /*Copy displacements to velocities if not done already*/
             if(!All2.PowerP.ScaleDepVelocity)
-                ICP[i].Vel[k] = ICP[i].Disp[k];
-            ICP[i].Vel[k] *= vel_prefac;
-            absv += ICP[i].Vel[k] * ICP[i].Vel[k];
-            ICP[i].Pos[k] = periodic_wrap(ICP[i].Pos[k]);
+                curICP[i].Vel[k] = curICP[i].Disp[k];
+            curICP[i].Vel[k] *= vel_prefac;
+            absv += curICP[i].Vel[k] * curICP[i].Vel[k];
+            curICP[i].Pos[k] = periodic_wrap(curICP[i].Pos[k]);
         }
         if(absv > maxvel)
             maxvel = absv;
@@ -324,26 +327,26 @@ static void disp_z_transfer(int64_t k2, int kpos[3], pfft_complex * value) {
  * functions iterating over particle / mesh pairs
  ***************/
 static void readout_density(int i, double * mesh, double weight) {
-    ICP[i].Density += weight * mesh[0];
+    curICP[i].Density += weight * mesh[0];
 }
 static void readout_vel_x(int i, double * mesh, double weight) {
-    ICP[i].Vel[0] += weight * mesh[0];
+    curICP[i].Vel[0] += weight * mesh[0];
 }
 static void readout_vel_y(int i, double * mesh, double weight) {
-    ICP[i].Vel[1] += weight * mesh[0];
+    curICP[i].Vel[1] += weight * mesh[0];
 }
 static void readout_vel_z(int i, double * mesh, double weight) {
-    ICP[i].Vel[2] += weight * mesh[0];
+    curICP[i].Vel[2] += weight * mesh[0];
 }
 
 static void readout_disp_x(int i, double * mesh, double weight) {
-    ICP[i].Disp[0] += weight * mesh[0];
+    curICP[i].Disp[0] += weight * mesh[0];
 }
 static void readout_disp_y(int i, double * mesh, double weight) {
-    ICP[i].Disp[1] += weight * mesh[0];
+    curICP[i].Disp[1] += weight * mesh[0];
 }
 static void readout_disp_z(int i, double * mesh, double weight) {
-    ICP[i].Disp[2] += weight * mesh[0];
+    curICP[i].Disp[2] += weight * mesh[0];
 }
 
 

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -49,7 +49,7 @@ ijk_to_id(int i, int j, int k, int Ngrid) {
 }
 
 /*Helper function to get size and offset of particles to the global grid.*/
-static int
+int
 get_size_offset(int * size, int * offset, int Ngrid)
 {
     int * ThisTask2d = petapm_get_thistask2d();

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -81,12 +81,11 @@ id_offset_from_index(const int i, const int Ngrid)
 }
 
 int
-setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP)
+setup_grid(double shift, int Ngrid, int NumPart, struct ic_part_data * ICP)
 {
     int size[3];
     int offset[3];
-    int NumPart = get_size_offset(size, offset, Ngrid);
-    struct ic_part_data * ICP = (struct ic_part_data *) mymalloc("PartTable", NumPart*sizeof(struct ic_part_data));
+    get_size_offset(size, offset, Ngrid);
     memset(ICP, 0, NumPart*sizeof(struct ic_part_data));
 
     int i;
@@ -101,7 +100,6 @@ setup_grid(double shift, int Ngrid, struct ic_part_data ** thisICP)
         ICP[i].Pos[2] = z * All.BoxSize / Ngrid + shift;
         ICP[i].Mass = 1.0;
     }
-    *thisICP = ICP;
     return NumPart;
 }
 


### PR DESCRIPTION
This cleans up our glass file support - MakeGlass is replaced with two options, MakeGlassCDM and MakeGlassBar for baryon and CDM glass file support respectively. Neutrinos can't be put into a glass (it makes little sense). The GenIC global particle table variable is removed in preparation (for something I am about to try, but it is a cleanup that makes sense on its own).