### PR TITLE
Fix the neutral fraction output

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -462,9 +462,8 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
                 double redshift = 1./All.Time - 1;
                 double InternalEnergy = DMAX(All.MinEgySpec, SPHP(other).Entropy / GAMMA_MINUS1 * pow(SPHP(other).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
                 double physdens = SPHP(other).Density * All.cf.a3inv;
-                double ne = SPHP(other).Ne;
                 struct UVBG uvbg = get_local_UVBG(redshift, P[other].Pos);
-                double nh0 = get_neutral_fraction(physdens, InternalEnergy, 1 - HYDROGEN_MASSFRAC, &uvbg, &ne);
+                double nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, SPHP(other).Ne);
                 if(r2 > 0)
                     O->FeedbackWeightSum += (P[other].Mass * nh0) / r2;
             } else {

--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -148,3 +148,14 @@ double GetCoolingTime(double redshift, double u_old, double rho, struct UVBG * u
 
     return coolingtime;
 }
+
+/*Gets the neutral fraction from density and internal energy in internal units*/
+double
+GetNeutralFraction(double u_old, double rho, const struct UVBG * uvbg, double ne_init)
+{
+    /* convert to physical cgs units */
+    rho *= coolunits.density_in_phys_cgs / PROTONMASS;
+    u_old *= coolunits.uu_in_cgs;
+    double nh0 = get_neutral_fraction(rho, u_old, 1 - HYDROGEN_MASSFRAC, uvbg, &ne_init);
+    return nh0;
+}

--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -156,6 +156,6 @@ GetNeutralFraction(double u_old, double rho, const struct UVBG * uvbg, double ne
     /* convert to physical cgs units */
     rho *= coolunits.density_in_phys_cgs / PROTONMASS;
     u_old *= coolunits.uu_in_cgs;
-    double nh0 = get_neutral_fraction(rho, u_old, 1 - HYDROGEN_MASSFRAC, uvbg, &ne_init);
+    double nh0 = get_neutral_fraction_phys_cgs(rho, u_old, 1 - HYDROGEN_MASSFRAC, uvbg, &ne_init);
     return nh0;
 }

--- a/libgadget/cooling.h
+++ b/libgadget/cooling.h
@@ -52,10 +52,9 @@ struct UVBG get_local_UVBG(double redshift, double * Pos);
     helium is a mass fraction*/
 double get_temp(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init);
 
-/*Get the neutral hydrogen fraction at a given temperature and density.
-density is gas density in protons/cm^3
-Internal energy is in J/kg == 10^-10 ergs/g.
-helium is a mass fraction.*/
-double get_neutral_fraction(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init);
+/*Gets the neutral fraction from density and internal energy in internal units.
+  u_old is in internal units. rho is in internal physical density units and is converted to
+  physical protons/cm^3 inside the function. */
+double GetNeutralFraction(double u_old, double rho, const struct UVBG * uvbg, double ne);
 
 #endif

--- a/libgadget/cooling_rates.c
+++ b/libgadget/cooling_rates.c
@@ -20,7 +20,7 @@
     These are:
         get_temp() - gets the temperature from the density and internal energy.
         get_heatingcooling_rate() - gets the total (net) heating and cooling rate from density and internal energy.
-        get_neutral_fraction() - gets the neutral fraction from the rate network given density and internal energy.
+        get_neutral_fraction_phys_cgs() - gets the neutral fraction from the rate network given density and internal energy in physical cgs units.
         get_global_UVBG() - Interpolates the TreeCool table to a desired redshift and returns a struct UVBG.
     Two useful helper functions:
         get_equilib_ne() - gets the equilibrium electron density.
@@ -1095,7 +1095,7 @@ density is gas density in protons/cm^3
 Internal energy is in ergs/g.
 helium is a mass fraction.*/
 double
-get_neutral_fraction(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init)
+get_neutral_fraction_phys_cgs(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init)
 {
     double logt;
     double ne = get_equilib_ne(density, ienergy, helium, &logt, uvbg, *ne_init);

--- a/libgadget/cooling_rates.h
+++ b/libgadget/cooling_rates.h
@@ -95,6 +95,6 @@ double get_heatingcooling_rate(double density, double ienergy, double helium, do
 density is gas density in protons/cm^3
 Internal energy is in J/kg == 10^-10 ergs/g.
 helium is a mass fraction.*/
-double get_neutral_fraction(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init);
+double get_neutral_fraction_phys_cgs(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init);
 
 #endif

--- a/libgadget/cooling_rates.h
+++ b/libgadget/cooling_rates.h
@@ -91,4 +91,10 @@ double get_ne_by_nh(double density, double ienergy, double helium, const struct 
  */
 double get_heatingcooling_rate(double density, double ienergy, double helium, double redshift, double metallicity, const struct UVBG * uvbg, double * ne_equilib);
 
+/*Get the neutral hydrogen fraction at a given temperature and density.
+density is gas density in protons/cm^3
+Internal energy is in J/kg == 10^-10 ergs/g.
+helium is a mass fraction.*/
+double get_neutral_fraction(double density, double ienergy, double helium, const struct UVBG * uvbg, double * ne_init);
+
 #endif

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -753,8 +753,7 @@ static void GTNeutralHydrogenFraction(int i, float * out) {
     struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
     double InternalEnergy = DMAX(All.MinEgySpec, SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
     double physdens = SPHP(i).Density * All.cf.a3inv;
-    double ne = SPHP(i).Ne;
-    double nh0 = get_neutral_fraction(physdens, InternalEnergy, 1 - HYDROGEN_MASSFRAC, &uvbg, &ne);
+    double nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, SPHP(i).Ne);
     *out = nh0;
 }
 

--- a/libgadget/tests/test_cooling_rates.c
+++ b/libgadget/tests/test_cooling_rates.c
@@ -131,20 +131,20 @@ static void test_rate_network(void ** state)
     double dens[3] = {1e-4, 1e-5, 1e-6};
     int i;
     for(i = 0; i < 3; i++) {
-        assert_true(fabs(get_neutral_fraction(dens[i], 200.*1e10,0.24, &uvbg, &ne) / dens[i] - 0.3113) < 1e-3);
+        assert_true(fabs(get_neutral_fraction_phys_cgs(dens[i], 200.*1e10,0.24, &uvbg, &ne) / dens[i] - 0.3113) < 1e-3);
     }
     //Neutral (self-shielded) at high density:
-    assert_true(get_neutral_fraction(1, 100.,0.24, &uvbg, &ne) > 0.95);
-    assert_true(0.75 > get_neutral_fraction(0.1, 100.*1e10,0.24, &uvbg, &ne));
-    assert_true(get_neutral_fraction(0.1, 100.*1e10,0.24, &uvbg, &ne) > 0.735);
+    assert_true(get_neutral_fraction_phys_cgs(1, 100.,0.24, &uvbg, &ne) > 0.95);
+    assert_true(0.75 > get_neutral_fraction_phys_cgs(0.1, 100.*1e10,0.24, &uvbg, &ne));
+    assert_true(get_neutral_fraction_phys_cgs(0.1, 100.*1e10,0.24, &uvbg, &ne) > 0.735);
 
     //Check self-shielding is working.
     coolpar.SelfShieldingOn = 0;
     set_coolpar(coolpar);
     init_cooling_rates(TreeCool, MetalCool);
 
-    assert_true( get_neutral_fraction(1, 100.*1e10,0.24, &uvbg, &ne) < 0.25);
-    assert_true( get_neutral_fraction(0.1, 100.*1e10,0.24, &uvbg, &ne) <0.05);
+    assert_true( get_neutral_fraction_phys_cgs(1, 100.*1e10,0.24, &uvbg, &ne) < 0.25);
+    assert_true( get_neutral_fraction_phys_cgs(0.1, 100.*1e10,0.24, &uvbg, &ne) <0.05);
 }
 
 /* This test checks that the heating and cooling rate is as expected.


### PR DESCRIPTION
get_neutral_fraction takes physical protons/cm^3, not internal gadget units.

Create new function that takes the internal units and use it.