### PR TITLE
Sfrneutralfix

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -461,7 +461,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             double mass_j;
             if(HAS(All.BlackHoleFeedbackMethod, BH_FEEDBACK_OPTTHIN)) {
                 double redshift = 1./All.Time - 1;
-                double nh0 = get_neutral_fraction_sfr(other, redshift);
+                double nh0 = get_neutral_fraction_sfreff(other, redshift);
                 if(r2 > 0)
                     O->FeedbackWeightSum += (P[other].Mass * nh0) / r2;
             } else {

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -16,6 +16,7 @@
 #include "blackhole.h"
 #include "timestep.h"
 #include "hydra.h"
+#include "sfr_eff.h"
 /*! \file blackhole.c
  *  \brief routines for gas accretion onto black holes, and black hole mergers
  */
@@ -460,10 +461,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             double mass_j;
             if(HAS(All.BlackHoleFeedbackMethod, BH_FEEDBACK_OPTTHIN)) {
                 double redshift = 1./All.Time - 1;
-                double InternalEnergy = DMAX(All.MinEgySpec, SPHP(other).Entropy / GAMMA_MINUS1 * pow(SPHP(other).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
-                double physdens = SPHP(other).Density * All.cf.a3inv;
-                struct UVBG uvbg = get_local_UVBG(redshift, P[other].Pos);
-                double nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, SPHP(other).Ne);
+                double nh0 = get_neutral_fraction_sfr(other, redshift);
                 if(r2 > 0)
                     O->FeedbackWeightSum += (P[other].Mass * nh0) / r2;
             } else {

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -750,11 +750,7 @@ SIMPLE_PROPERTY(BlackholeJumpToMinPot, BHP(i).JumpToMinPot, int, 1)
 SIMPLE_GETTER(GTGroupID, P[i].GrNr, uint32_t, 1)
 static void GTNeutralHydrogenFraction(int i, float * out) {
     double redshift = 1./All.Time - 1;
-    struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
-    double InternalEnergy = DMAX(All.MinEgySpec, SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
-    double physdens = SPHP(i).Density * All.cf.a3inv;
-    double nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, SPHP(i).Ne);
-    *out = nh0;
+    *out = get_neutral_fraction_sfr(i, redshift);
 }
 
 static void GTInternalEnergy(int i, float * out) {

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -750,7 +750,7 @@ SIMPLE_PROPERTY(BlackholeJumpToMinPot, BHP(i).JumpToMinPot, int, 1)
 SIMPLE_GETTER(GTGroupID, P[i].GrNr, uint32_t, 1)
 static void GTNeutralHydrogenFraction(int i, float * out) {
     double redshift = 1./All.Time - 1;
-    *out = get_neutral_fraction_sfr(i, redshift);
+    *out = get_neutral_fraction_sfreff(i, redshift);
 }
 
 static void GTInternalEnergy(int i, float * out) {

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -40,7 +40,7 @@ static int starformation(int i, double *localsfr, double * sum_sm);
 static int quicklyastarformation(int i);
 static double get_sfr_factor_due_to_selfgravity(int i);
 static double get_sfr_factor_due_to_h2(int i);
-static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot, double * coolfrac);
+static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * coolfrac);
 static double find_star_mass(int i);
 /*Get enough memory for new star slots. This may be excessively slow! Don't do it too often.*/
 static int * sfr_reserve_slots(int * NewStars, int NumNewStar, ForceTree * tt);
@@ -371,7 +371,7 @@ sfreff_on_eeqos(int i)
 }
 
 /*Get the neutral fraction of a particle correctly, accounting for being on the star-forming equation of state*/
-double get_neutral_fraction_sfr(int i, double redshift)
+double get_neutral_fraction_sfreff(int i, double redshift)
 {
     double nh0;
     struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
@@ -561,7 +561,7 @@ double get_starformation_rate(int i) {
     return get_starformation_rate_full(i, 0, NULL, NULL, NULL, NULL);
 }
 
-static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_i, double * coolfrac) {
+static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * coolfrac) {
     double rateOfSF, tsfr;
     double factorEVP, egyhot, ne, tcool, y, x, cloudmass;
 
@@ -575,8 +575,8 @@ static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new,
         if (trelax) {
             *trelax = All.MaxSfrTimescale;
         }
-        if (egyhot_i) {
-            *egyhot_i = All.EgySpecCold;
+        if (egyhot_out) {
+            *egyhot_out = All.EgySpecCold;
         }
         if (coolfrac) {
             *coolfrac = 0;
@@ -621,8 +621,8 @@ static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new,
     if (coolfrac) {
         *coolfrac = x;
     }
-    if(egyhot_i) {
-        *egyhot_i = egyhot;
+    if(egyhot_out) {
+        *egyhot_out = egyhot;
     }
 
     if (HAS(All.StarformationCriterion, SFR_CRITERION_MOLECULAR_H2)) {
@@ -789,7 +789,7 @@ find_star_mass(int i)
  * We really are mostly concerned about H2 here.
  *
  * You may need a license to run with these modess.
- 
+
  * */
 #if defined SPH_GRAD_RHO
 static double ev_NH_from_GradRho(MyFloat gradrho[3], double hsml, double rho, double include_h)

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -40,7 +40,7 @@ static int starformation(int i, double *localsfr, double * sum_sm);
 static int quicklyastarformation(int i);
 static double get_sfr_factor_due_to_selfgravity(int i);
 static double get_sfr_factor_due_to_h2(int i);
-static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * coolfrac);
+static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * cloudfrac);
 static double find_star_mass(int i);
 /*Get enough memory for new star slots. This may be excessively slow! Don't do it too often.*/
 static int * sfr_reserve_slots(int * NewStars, int NumNewStar, ForceTree * tt);
@@ -388,12 +388,12 @@ double get_neutral_fraction_sfreff(int i, double redshift)
          * fraction than the hot gas*/
         double dloga = get_dloga_for_bin(P[i].TimeBin);
         double dtime = dloga / All.cf.hubble;
-        double egyhot, coolfrac;
+        double egyhot, cloudfrac;
         double ne = SPHP(i).Ne;
-        get_starformation_rate_full(i, dtime, &ne, NULL, &egyhot, &coolfrac);
+        get_starformation_rate_full(i, dtime, &ne, NULL, &egyhot, &cloudfrac);
         double nh0cold = GetNeutralFraction(All.EgySpecCold, physdens, &uvbg, ne);
         double nh0hot = GetNeutralFraction(egyhot, physdens, &uvbg, ne);
-        nh0 =  nh0cold * coolfrac + (1-coolfrac) * nh0hot;
+        nh0 =  nh0cold * cloudfrac + (1-cloudfrac) * nh0hot;
     }
     return nh0;
 }
@@ -500,8 +500,8 @@ starformation(int i, double *localsfr, double * sum_sm)
     double dtime = dloga / All.cf.hubble;
     int newstar = -1;
 
-    double coolfrac, trelax, egyhot;
-    double rateOfSF = get_starformation_rate_full(i, dtime, &SPHP(i).Ne, &trelax, &egyhot, &coolfrac);
+    double cloudfrac, trelax, egyhot;
+    double rateOfSF = get_starformation_rate_full(i, dtime, &SPHP(i).Ne, &trelax, &egyhot, &cloudfrac);
 
     /* amount of stars expect to form */
 
@@ -518,7 +518,7 @@ starformation(int i, double *localsfr, double * sum_sm)
 
     if(dloga > 0 && P[i].TimeBin)
     {
-        double egyeff = All.EgySpecCold * coolfrac + (1 - coolfrac) * egyhot;
+        double egyeff = All.EgySpecCold * cloudfrac + (1 - cloudfrac) * egyhot;
         /* upon start-up, we need to protect against dloga ==0 */
         cooling_relaxed(i, egyeff, dtime, trelax);
     }
@@ -561,7 +561,7 @@ double get_starformation_rate(int i) {
     return get_starformation_rate_full(i, 0, NULL, NULL, NULL, NULL);
 }
 
-static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * coolfrac) {
+static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyhot_out, double * cloudfrac) {
     double rateOfSF, tsfr;
     double factorEVP, egyhot, ne, tcool, y, x, cloudmass;
 
@@ -578,8 +578,8 @@ static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new,
         if (egyhot_out) {
             *egyhot_out = All.EgySpecCold;
         }
-        if (coolfrac) {
-            *coolfrac = 0;
+        if (cloudfrac) {
+            *cloudfrac = 0;
         }
 
         return 0;
@@ -618,8 +618,8 @@ static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new,
     if (trelax) {
         *trelax = tsfr * (1 - x) / x / (All.FactorSN * (1 + factorEVP));
     }
-    if (coolfrac) {
-        *coolfrac = x;
+    if (cloudfrac) {
+        *cloudfrac = x;
     }
     if(egyhot_out) {
         *egyhot_out = egyhot;

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -14,4 +14,9 @@ void init_cooling_and_star_formation(void);
 void cooling_and_starformation(ForceTree * tree);
 double get_starformation_rate(int i);
 
+/*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
+ * This calls the cooling routines for the current internal energy when off the equation of state, but
+ * when on the equation of state calls them separately for the cold and hot gas.*/
+double get_neutral_fraction_sfr(int i, double redshift);
+
 #endif

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -17,6 +17,6 @@ double get_starformation_rate(int i);
 /*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
  * This calls the cooling routines for the current internal energy when off the equation of state, but
  * when on the equation of state calls them separately for the cold and hot gas.*/
-double get_neutral_fraction_sfr(int i, double redshift);
+double get_neutral_fraction_sfreff(int i, double redshift);
 
 #endif


### PR DESCRIPTION
This fixes a very old bug in Gadget: that the neutral fraction on the effective equation of state is reported as
GetNeutralFraction(egyeff) (which is usually << 1) when it should be GetNeutralFraction(egycold) * cold cloud fraction + GetNeutralFraction(egyhot) * (1- cold cloud fraction) (which is usually ~ 1). I fix this now because Jamie Bolton got caught by it in Illustris.

This normally only affects the NH0 saved in the snapshots for star-forming particles, and I would not even ask for a review if that were all. However, the second commit changes the BH_OPTHIN AGN feedback by reweighting the feedback energy more towards dense particles (in that method feedback is weighted by neutral fraction). Do we use that method anywhere? Does that seem plausible? It is certainly more physical, but AGN feedback is not based on physics anyway so it might have negative consequences.