### PR TITLE
Barriers

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -386,8 +386,6 @@ void read_parameter_file(char *fname)
         All.CP.Omega_ur = param_get_double(ps, "Omega_ur");
         All.CP.HubbleParam = param_get_double(ps, "HubbleParam");
 
-        All.DomainOverDecompositionFactor = param_get_int(ps, "DomainOverDecompositionFactor");
-        All.DomainUseGlobalSorting = param_get_int(ps, "DomainUseGlobalSorting");
         All.OutputPotential = param_get_int(ps, "OutputPotential");
         double MaxMemSizePerNode = param_get_double(ps, "MaxMemSizePerNode");
         if(MaxMemSizePerNode <= 1) {
@@ -437,7 +435,6 @@ void read_parameter_file(char *fname)
         All.GravitySofteningGas = param_get_double(ps, "GravitySofteningGas");
 
         All.PartAllocFactor = param_get_double(ps, "PartAllocFactor");
-        All.TopNodeAllocFactor = param_get_double(ps, "TopNodeAllocFactor");
         All.SlotsIncreaseFactor = param_get_double(ps, "SlotsIncreaseFactor");
 
         All.SnapshotWithFOF = param_get_int(ps, "SnapshotWithFOF");
@@ -553,6 +550,7 @@ void read_parameter_file(char *fname)
 
     set_cooling_params(ps);
     set_treewalk_params(ps);
+    set_domain_params(ps);
 
     parameter_set_free(ps);
 }

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -149,9 +149,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeMax", OPTIONAL, 1.0, "Scale factor to end run.");
     param_declare_double(ps, "TimeLimitCPU", REQUIRED, 0, "CPU time to run for in seconds.");
 
-    param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 1, "Create on average this number of sub domains on a MPI rank. Load balancer will try to create this number of equal sized chunks on each rank. Higher numbers improve the load balancing but make domain more expensive.");
+    param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 4, "Create on average this number of sub domains on a MPI rank. Load balancer will then move these subdomains around to equalize the work per rank. Higher numbers improve the load balancing but make domain more expensive.");
     param_declare_int   (ps, "DomainUseGlobalSorting", OPTIONAL, 1, "Determining the initial refinement of chunks globally. Enabling this produces better domains at costs of slowing down the domain decomposition.");
-    param_declare_int   (ps, "TopNodeIncreaseFactor", OPTIONAL, 4, "Create on average this number of topNodes per MPI rank. Higher numbers improve the load balancing but make domain more expensive. Similar to DomainOverDecompositionFactor, but ignored by load balancer.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
     param_declare_double(ps, "BHOpeningAngle", OPTIONAL, 0.175, "Barnes-Hut opening angle. Alternative purely geometric tree opening angle. Lower values are more accurate.");
@@ -389,7 +388,6 @@ void read_parameter_file(char *fname)
 
         All.DomainOverDecompositionFactor = param_get_int(ps, "DomainOverDecompositionFactor");
         All.DomainUseGlobalSorting = param_get_int(ps, "DomainUseGlobalSorting");
-        All.TopNodeIncreaseFactor = param_get_int(ps, "TopNodeIncreaseFactor");
         All.OutputPotential = param_get_int(ps, "OutputPotential");
         double MaxMemSizePerNode = param_get_double(ps, "MaxMemSizePerNode");
         if(MaxMemSizePerNode <= 1) {

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -206,13 +206,10 @@ extern struct global_data_all_processes
     /* Code options */
     /* Number of sub-domains per processor. TopNodes are refined so that no TopNode contains
      * no more than 1/(DODF * NTask) fraction of the work.
-     * Then the load balancer will aim to produce DODF*NTask equal-sized chunks, distributed
+     * Then the load balancer will aim to produce NTask equal-sized chunks, distributed
      * evenly across MPI ranks.*/
     int DomainOverDecompositionFactor;
     int DomainUseGlobalSorting;
-    /* Sets average TopNodes per MPI rank. Like DomainOverDecompositionFactor
-     * but only changes refinement, not load balancing.*/
-    int TopNodeIncreaseFactor;
 
     int CoolingOn;  /* if cooling is enabled */
     int HydroOn;  /*  if hydro force is enabled */

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -170,10 +170,6 @@ extern struct global_data_all_processes
                               NOT be balanced.  Each processor allocates memory for PartAllocFactor times
                               the average number of particles to allow for that */
 
-    double TreeAllocFactor;	/*!< Each processor allocates a number of nodes which is TreeAllocFactor times
-                              the maximum(!) number of particles.  Note: A typical local tree for N
-                              particles needs usually about ~0.65*N nodes. */
-
     double TopNodeAllocFactor;	/*!< Each processor allocates a number of nodes which is TreeAllocFactor times
                                   the maximum(!) number of particles.  Note: A typical local tree for N
                                   particles needs usually about ~0.65*N nodes. */
@@ -321,7 +317,6 @@ extern struct global_data_all_processes
     double GravitySoftening; /* Softening as a fraction of DM mean separation. */
     double GravitySofteningGas;  /* if 0, enable adaptive gravitational softening for gas particles, which uses the Hsml as ForceSoftening */
 
-    double TreeNodeMinSize; /* The minimum size of a Force Tree Node in length units. */
     double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
     /* some filenames */

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -170,10 +170,6 @@ extern struct global_data_all_processes
                               NOT be balanced.  Each processor allocates memory for PartAllocFactor times
                               the average number of particles to allow for that */
 
-    double TopNodeAllocFactor;	/*!< Each processor allocates a number of nodes which is TreeAllocFactor times
-                                  the maximum(!) number of particles.  Note: A typical local tree for N
-                                  particles needs usually about ~0.65*N nodes. */
-
     double SlotsIncreaseFactor; /* !< What percentage to increase the slot allocation by when requested*/
     int OutputPotential;        /*!< Flag whether to include the potential in snapshots*/
 
@@ -204,13 +200,6 @@ extern struct global_data_all_processes
     Cosmology CP;
 
     /* Code options */
-    /* Number of sub-domains per processor. TopNodes are refined so that no TopNode contains
-     * no more than 1/(DODF * NTask) fraction of the work.
-     * Then the load balancer will aim to produce NTask equal-sized chunks, distributed
-     * evenly across MPI ranks.*/
-    int DomainOverDecompositionFactor;
-    int DomainUseGlobalSorting;
-
     int CoolingOn;  /* if cooling is enabled */
     int HydroOn;  /*  if hydro force is enabled */
     int DensityOn;  /*  if SPH density computation is enabled */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -178,6 +178,7 @@ void blackhole(ForceTree * tree)
     tw_feedback->result_type_elsize = sizeof(TreeWalkResultBHFeedback);
     tw_feedback->tree = tree;
 
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Beginning black-hole accretion\n");
 
     N_sph_swallowed = N_BH_swallowed = 0;
@@ -186,6 +187,7 @@ void blackhole(ForceTree * tree)
 
     treewalk_run(tw_accretion, ActiveParticle, NumActiveParticle);
 
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Start swallowing of gas particles and black holes\n");
 
     /* Now do the swallowing of particles and dump feedback energy */
@@ -194,6 +196,7 @@ void blackhole(ForceTree * tree)
     MPI_Reduce(&N_sph_swallowed, &Ntot_gas_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&N_BH_swallowed, &Ntot_BH_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Accretion done: %d gas particles swallowed, %d BH particles swallowed\n",
                 Ntot_gas_swallowed, Ntot_BH_swallowed);
 

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -229,6 +229,8 @@ void domain_decompose_full(DomainDecomp * ddecomp)
      *the same as the particles, garbage is at the end and all particles are in peano order.*/
     slots_gc_sorted();
 
+    /*Ensure collective*/
+    MPI_Barrier(ddecomp->DomainComm);
     message(0, "Domain decomposition done.\n");
 
     report_memory_usage("DOMAIN");

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -173,13 +173,9 @@ void domain_decompose_full(DomainDecomp * ddecomp)
         Npolicies = domain_policies_init(policies, NincreaseAlloc, 8);
     }
 
-    double t0, t1;
-
     walltime_measure("/Misc");
 
     message(0, "domain decomposition... (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
-
-    t0 = second();
 
     int decompose_failed = 1;
     int i;
@@ -233,9 +229,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
      *the same as the particles, garbage is at the end and all particles are in peano order.*/
     slots_gc_sorted();
 
-    t1 = second();
-
-    message(0, "domain decomposition done. (took %g sec)\n", timediff(t0, t1));
+    message(0, "Domain decomposition done.\n");
 
     report_memory_usage("DOMAIN");
 

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -524,12 +524,7 @@ domain_assign_balanced(DomainDecomp * ddecomp, int64_t * cost)
 
     /* A Segment is a subset of the TopLeaf nodes */
 
-    int Nsegment = All.DomainOverDecompositionFactor * NTask;
-
-    /* When would this ever happen?*/
-    if((size_t) All.DomainOverDecompositionFactor * NTask >= (1L << 31)) {
-        endrun(0, "Too many segments requested, overflowing integer\n");
-    }
+    int Nsegment = NTask;
 
     TopLeafExt = (struct topleaf_extdata *) mymalloc("TopLeafExt", ddecomp->NTopLeaves * sizeof(TopLeafExt[0]));
 
@@ -1160,16 +1155,16 @@ int domain_determine_global_toptree(DomainDecompositionPolicy * policy,
     MPI_Allreduce(&topTree[0].Cost, &TotCost, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&topTree[0].Count, &TotCount, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
 
-    costlimit = TotCost / (All.TopNodeIncreaseFactor * All.DomainOverDecompositionFactor * NTask);
-    countlimit = TotCount / (All.TopNodeIncreaseFactor * All.DomainOverDecompositionFactor * NTask);
+    costlimit = TotCost / (All.DomainOverDecompositionFactor * NTask);
+    countlimit = TotCount / (All.DomainOverDecompositionFactor * NTask);
 
     domain_toptree_truncate(topTree, topTreeSize, countlimit, costlimit);
 
     walltime_measure("/Domain/DetermineTopTree/LocalRefine/truncate");
 
-    if(*topTreeSize > 4 * All.DomainOverDecompositionFactor * NTask * All.TopNodeIncreaseFactor) {
+    if(*topTreeSize > 4 * All.DomainOverDecompositionFactor * NTask) {
         message(1, "local TopTree Size =%d >> expected = %d; Usually this indicates very bad imbalance, due to a giant density peak.\n",
-            *topTreeSize, 4 * All.DomainOverDecompositionFactor * NTask * All.TopNodeIncreaseFactor);
+            *topTreeSize, 4 * All.DomainOverDecompositionFactor * NTask);
     }
 
 #if 0

--- a/libgadget/domain.h
+++ b/libgadget/domain.h
@@ -2,6 +2,7 @@
 #define DOMAIN_H
 
 #include "utils/peano.h"
+#include "utils/paramset.h"
 
 /*These variables are used externally in forcetree.c.
  * DomainTask is also used in treewalk and NTopLeaves is used in gravpm.c*/
@@ -38,7 +39,12 @@ typedef struct DomainDecomp {
     struct task_data * Tasks;
 } DomainDecomp;
 
+/*Set the parameters of the domain module*/
+void set_domain_params(ParameterSet * ps);
+
+/* Do a full domain decomposition, which splits the particles into even clumps*/
 void domain_decompose_full(DomainDecomp * ddecomp);
+/* Exchange particles which have moved into the new domains, not re-doing the split unless we have to*/
 void domain_maintain(DomainDecomp * ddecomp);
 
 /** This function determines the TopLeaves entry for the given key.*/

--- a/libgadget/domain.h
+++ b/libgadget/domain.h
@@ -37,6 +37,9 @@ typedef struct DomainDecomp {
     int NTopNodes;
     int NTopLeaves;
     struct task_data * Tasks;
+    /* MPI Communicator over which to build the Domain.
+     * Currently this is always MPI_COMM_WORLD.*/
+    MPI_Comm DomainComm;
 } DomainDecomp;
 
 /*Set the parameters of the domain module*/

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -328,8 +328,6 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc)
     }
     myfree(partBuf);
 
-    MPI_Barrier(MPI_COMM_WORLD);
-
     PartManager->NumPart = newNumPart;
 
     for(ptype = 0; ptype < 6; ptype++) {

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -498,7 +498,6 @@ void
 domain_test_id_uniqueness(void)
 {
     int i;
-    double t0, t1;
     MyIDType *ids, *ids_first;
 
     message(0, "Testing ID uniqueness...\n");
@@ -507,8 +506,6 @@ domain_test_id_uniqueness(void)
     {
         endrun(8, "need at least one particle per cpu\n");
     }
-
-    t0 = second();
 
     ids = (MyIDType *) mymalloc("ids", PartManager->NumPart * sizeof(MyIDType));
     ids_first = (MyIDType *) mymalloc("ids_first", NTask * sizeof(MyIDType));
@@ -547,9 +544,5 @@ domain_test_id_uniqueness(void)
 
     myfree(ids_first);
     myfree(ids);
-
-    t1 = second();
-
-    message(0, "success.  took=%g sec\n", timediff(t0, t1));
 }
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -130,7 +130,6 @@ static MPI_Datatype MPI_TYPE_GROUP;
 void fof_fof(ForceTree * tree)
 {
     int i;
-    double t0, t1;
 
     MPI_Type_contiguous(sizeof(Group[0]), MPI_BYTE, &MPI_TYPE_GROUP);
     MPI_Type_commit(&MPI_TYPE_GROUP);
@@ -150,25 +149,19 @@ void fof_fof(ForceTree * tree)
         HaloLabel[i].Pindex = i;
     }
     /* Fill FOFP_List of primary */
-    t0 = second();
     fof_label_primary(tree);
-    t1 = second();
 
-    message(0, "group finding took = %g sec\n", timediff(t0, t1));
+    message(0, "Group finding done.\n");
     walltime_measure("/FOF/Primary");
 
     /* Fill FOFP_List of secondary */
-    t0 = second();
     fof_label_secondary(tree);
     walltime_measure("/FOF/Secondary");
-    t1 = second();
 
-    message(0, "attaching gas and star particles to nearest dm particles took = %g sec\n", timediff(t0, t1));
+    message(0, "Attached gas and star particles to nearest dm particles.\n");
 
     /* sort HaloLabel according to MinID, because we need that for compiling catalogues */
     qsort_openmp(HaloLabel, PartManager->NumPart, sizeof(struct fof_particle_list), fof_compare_HaloLabel_MinID);
-
-    t0 = second();
 
     NgroupsExt = 0;
 
@@ -182,15 +175,11 @@ void fof_fof(ForceTree * tree)
 
     fof_compile_base(base);
 
-    t1 = second();
-
-    message(0, "compiling local group data and catalogue took = %g sec\n", timediff(t0, t1));
+    message(0, "Compiled local group data and catalogue.\n");
 
     walltime_measure("/FOF/Compile");
 
     fof_assign_grnr(base);
-
-    t0 = second();
 
     /*Initialise the Group object from the BaseGroup*/
     Group = fof_alloc_group(base, NgroupsExt);
@@ -198,14 +187,11 @@ void fof_fof(ForceTree * tree)
     myfree(base);
 
     fof_compile_catalogue(Group);
-    t1 = second();
 
     walltime_measure("/FOF/Prop");
 
-    message(0, "group properties are now allocated.. (presently allocated=%g MB)\n",
+    message(0, "Finished FoF. Group properties are now allocated.. (presently allocated=%g MB)\n",
             mymalloc_usedbytes() / (1024.0 * 1024.0));
-
-    message(0, "computation of group properties took = %g sec\n", timediff(t0, t1));
 
     myfree(HaloLabel);
 }
@@ -1022,17 +1008,11 @@ static void fof_assign_grnr(struct BaseGroup * base)
 void
 fof_save_groups(int num)
 {
-    double t0, t1;
-
     message(0, "start global sorting of group catalogues\n");
-
-    t0 = second();
 
     fof_save_particles(num);
 
-    t1 = second();
-
-    message(0, "Group catalogues saved. took = %g sec\n", timediff(t0, t1));
+    message(0, "Group catalogues saved.\n");
 }
 
 /* FIXME: these shall goto the private member of secondary tree walk */

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -151,14 +151,13 @@ void fof_fof(ForceTree * tree)
     /* Fill FOFP_List of primary */
     fof_label_primary(tree);
 
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Group finding done.\n");
     walltime_measure("/FOF/Primary");
 
     /* Fill FOFP_List of secondary */
     fof_label_secondary(tree);
     walltime_measure("/FOF/Secondary");
-
-    message(0, "Attached gas and star particles to nearest dm particles.\n");
 
     /* sort HaloLabel according to MinID, because we need that for compiling catalogues */
     qsort_openmp(HaloLabel, PartManager->NumPart, sizeof(struct fof_particle_list), fof_compare_HaloLabel_MinID);
@@ -175,6 +174,7 @@ void fof_fof(ForceTree * tree)
 
     fof_compile_base(base);
 
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Compiled local group data and catalogue.\n");
 
     walltime_measure("/FOF/Compile");
@@ -188,10 +188,11 @@ void fof_fof(ForceTree * tree)
 
     fof_compile_catalogue(Group);
 
-    walltime_measure("/FOF/Prop");
-
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Finished FoF. Group properties are now allocated.. (presently allocated=%g MB)\n",
             mymalloc_usedbytes() / (1024.0 * 1024.0));
+
+    walltime_measure("/FOF/Prop");
 
     myfree(HaloLabel);
 }
@@ -1149,7 +1150,8 @@ static void fof_label_secondary(ForceTree * tree)
     myfree(FOF_SECONDARY_GET_PRIV(tw)->hsml);
     myfree(FOF_SECONDARY_GET_PRIV(tw)->distance);
 
-    message(0, "done finding nearest dm-particle\n");
+    MPI_Barrier(MPI_COMM_WORLD);
+    message(0, "Attached gas and star particles to nearest dm particles.\n");
 }
 
 static void

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -29,9 +29,10 @@
 
 static struct forcetree_params
 {
-    /*!< Each processor allocates a number of nodes which is TreeAllocFactor times
-         the maximum(!) number of particles.  Note: A typical local tree for N
-         particles needs usually about ~0.65*N nodes. */
+    /* Each processor allocates a number of nodes which is TreeAllocFactor times
+       the maximum(!) number of particles.  Note: A typical local tree for N
+       particles needs usually about ~0.65*N nodes.
+       If the allocated memory is not sufficient, this parameter will be increased.*/
     double TreeAllocFactor;
     /* The minimum size of a Force Tree Node in length units. */
     double TreeNodeMinSize;

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -110,6 +110,7 @@ force_tree_allocated(const ForceTree * tree)
 void
 force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp, const double BoxSize, const int HybridNuGrav)
 {
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Tree construction.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     if(force_tree_allocated(tree)) {
@@ -121,9 +122,9 @@ force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp, const double BoxSiz
 
     event_listen(&EventSlotsFork, force_tree_eh_slots_fork, tree);
 
-    walltime_measure("/Tree/Build");
-
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Tree construction done.\n");
+    walltime_measure("/Tree/Build");
 }
 
 /*! This function is a driver routine for constructing the gravitational

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -76,13 +76,16 @@ typedef struct ForceTree {
     int *Father;
 } ForceTree;
 
+/*Initialize the internal parameters of the forcetree module*/
+void init_forcetree_params(const int FastParticleType, const double * GravitySofteningTable);
+
 int force_tree_allocated(const ForceTree * tt);
 
 /* This function propagates changed SPH smoothing lengths up the tree*/
 void force_update_hmax(int * activeset, int size, ForceTree * tt);
 
-/*This is the main constructor for the tree structure. Pass in something empty.*/
-void force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp);
+/*This is the main constructor for the tree structure. Pass in something empty for tree.*/
+void force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp, const double BoxSize, const int HybridNuGrav);
 
 /*Free the memory associated with the tree*/
 void   force_tree_free(ForceTree * tt);

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -84,7 +84,9 @@ int force_tree_allocated(const ForceTree * tt);
 /* This function propagates changed SPH smoothing lengths up the tree*/
 void force_update_hmax(int * activeset, int size, ForceTree * tt);
 
-/*This is the main constructor for the tree structure. Pass in something empty for tree.*/
+/* This is the main constructor for the tree structure.
+   The tree shall be either zero-filled, so that force_tree_allocated = 0, or a valid ForceTree.
+*/
 void force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp, const double BoxSize, const int HybridNuGrav);
 
 /*Free the memory associated with the tree*/

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -68,6 +68,7 @@ void grav_short_tree(ForceTree * tree)
     walltime_measure("/Misc");
 
     /* allocate buffers to arrange communication */
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Begin tree force.  (presently allocated=%g MB)\n", mymalloc_usedbytes() / (1024.0 * 1024.0));
 
     walltime_measure("/Misc");
@@ -76,7 +77,8 @@ void grav_short_tree(ForceTree * tree)
 
     /* now add things for comoving integration */
 
-    message(0, "tree is done.\n");
+    MPI_Barrier(MPI_COMM_WORLD);
+    message(0, "Short-range gravitational tree force is done.\n");
 
     /* Now the force computation is finished */
 

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -80,8 +80,6 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
     All.SnapshotFileCount = RestartSnapNum + 1;
     All.InitSnapshotCount = RestartSnapNum + 1;
 
-    All.TreeAllocFactor = 0.7;
-
     #pragma omp parallel for
     for(i = 0; i < PartManager->NumPart; i++)	/* initialize sph_properties */
     {
@@ -190,7 +188,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
     const double a3 = All.Time * All.Time * All.Time;
 
     ForceTree Tree = {0};
-    force_tree_rebuild(&Tree, ddecomp);
+    force_tree_rebuild(&Tree, ddecomp, All.BoxSize, 0);
 
     if(RestartSnapNum == -1)
     {

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -75,6 +75,10 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
 
     check_positions();
 
+    /* As the above will mostly take place
+     * on Task 0, there will be a lot of imbalance*/
+    MPI_Barrier(MPI_COMM_WORLD);
+
     fof_init();
 
     All.SnapshotFileCount = RestartSnapNum + 1;

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 
 #include "types.h"
+#include "utils/peano.h"
 
 /*! This structure holds all the information that is
  * stored for each particle of the simulation.

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -473,7 +473,6 @@ static void layout_prepare (struct Layout * L, double * meshbuf, PetaPMRegion * 
         endrun(1, "totNcExport = %ld\n", totNcExport);
     }
 
-    MPI_Barrier(MPI_COMM_WORLD);
     /* exchange the pencils */
     message(0, "PetaPM:  %010ld/%010ld Pencils and %010ld Cells\n", totNpExport, totNpAlloc, totNcExport);
     L->PencilRecv = mymalloc("PencilRecv", L->NpImport * sizeof(struct Pencil));

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -298,6 +298,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, int HybridN
         /***** update smoothing lengths in tree *****/
         force_update_hmax(ActiveParticle, NumActiveParticle, tree);
         /***** hydro forces *****/
+        MPI_Barrier(MPI_COMM_WORLD);
         message(0, "Start hydro-force computation...\n");
 
         hydro_force(tree);		/* adds hydrodynamical accelerations  and computes du/dt  */
@@ -360,6 +361,8 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, int HybridN
         /**** radiative cooling and star formation *****/
         cooling_and_starformation(tree);
     }
+
+    MPI_Barrier(MPI_COMM_WORLD);
     message(0, "Forces computed.\n");
 }
 

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -41,9 +41,9 @@ void runtests(DomainDecomp * ddecomp)
     rebuild_activelist(All.Ti_Current, 0);
 
     ForceTree Tree = {0};
-    force_tree_rebuild(&Tree, ddecomp);
+    force_tree_rebuild(&Tree, ddecomp, All.BoxSize, 1);
     gravpm_force(&Tree);
-    force_tree_rebuild(&Tree, ddecomp);
+    force_tree_rebuild(&Tree, ddecomp, All.BoxSize, 1);
 
     grav_short_pair(&Tree);
     message(0, "GravShort Pairs %s\n", GDB_format_particle(0));
@@ -64,7 +64,8 @@ void runfof(int RestartSnapNum, DomainDecomp * ddecomp)
 {
     ForceTree Tree = {0};
     /*FoF needs a tree*/
-    force_tree_rebuild(&Tree, ddecomp);
+    int HybridNuGrav = All.HybridNeutrinosOn && All.Time <= All.HybridNuPartTime;
+    force_tree_rebuild(&Tree, ddecomp, All.BoxSize, HybridNuGrav);
     fof_fof(&Tree);
     force_tree_free(&Tree);
     fof_save_groups(RestartSnapNum);

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -181,9 +181,6 @@ void cooling_and_starformation(ForceTree * tree)
     sumup_large_ints(1, &stars_spawned, &tot_spawned);
     sumup_large_ints(1, &stars_converted, &tot_converted);
 
-    if(tot_spawned || tot_converted)
-        message(0, "SFR: spawned %ld stars, converted %ld gas particles into stars\n", tot_spawned, tot_converted);
-
     double total_sum_mass_stars, total_sm, totsfrrate;
 
     MPI_Reduce(&localsfr, &totsfrrate, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
@@ -203,6 +200,10 @@ void cooling_and_starformation(ForceTree * tree)
                 total_sum_mass_stars);
         fflush(FdSfr);
     }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if(tot_spawned || tot_converted)
+        message(0, "SFR: spawned %ld stars, converted %ld gas particles into stars\n", tot_spawned, tot_converted);
 
     walltime_measure("/Cooling/StarFormation");
 

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -607,7 +607,6 @@ slots_check_id_consistency()
             message(0, "Task 0: GC: Used slots for type %d is %ld\n", ptype, used[ptype]);
         }
     }
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 /* this function needs the Type of P[i] to be setup */

--- a/libgadget/utils/endrun.c
+++ b/libgadget/utils/endrun.c
@@ -189,9 +189,6 @@ messagev(int crash, int where, const char * fmt, va_list va)
         sprintf(prefix, "[ %09.2f ] ", MPI_Wtime() - _timestart);
     }
 
-    if(!crash && where <= 0)
-        MPI_Barrier(MPI_COMM_WORLD);
-
     if(ThisTask == 0 || where > 0) {
         putline(prefix, buf);
         if(crash) {


### PR DESCRIPTION
Remove MPI_Barriers, including the one in a collective message().

The last time I tried this the code got a factor of 3 slower - I never worked out why and when I tried again the slowdown has disappeared. Removing the barriers now makes the code a small (~1%) amount faster.

So let's just remove them.