### PR TITLE
Fixgcc9

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <gsl/gsl_math.h>
+#include <gsl/gsl_errno.h>
 
 #include <libgadget/allvars.h>
 #include <libgadget/slotsmanager.h>

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -19,8 +19,6 @@
 #include <mpi.h>
 #include <stdio.h>
 
-#include <gsl/gsl_rng.h>
-
 #include <signal.h>
 #define BREAKPOINT raise(SIGTRAP)
 #ifdef _OPENMP
@@ -43,19 +41,6 @@
 
 #define NEAREST(x) (((x)>0.5*All.BoxSize)?((x)-All.BoxSize):(((x)<-0.5*All.BoxSize)?((x)+All.BoxSize):(x)))
 
-#define MAXHSML 30000.0
-
-#define  MAX_REAL_NUMBER  1e37
-#define  MIN_REAL_NUMBER  1e-37
-
-#ifndef RCUT
-/*! RCUT gives the maximum distance (in units of the scale used for the force split) out to which short-range
- * forces are evaluated in the short-range tree walk.
- */
-#define RCUT  4.5
-#endif
-
-#define MAXITER 400
 enum ShortRangeForceWindowType {
     SHORTRANGE_FORCE_WINDOW_TYPE_EXACT = 0,
     SHORTRANGE_FORCE_WINDOW_TYPE_ERFC = 1,

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -14,6 +14,8 @@
 #include "winds.h"
 #include "utils.h"
 
+#define MAXITER 400
+
 /*! Structure for communication during the density computation. Holds data that is sent to other processors.
 */
 typedef struct {

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -12,6 +12,8 @@
 #include "partmanager.h"
 #include "utils.h"
 
+#define MAXHSML 30000.0
+
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
 
 void lock_particle(int i) {

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -768,7 +768,13 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
              *or if we are deep enough that we already spawned a lot.
              Note: final clause is much slower for some reason. */
             if(chldcnt > 1 && level < 513) {
-                #pragma omp task default(none) shared(tails, level, chldcnt, tree) firstprivate(j, nextsib, p)
+                /* We cannot use default(none) here because we need a const (HybridNuGrav),
+                 * which for gcc < 9 is default shared (and thus cannot be explicitly shared
+                 * without error) and for gcc == 9 must be explicitly shared. The other solution
+                 * is to make it firstprivate which I think will be excessively expensive for a
+                 * recursive call like this. See:
+                 * https://www.gnu.org/software/gcc/gcc-9/porting_to.html */
+                #pragma omp task shared(tails, level, chldcnt, tree) firstprivate(j, nextsib, p)
                 tails[j] = force_update_node_recursive(p, nextsib, level*chldcnt, tree, HybridNuGrav);
             }
             else

--- a/libgadget/gravshort.h
+++ b/libgadget/gravshort.h
@@ -4,6 +4,13 @@
 #include "partmanager.h"
 #include "treewalk.h"
 
+#ifndef RCUT
+/*! RCUT gives the maximum distance (in units of the scale used for the force split) out to which short-range
+ * forces are evaluated in the short-range tree walk.
+ */
+#define RCUT  4.5
+#endif
+
 typedef struct {
     TreeWalkNgbIterBase base;
 } TreeWalkNgbIterGravShort;


### PR DESCRIPTION
This PR fixes compilation on gcc9, broken due to an incompatible change in the openmp standard and tidies a couple of defines from allvars.