### PR TITLE
More code towards using the UNDEFINED state of optional parameters.

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -14,11 +14,6 @@
 #include <libgadget/blackhole.h>
 #include <libgadget/fof.h>
 
-/* Optional parameters are passed the flag 0 and required parameters 1.
- * These macros are just to document the semantic meaning of these flags. */
-#define OPTIONAL 0
-#define REQUIRED 1
-
 static int
 BlackHoleFeedbackMethodAction (ParameterSet * ps, char * name, void * data)
 {

--- a/genic/params.c
+++ b/genic/params.c
@@ -8,9 +8,6 @@
 #include <libgadget/physconst.h>
 #include <libgadget/utils.h>
 
-#define OPTIONAL 0
-#define REQUIRED 1
-
 static ParameterSet *
 create_parameters()
 {

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -316,6 +316,9 @@ double
 param_get_double(ParameterSet * ps, char * name)
 {
     ParameterSchema * p = param_get_schema(ps, name);
+    if (param_is_nil(ps, name)) {
+        printf("Accessing an undefined parameter `%s`.\n", p->name);
+    }
     return ps->value[p->index].d;
 }
 
@@ -323,12 +326,18 @@ char *
 param_get_string(ParameterSet * ps, char * name)
 {
     ParameterSchema * p = param_get_schema(ps, name);
+    if (param_is_nil(ps, name)) {
+        printf("Accessing an undefined parameter `%s`.\n", p->name);
+    }
     return ps->value[p->index].s;
 }
 void
 param_get_string2(ParameterSet * ps, char * name, char * dst)
 {
     ParameterSchema * p = param_get_schema(ps, name);
+    if (param_is_nil(ps, name)) {
+        printf("Accessing an undefined parameter `%s`.\n", p->name);
+    }
     strcpy(dst, ps->value[p->index].s);
 }
 
@@ -336,6 +345,9 @@ int
 param_get_int(ParameterSet * ps, char * name)
 {
     ParameterSchema * p = param_get_schema(ps, name);
+    if (param_is_nil(ps, name)) {
+        printf("Accessing an undefined parameter `%s`.\n", p->name);
+    }
     return ps->value[p->index].i;
 }
 
@@ -343,6 +355,9 @@ int
 param_get_enum(ParameterSet * ps, char * name)
 {
     ParameterSchema * p = param_get_schema(ps, name);
+    if (param_is_nil(ps, name)) {
+        printf("Accessing an undefined parameter `%s`.\n", p->name);
+    }
     return ps->value[p->index].i;
 }
 
@@ -351,7 +366,7 @@ param_format_value(ParameterSet * ps, char * name)
 {
     ParameterSchema * p = param_get_schema(ps, name);
     if(ps->value[p->index].nil) {
-        return fastpm_strdup("NIL");
+        return fastpm_strdup("UNDEFINED");
     }
     switch(p->type) {
         case INT:

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -6,7 +6,7 @@
 enum ParameterFlag {
     REQUIRED = 0,
     OPTIONAL = 1,
-    OPTIONAL_NIL = 2,
+    OPTIONAL_UNDEF = 2, /* optional and the default is undefined param_is_nil() is true if no value is given. */
 };
 
 typedef struct ParameterEnum {
@@ -51,9 +51,6 @@ param_get_enum(ParameterSet * ps, char * name);
 
 char *
 param_format_value(ParameterSet * ps, char * name);
-
-void
-param_set_from_string(ParameterSet * ps, char * name, char * value);
 
 int param_parse (ParameterSet * ps, char * content);
 int param_parse_file (ParameterSet * ps, const char * filename);

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -3,6 +3,12 @@
 
 #include <stdio.h>
 
+enum ParameterFlag {
+    REQUIRED = 0,
+    OPTIONAL = 1,
+    OPTIONAL_NIL = 2,
+};
+
 typedef struct ParameterEnum {
     char * name;
     int value;
@@ -12,16 +18,16 @@ typedef struct ParameterSet ParameterSet;
 typedef int (*ParameterAction)(ParameterSet * ps, char * name, void * userdata);
 
 void
-param_declare_int(ParameterSet * ps, char * name, int required, int defvalue, char * help);
+param_declare_int(ParameterSet * ps, char * name, enum ParameterFlag required, int defvalue, char * help);
 
 void
-param_declare_double(ParameterSet * ps, char * name, int required, double defvalue, char * help);
+param_declare_double(ParameterSet * ps, char * name, enum ParameterFlag required, double defvalue, char * help);
 
 void
-param_declare_string(ParameterSet * ps, char * name, int required, char * defvalue, char * help);
+param_declare_string(ParameterSet * ps, char * name, enum ParameterFlag required, char * defvalue, char * help);
 
 void
-param_declare_enum(ParameterSet * ps, char * name, ParameterEnum * enumtable, int required, char * defvalue, char * help);
+param_declare_enum(ParameterSet * ps, char * name, ParameterEnum * enumtable, enum ParameterFlag required, char * defvalue, char * help);
 
 void
 param_set_action(ParameterSet * ps, char * name, ParameterAction action, void * userdata);


### PR DESCRIPTION
- trace the origin of a parameter value (line number of default value)
- warn if a undefined optional is cast to a concrete value.

The third state is not yet used anywhere. A few cases I tried it only makes the situation harder to deal with.

I think we may want to get rid of most of the duplicated items in All / xxx params and ParameterSet at some point, the modules can cache the concrete values before entering expensive loops, and read from the paramset in other occasions; but that's more work than I can do this week.

