### PR TITLE
Runtimesph

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -1,5 +1,4 @@
 #Uncomment below to specify default options
-
 MPICC       =   mpicc
 MPICXX       =   mpic++
 
@@ -13,7 +12,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH        #Pressure-entropy SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,6 @@ You may also tweak the compilation options in Options.mk to enable various featu
 Unlike P-Gadget3, this is mostly unnecessary. Most options are now set at runtime.
 Remaining compule time flags are:
 There are still compile-time flags for:
-- DENSITY_INDEPENDENT_SPH which if set enables Pressure-Entropy SPH. This cannot be set at runtime.
 - BLACK_HOLES which is required if you want to enable the black hole model. You must also set the BlackHoleOn runtime flag.
 - SPH_GRAD_RHO which computes the SPH density gradient and is required for some advanced star formation routines.
 

--- a/examples/dm-only/paramfile.gadget
+++ b/examples/dm-only/paramfile.gadget
@@ -22,6 +22,7 @@ CoolingOn = 0
 StarformationOn = 0
 RadiationOn = 1
 BlackHoleOn = 0
+DensityIndependentSphOn = 1
 HydroOn = 0
 WindOn = 0
 MassiveNuLinRespOn = 0

--- a/examples/fastpm-compat/paramfile.gadget
+++ b/examples/fastpm-compat/paramfile.gadget
@@ -28,6 +28,7 @@ RadiationOn = 0
 HydroOn = 0
 BlackHoleOn = 0
 MassiveNuLinRespOn = 0
+DensityIndependentSphOn = 1
 WindOn = 0
 
 # Accuracy of time integration

--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -27,6 +27,7 @@ CoolingOn = 1
 StarformationOn = 1
 BlackHoleOn = 1
 HydroOn = 1
+DensityIndependentSphOn = 1
 StarformationCriterion = density
 RadiationOn = 1
 MassiveNuLinRespOn = 0

--- a/examples/linear_growth/paramfile.gadget
+++ b/examples/linear_growth/paramfile.gadget
@@ -26,6 +26,7 @@ HubbleParam = 0.6724      # Hubble paramater
 CoolingOn = 0
 StarformationOn = 0
 RadiationOn = 1
+DensityIndependentSphOn = 0
 HydroOn = 0
 WindOn = 0
 StarformationCriterion = density

--- a/examples/lya/paramfile.gadget
+++ b/examples/lya/paramfile.gadget
@@ -23,6 +23,7 @@ CoolingOn = 1
 StarformationOn = 1
 RadiationOn = 1
 HydroOn = 1
+DensityIndependentSphOn = 0
 BlackHoleOn = 0
 WindOn = 0
 StarformationCriterion = density

--- a/examples/neutrinos/paramfile.gadget
+++ b/examples/neutrinos/paramfile.gadget
@@ -19,6 +19,7 @@ HubbleParam = 0.7      # Hubble paramater (may be used for power spec parameteri
 CoolingOn = 0
 StarformationOn = 0
 RadiationOn = 1
+DensityIndependentSphOn = 1
 HydroOn = 0
 BlackHoleOn = 0
 WindOn = 0

--- a/examples/small/paramfile.gadget
+++ b/examples/small/paramfile.gadget
@@ -26,6 +26,7 @@ HubbleParam = 0.697      # Hubble paramater (may be used for power spec paramete
 CoolingOn = 1
 StarformationOn = 1
 StarformationCriterion = density
+DensityIndependentSphOn = 1
 RadiationOn = 1
 HydroOn = 1
 BlackHoleOn = 1

--- a/examples/travis/paramfile.gadget
+++ b/examples/travis/paramfile.gadget
@@ -24,6 +24,7 @@ CoolingOn = 1
 StarformationOn = 1
 StarformationCriterion = density
 RadiationOn = 1
+DensityIndependentSphOn = 1
 MassiveNuLinRespOn = 0
 
 MetalCoolFile = ../cooling_metal_UVB

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -178,7 +178,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "CourantFac", OPTIONAL, 0.15, "Courant factor for the timestepping.");
     param_declare_double(ps, "DensityResolutionEta", OPTIONAL, 1.0, "Resolution eta factor (See Price 2008) 1 = 33 for Cubic Spline");
 
-    param_declare_double(ps, "DensityContrastLimit", OPTIONAL, 100, "Max contrast for hydro force calculation");
+    param_declare_double(ps, "DensityContrastLimit", OPTIONAL, 100, "Has an effect only if DensityIndepndentSphOn=1. If = 0 enables the grad-h term in the SPH calculation. If > 0 also sets a maximum density contrast for hydro force calculation.");
     param_declare_double(ps, "MaxNumNgbDeviation", OPTIONAL, 2, "Maximal deviation from the desired number of neighbours for each SPH particle.");
     param_declare_double(ps, "HydroCostFactor", OPTIONAL, 1, "Cost factor of hydro calculation: this allows gas particles to be considered more expensive than gravity computations.");
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -218,7 +218,7 @@ create_gadget_parameter_set()
 
     param_declare_int(ps, "HydroOn", OPTIONAL, 1, "Enables hydro force");
     param_declare_int(ps, "DensityOn", OPTIONAL, 1, "Enables SPH density computation.");
-    param_declare_int(ps, "DensityIndependentSphOn", OPTIONAL, 1, "Enables density-independent (pressure-entropy) SPH.");
+    param_declare_int(ps, "DensityIndependentSphOn", REQUIRED, 1, "Enables density-independent (pressure-entropy) SPH.");
     param_declare_int(ps, "TreeGravOn", OPTIONAL, 1, "Enables tree gravity");
     param_declare_int(ps, "RadiationOn", OPTIONAL, 1, "Include radiation density in the background evolution.");
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -218,6 +218,7 @@ create_gadget_parameter_set()
 
     param_declare_int(ps, "HydroOn", OPTIONAL, 1, "Enables hydro force");
     param_declare_int(ps, "DensityOn", OPTIONAL, 1, "Enables SPH density computation.");
+    param_declare_int(ps, "DensityIndependentSphOn", OPTIONAL, 1, "Enables density-independent (pressure-entropy) SPH.");
     param_declare_int(ps, "TreeGravOn", OPTIONAL, 1, "Enables tree gravity");
     param_declare_int(ps, "RadiationOn", OPTIONAL, 1, "Include radiation density in the background evolution.");
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");
@@ -437,6 +438,7 @@ void read_parameter_file(char *fname)
         All.CoolingOn = param_get_int(ps, "CoolingOn");
         All.HydroOn = param_get_int(ps, "HydroOn");
         All.DensityOn = param_get_int(ps, "DensityOn");
+        All.DensityIndependentSphOn= param_get_int(ps, "DensityIndependentSphOn");
         All.TreeGravOn = param_get_int(ps, "TreeGravOn");
         All.FastParticleType = param_get_int(ps, "FastParticleType");
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -163,9 +163,12 @@ extern struct global_data_all_processes
     int HydroOn;  /*  if hydro force is enabled */
     int DensityOn;  /*  if SPH density computation is enabled */
     int TreeGravOn;     /* tree gravity force is enabled*/
+    int DensityIndependentSphOn; /* Enables density independent (Pressure-entropy) SPH */
+
     int BlackHoleOn;  /* if black holes are enabled */
     int StarformationOn;  /* if star formation is enabled */
     int WindOn; /* if Wind is enabled */
+
     int MassiveNuLinRespOn; /*!< flags that massive neutrinos using the linear
                                  response code of Ali-Haimoud & Bird 2013.*/
     int HybridNeutrinosOn; /*!< Flags that hybrid neutrinos are enabled */

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -115,10 +115,11 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
     {
         /* This accounts for adiabatic density changes,
          * and is a good predictor for most of the gas.*/
-        SPHP(i).Density *= exp(-SPHP(i).DivVel * ddrift);
-#ifdef DENSITY_INDEPENDENT_SPH
-        SPHP(i).EgyWtDensity *= exp(-SPHP(i).DivVel * ddrift);
-#endif
+        double densdriftfac = exp(-SPHP(i).DivVel * ddrift);
+        SPHP(i).Density *= densdriftfac;
+        if(All.DensityIndependentSphOn)
+            SPHP(i).EgyWtDensity *= densdriftfac;
+
         /* Evolve entropy at drift time: evolved dlog a.
          * Used to predict pressure and entropy for SPH*/
         double dloga = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -23,6 +23,22 @@
  *  (via artificial viscosity) is computed.
  */
 
+MyFloat SPH_EOMDensity(int i)
+{
+    if(All.DensityIndependentSphOn)
+        return SPHP(i).EgyWtDensity;
+    else
+        return SPHP(i).Density;
+}
+
+MyFloat SPH_DhsmlDensityFactor(int i)
+{
+    if(All.DensityIndependentSphOn)
+        return SPHP(i).DhsmlEgyDensityFactor;
+    else
+        return SPHP(i).DhsmlDensityFactor;
+}
+
 double
 PressurePred(int i)
 {
@@ -31,10 +47,9 @@ PressurePred(int i)
 
 typedef struct {
     TreeWalkQueryBase base;
-#ifdef DENSITY_INDEPENDENT_SPH
+    /* These are only used for DensityIndependentSphOn*/
     MyFloat EgyRho;
     MyFloat EntVarPred;
-#endif
 
     double Vel[3];
     MyFloat Hsml;
@@ -139,10 +154,12 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
     input->Hsml = P[place].Hsml;
     input->Mass = P[place].Mass;
     input->Density = SPHP(place).Density;
-#ifdef DENSITY_INDEPENDENT_SPH
-    input->EgyRho = SPHP(place).EgyWtDensity;
-    input->EntVarPred = SPHP(place).EntVarPred;
-#endif
+
+    if(All.DensityIndependentSphOn) {
+        input->EgyRho = SPHP(place).EgyWtDensity;
+        input->EntVarPred = SPHP(place).EntVarPred;
+    }
+
     input->SPH_DhsmlDensityFactor = SPH_DhsmlDensityFactor(place);
 
     input->Pressure = PressurePred(place);
@@ -190,22 +207,20 @@ hydro_ngbiter(
         iter->base.mask = 1;
         iter->base.symmetric = NGB_TREEFIND_SYMMETRIC;
 
-    #ifdef DENSITY_INDEPENDENT_SPH
-        iter->soundspeed_i = sqrt(GAMMA * I->Pressure / I->EgyRho);
-    #else
-        iter->soundspeed_i = sqrt(GAMMA * I->Pressure / I->Density);
-    #endif
+        if(All.DensityIndependentSphOn)
+            iter->soundspeed_i = sqrt(GAMMA * I->Pressure / I->EgyRho);
+        else
+            iter->soundspeed_i = sqrt(GAMMA * I->Pressure / I->Density);
 
         /* initialize variables before SPH loop is started */
 
         O->Acc[0] = O->Acc[1] = O->Acc[2] = O->DtEntropy = 0;
         density_kernel_init(&iter->kernel_i, I->Hsml);
 
-    #ifdef DENSITY_INDEPENDENT_SPH
-        iter->p_over_rho2_i = I->Pressure / (I->EgyRho * I->EgyRho);
-    #else
-        iter->p_over_rho2_i = I->Pressure / (I->Density * I->Density);
-    #endif
+        if(All.DensityIndependentSphOn)
+            iter->p_over_rho2_i = I->Pressure / (I->EgyRho * I->EgyRho);
+        else
+            iter->p_over_rho2_i = I->Pressure / (I->Density * I->Density);
 
         O->MaxSignalVel = iter->soundspeed_i;
         return;
@@ -281,29 +296,31 @@ hydro_ngbiter(
         }
         double hfc_visc = 0.5 * P[other].Mass * visc * (dwk_i + dwk_j) / r;
         double hfc = hfc_visc;
-#ifndef DENSITY_INDEPENDENT_SPH
         double r1 = 1, r2 = 1;
-#else
-        double r1 = 0, r2 = 0;
-        /* leading-order term */
-        double EntOther = SPHP(other).EntVarPred;
 
-        hfc += P[other].Mass *
-            (dwk_i*iter->p_over_rho2_i*EntOther/I->EntVarPred +
-             dwk_j*p_over_rho2_j*I->EntVarPred/EntOther) / r;
+        if(All.DensityIndependentSphOn) {
+            /*This enables the grad-h corrections*/
+            r1 = 0, r2 = 0;
+            /* leading-order term */
+            double EntOther = SPHP(other).EntVarPred;
 
-        /* enable grad-h corrections only if contrastlimit is non negative */
-        if(All.DensityContrastLimit >= 0) {
-            r1 = I->EgyRho / I->Density;
-            r2 = SPHP(other).EgyWtDensity / SPHP(other).Density;
-            if(All.DensityContrastLimit > 0) {
-                /* apply the limit if it is enabled > 0*/
-                r1 = DMIN(r1, All.DensityContrastLimit);
-                r2 = DMIN(r2, All.DensityContrastLimit);
+            hfc += P[other].Mass *
+                (dwk_i*iter->p_over_rho2_i*EntOther/I->EntVarPred +
+                dwk_j*p_over_rho2_j*I->EntVarPred/EntOther) / r;
+
+            /* enable grad-h corrections only if contrastlimit is non negative */
+            if(All.DensityContrastLimit >= 0) {
+                r1 = I->EgyRho / I->Density;
+                r2 = SPHP(other).EgyWtDensity / SPHP(other).Density;
+                if(All.DensityContrastLimit > 0) {
+                    /* apply the limit if it is enabled > 0*/
+                    r1 = DMIN(r1, All.DensityContrastLimit);
+                    r2 = DMIN(r2, All.DensityContrastLimit);
+                }
             }
         }
-#endif
-        /* grad-h corrections: enabled if DENSITY_INDEPENDENT_SPH is off, or DensityConstrastLimit >= 0 */
+
+        /* grad-h corrections: enabled if DensityIndependentSphOn = 0 is off, or DensityConstrastLimit >= 0 */
         /* Formulation derived from the Lagrangian */
         hfc += P[other].Mass * (iter->p_over_rho2_i*I->SPH_DhsmlDensityFactor * dwk_i * r1
                  + p_over_rho2_j*SPH_DhsmlDensityFactor(other) * dwk_j * r2) / r;

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -320,7 +320,7 @@ hydro_ngbiter(
             }
         }
 
-        /* grad-h corrections: enabled if DensityIndependentSphOn = 0 is off, or DensityConstrastLimit >= 0 */
+        /* grad-h corrections: enabled if DensityIndependentSphOn = 0, or DensityConstrastLimit >= 0 */
         /* Formulation derived from the Lagrangian */
         hfc += P[other].Mass * (iter->p_over_rho2_i*I->SPH_DhsmlDensityFactor * dwk_i * r1
                  + p_over_rho2_j*SPH_DhsmlDensityFactor(other) * dwk_j * r2) / r;

--- a/libgadget/hydra.h
+++ b/libgadget/hydra.h
@@ -2,9 +2,15 @@
 #define HYDRA_H
 
 #include "forcetree.h"
+#include "types.h"
 
 /*Function to get the pressure from the entropy and the density*/
 double PressurePred(int i);
+
+/* Functions to get the center of mass density and HSML correction factor for an SPH particle with index i.
+ * These encode the main difference between pressure-entropy SPH and regular SPH.*/
+MyFloat SPH_EOMDensity(int i);
+MyFloat SPH_DhsmlDensityFactor(int i);
 
 /*Function to compute hydro accelerations and adiabatic entropy change*/
 void hydro_force(ForceTree * tree);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -179,6 +179,50 @@ void check_positions(void)
     }
 }
 
+/* Initialize the entropy variable in Pressure-Entropy Sph.
+ * Initialization of the entropy variable is a little trickier in this version of SPH,
+ * since we need to make sure it 'talks to' the density appropriately */
+static void
+setup_density_indep_entropy(ForceTree * Tree, double u_init, double a3)
+{
+    message(0, "Converting u -> entropy, with density split sph\n");
+
+    int j;
+    double * olddensity = (double *)mymalloc("olddensity ", PartManager->NumPart * sizeof(double));
+    for(j = 0; j < 100; j++)
+    {
+        int i;
+        /* since ICs give energies, not entropies, need to iterate get this initialized correctly */
+        #pragma omp parallel for
+        for(i = 0; i < PartManager->NumPart; i++)
+        {
+            if(P[i].Type == 0) {
+                SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EgyWtDensity / a3 , GAMMA_MINUS1);
+                SPHP(i).EntVarPred = pow(SPHP(i).Entropy, 1/GAMMA);
+                olddensity[i] = SPHP(i).EgyWtDensity;
+            }
+        }
+        density_update(Tree);
+        double badness = 0;
+
+        #pragma omp parallel for reduction(max: badness)
+        for(i = 0; i < PartManager->NumPart; i++) {
+            if(P[i].Type == 0) {
+                if(SPHP(i).EgyWtDensity <= 0)
+                    continue;
+                double value = fabs(SPHP(i).EgyWtDensity - olddensity[i]) / SPHP(i).EgyWtDensity;
+                badness = DMAX(badness,value);
+            }
+        }
+        MPI_Allreduce(MPI_IN_PLACE, &badness, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+        message(0, "iteration %03d, max relative difference = %g \n", j, badness);
+
+        if(badness < 1e-3) break;
+    }
+    myfree(olddensity);
+}
+
 /*! This function is used to find an initial smoothing length for each SPH
  *  particle. It guarantees that the number of neighbours will be between
  *  desired_ngb-MAXDEV and desired_ngb+MAXDEV. For simplicity, a first guess
@@ -265,43 +309,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
         u_init /= molecular_weight;
 
         if(All.DensityIndependentSphOn) {
-            /* initialization of the entropy variable is a little trickier in this version of SPH,
-            since we need to make sure it 'talks to' the density appropriately */
-            message(0, "Converting u -> entropy, with density split sph\n");
-
-            int j;
-            double * olddensity = (double *)mymalloc("olddensity ", PartManager->NumPart * sizeof(double));
-            for(j=0;j<100;j++)
-            {
-                /* since ICs give energies, not entropies, need to iterate get this initialized correctly */
-                #pragma omp parallel for
-                for(i = 0; i < PartManager->NumPart; i++)
-                {
-                    if(P[i].Type == 0) {
-                        SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EgyWtDensity / a3 , GAMMA_MINUS1);
-                        SPHP(i).EntVarPred = pow(SPHP(i).Entropy, 1/GAMMA);
-                        olddensity[i] = SPHP(i).EgyWtDensity;
-                    }
-                }
-                density_update(&Tree);
-                double badness = 0;
-
-                #pragma omp parallel for reduction(max: badness)
-                for(i = 0; i < PartManager->NumPart; i++) {
-                    if(P[i].Type == 0) {
-                        if(SPHP(i).EgyWtDensity <= 0)
-                            continue;
-                        double value = fabs(SPHP(i).EgyWtDensity - olddensity[i]) / SPHP(i).EgyWtDensity;
-                        badness = DMAX(badness,value);
-                    }
-                }
-                MPI_Allreduce(MPI_IN_PLACE, &badness, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-
-                message(0, "iteration %03d, max relative difference = %g \n", j, badness);
-
-                if(badness < 1e-3) break;
-            }
-            myfree(olddensity);
+            setup_density_indep_entropy(&Tree, u_init, a3);
         }
 
         /*Initialize to initial energy*/

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -308,7 +308,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
         #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++) {
             if(P[i].Type == 0) {
-                SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EOMDensity/a3 , GAMMA_MINUS1);
+                SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPH_EOMDensity(i)/a3 , GAMMA_MINUS1);
             }
         }
     }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -775,12 +775,12 @@ static void GTNeutralHydrogenFraction(int i, float * out) {
 
 static void GTInternalEnergy(int i, float * out) {
     *out = DMAX(All.MinEgySpec,
-        SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+        SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 }
 
 static void STInternalEnergy(int i, float * out) {
     float u = *out;
-    SPHP(i).Entropy = GAMMA_MINUS1 * u / pow(SPHP(i).EOMDensity * All.cf.a3inv , GAMMA_MINUS1);
+    SPHP(i).Entropy = GAMMA_MINUS1 * u / pow(SPH_EOMDensity(i) * All.cf.a3inv , GAMMA_MINUS1);
 }
 
 static int order_by_type(const void *a, const void *b)

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -15,6 +15,7 @@
 
 #include "petaio.h"
 #include "slotsmanager.h"
+#include "hydra.h"
 #include "partmanager.h"
 #include "config.h"
 #include "neutrinos_lra.h"
@@ -744,9 +745,7 @@ SIMPLE_PROPERTY(Generation, P[i].Generation, unsigned char, 1)
 SIMPLE_GETTER(GTPotential, P[i].Potential, float, 1)
 SIMPLE_PROPERTY(SmoothingLength, P[i].Hsml, float, 1)
 SIMPLE_PROPERTY(Density, SPHP(i).Density, float, 1)
-#ifdef DENSITY_INDEPENDENT_SPH
 SIMPLE_PROPERTY(EgyWtDensity, SPHP(i).EgyWtDensity, float, 1)
-#endif
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 4, STARP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BirthDensity, STARP(i).BirthDensity, float, 1)
@@ -821,9 +820,9 @@ static void register_io_blocks() {
     /* Bare Bone SPH*/
     IO_REG(SmoothingLength,  "f4", 1, 0);
     IO_REG(Density,          "f4", 1, 0);
-#ifdef DENSITY_INDEPENDENT_SPH
-    IO_REG(EgyWtDensity,          "f4", 1, 0);
-#endif
+
+    if(All.DensityIndependentSphOn)
+        IO_REG(EgyWtDensity,          "f4", 1, 0);
 
     /* On reload this sets the Entropy variable, need the densities.
      * Register this after Density and EgyWtDensity will ensure density is read

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -26,6 +26,7 @@
 #include "cooling.h"
 #include "slotsmanager.h"
 #include "winds.h"
+#include "hydra.h"
 /*Only for the star slot reservation*/
 #include "forcetree.h"
 #include "timestep.h"

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -345,7 +345,7 @@ cooling_direct(int i) {
 
     double unew = DMAX(All.MinEgySpec,
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
-            GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+            GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 
 #ifdef BLACK_HOLES
     if(SPHP(i).Injected_BH_Energy)
@@ -382,7 +382,7 @@ cooling_direct(int i) {
     {
         /* note: the adiabatic rate has been already added in ! */
         SPHP(i).DtEntropy = (unew * GAMMA_MINUS1 /
-                pow(SPHP(i).EOMDensity * All.cf.a3inv,
+                pow(SPH_EOMDensity(i) * All.cf.a3inv,
                     GAMMA_MINUS1) - SPHP(i).Entropy) / dloga;
 
         if(SPHP(i).DtEntropy < -0.5 * SPHP(i).Entropy / dloga)
@@ -427,7 +427,7 @@ double get_neutral_fraction_sfreff(int i, double redshift)
 
     if(!All.StarformationOn || sfr_params.QuickLymanAlphaProbability > 0 || !sfreff_on_eeqos(i)) {
         /*This gets the neutral fraction for standard gas*/
-        double InternalEnergy = DMAX(All.MinEgySpec, SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+        double InternalEnergy = DMAX(All.MinEgySpec, SPHP(i).Entropy / GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
         nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, SPHP(i).Ne);
     }
     else {
@@ -471,7 +471,7 @@ static int make_particle_star(int child, int parent, int placement)
 }
 
 static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
-    const double densityfac = pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+    const double densityfac = pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double egycurrent = SPHP(i).Entropy *  densityfac;
 
 #ifdef BLACK_HOLES
@@ -520,7 +520,7 @@ quicklyastarformation(int i)
     double dloga = get_dloga_for_bin(P[i].TimeBin);
     double unew = DMAX(All.MinEgySpec,
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
-            GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+            GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 
     const double u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1
     * All.UnitEnergy_in_cgs / All.UnitMass_in_g;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -78,14 +78,12 @@ struct sph_particle_data
     struct particle_data_ext base;
 
 #ifdef DENSITY_INDEPENDENT_SPH
+    /*These two data members are only used if DensityIndependentSph is on.
+     * If DensityIndependentSph is off then Density and DhsmlDensityFactor are used instead.*/
     MyFloat EgyWtDensity;           /*!< 'effective' rho to use in hydro equations */
     MyFloat DhsmlEgyDensityFactor;  /*!< correction factor for density-independent entropy formulation */
-#define EOMDensity EgyWtDensity
-#define DhsmlEOMDensityFactor DhsmlEgyDensityFactor
-#else
-#define EOMDensity Density
-#define DhsmlEOMDensityFactor DhsmlDensityFactor
 #endif
+
     MyFloat EntVarPred;         /*!< Predicted entropy at current particle drift time for SPH computation*/
     /* VelPred can always be derived from the current time and acceleration.
      * However, doing so makes the SPH and hydro code much (a factor of two)
@@ -137,6 +135,24 @@ extern MPI_Datatype MPI_TYPE_SLOT[6];
 /* shortcuts to access base slot attributes */
 #define BASESLOT_PI(PI, ptype) ((struct particle_data_ext *)(SlotsManager->info[ptype].ptr + SlotsManager->info[ptype].elsize * (PI)))
 #define BASESLOT(i) BASESLOT_PI(P[i].PI, P[i].Type)
+
+inline MyFloat SPH_EOMDensity(int i)
+{
+#ifdef DENSITY_INDEPENDENT_SPH
+        return SPHP(i).EgyWtDensity;
+#else
+        return SPHP(i).Density;
+#endif
+}
+
+inline MyFloat SPH_DhsmlDensityFactor(int i)
+{
+#ifdef DENSITY_INDEPENDENT_SPH
+        return SPHP(i).DhsmlEgyDensityFactor;
+#else
+        return SPHP(i).DhsmlDensityFactor;
+#endif
+}
 
 void slots_init(double increase);
 /*Enable a slot on type ptype. All slots are disabled after slots_init().*/

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -77,12 +77,10 @@ struct sph_particle_data
 {
     struct particle_data_ext base;
 
-#ifdef DENSITY_INDEPENDENT_SPH
     /*These two data members are only used if DensityIndependentSph is on.
      * If DensityIndependentSph is off then Density and DhsmlDensityFactor are used instead.*/
     MyFloat EgyWtDensity;           /*!< 'effective' rho to use in hydro equations */
     MyFloat DhsmlEgyDensityFactor;  /*!< correction factor for density-independent entropy formulation */
-#endif
 
     MyFloat EntVarPred;         /*!< Predicted entropy at current particle drift time for SPH computation*/
     /* VelPred can always be derived from the current time and acceleration.
@@ -135,24 +133,6 @@ extern MPI_Datatype MPI_TYPE_SLOT[6];
 /* shortcuts to access base slot attributes */
 #define BASESLOT_PI(PI, ptype) ((struct particle_data_ext *)(SlotsManager->info[ptype].ptr + SlotsManager->info[ptype].elsize * (PI)))
 #define BASESLOT(i) BASESLOT_PI(P[i].PI, P[i].Type)
-
-inline MyFloat SPH_EOMDensity(int i)
-{
-#ifdef DENSITY_INDEPENDENT_SPH
-        return SPHP(i).EgyWtDensity;
-#else
-        return SPHP(i).Density;
-#endif
-}
-
-inline MyFloat SPH_DhsmlDensityFactor(int i)
-{
-#ifdef DENSITY_INDEPENDENT_SPH
-        return SPHP(i).DhsmlEgyDensityFactor;
-#else
-        return SPHP(i).DhsmlDensityFactor;
-#endif
-}
 
 void slots_init(double increase);
 /*Enable a slot on type ptype. All slots are disabled after slots_init().*/

--- a/libgadget/stats.c
+++ b/libgadget/stats.c
@@ -8,6 +8,7 @@
 #include "timestep.h"
 #include "cooling.h"
 #include "slotsmanager.h"
+#include "hydra.h"
 #include "utils.h"
 
 /* global state of system

--- a/libgadget/stats.c
+++ b/libgadget/stats.c
@@ -38,7 +38,7 @@ struct state_of_system
 
 /* This routine computes various global properties of the particle
  * distribution and stores the result in the struct `SysState'.
- * Currently, not all the information that's computed here is 
+ * Currently, not all the information that's computed here is
  * actually used (e.g. momentum is not really used anywhere),
  * just the energies are written to a log-file every once in a while.
  */
@@ -73,10 +73,10 @@ struct state_of_system compute_global_quantities_of_system(void)
         {
             struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
             entr = SPHP(i).Entropy;
-            egyspec = entr / (GAMMA_MINUS1) * pow(SPHP(i).EOMDensity / a3, GAMMA_MINUS1);
+            egyspec = entr / (GAMMA_MINUS1) * pow(SPH_EOMDensity(i) / a3, GAMMA_MINUS1);
             sys.EnergyIntComp[0] += P[i].Mass * egyspec;
             double ne = SPHP(i).Ne;
-            sys.TemperatureComp[0] += P[i].Mass * get_temp(SPHP(i).EOMDensity, egyspec, (1 - HYDROGEN_MASSFRAC), &uvbg, &ne);
+            sys.TemperatureComp[0] += P[i].Mass * get_temp(SPH_EOMDensity(i), egyspec, (1 - HYDROGEN_MASSFRAC), &uvbg, &ne);
         }
 
         for(j = 0; j < 3; j++)

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -341,7 +341,7 @@ do_the_short_range_kick(int i, inttime_t tistart, inttime_t tiend)
         /* Implement an entropy floor*/
         if(All.MinEgySpec)
         {
-            const double minentropy = All.MinEgySpec * GAMMA_MINUS1 / pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1);
+            const double minentropy = All.MinEgySpec * GAMMA_MINUS1 / pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1);
             if(SPHP(i).Entropy < minentropy)
             {
                 SPHP(i).Entropy = minentropy;
@@ -462,8 +462,8 @@ get_timestep_ti(const int p, const inttime_t dti_max)
               );
         if(P[p].Type == 0)
             message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n",
-                    SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb, SPHP(p).EOMDensity,
-                    SPHP(p).DhsmlEOMDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy);
+                    SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb, SPH_EOMDensity(p),
+                    SPH_DhsmlDensityFactor(p), SPHP(p).Entropy, SPHP(p).DtEntropy);
 #ifdef BLACK_HOLES
         if(P[p].Type == 0) {
             message(1, "injected_energy = %g\n" , SPHP(p).Injected_BH_Energy);

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -14,6 +14,7 @@
 #include "checkpoint.h"
 #include "slotsmanager.h"
 #include "partmanager.h"
+#include "hydra.h"
 #include "timestep.h"
 
 /*! \file timestep.c

--- a/platform-options/Options.mk.BlueTides
+++ b/platform-options/Options.mk.BlueTides
@@ -2,8 +2,6 @@
 # that runs the BlueTides simulation
 # on BlueWaters
 # the silly compiler is 
-# off-tree build into $(DESTDIR)
-DESTDIR  = build/
 
 #CC       = cc -h gnu -h omp
 MPICC       = cc
@@ -16,7 +14,6 @@ GSL_INCL = -I$(GSL_DIR)/include
 GSL_LIBS = -L$(GSL_DIR)/lib -lgsl -lgslcblas
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR

--- a/platform-options/Options.mk.cori
+++ b/platform-options/Options.mk.cori
@@ -1,6 +1,3 @@
-# off-tree build into $(DESTDIR)
-DESTDIR  = build/
-
 #Uncomment below to specify default options
 
 MPICC       =   cc
@@ -16,7 +13,6 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR

--- a/platform-options/Options.mk.coriknl
+++ b/platform-options/Options.mk.coriknl
@@ -1,6 +1,3 @@
-# off-tree build into $(DESTDIR)
-DESTDIR  = build/
-
 #Uncomment below to specify default options
 
 MPICC       =   cc
@@ -16,7 +13,6 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 

--- a/platform-options/Options.mk.edison
+++ b/platform-options/Options.mk.edison
@@ -1,6 +1,3 @@
-# off-tree build into $(DESTDIR)
-DESTDIR  = build/
-
 #Uncomment below to specify default options
 
 MPICC       =   cc
@@ -16,7 +13,6 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 

--- a/platform-options/Options.mk.example.coma
+++ b/platform-options/Options.mk.example.coma
@@ -5,7 +5,6 @@ GSL_INCL = -I/opt/gsl/impi/include/gsl
 GSL_LIBS = -L/opt/gsl/impi/lib64 -lgsl -lgslcblas
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 

--- a/platform-options/Options.mk.example.icc
+++ b/platform-options/Options.mk.example.icc
@@ -1,6 +1,3 @@
-# off-tree build into $(DESTDIR)
-DESTDIR  = build/
-
 #Uncomment below to specify default options
 MPICC       =   mpicc
 MPICXX      = mpic++
@@ -13,7 +10,6 @@ GSL_INCL = $(shell pkg-config --cflags gsl)
 GSL_LIBS = $(filter-out -lm,$(shell pkg-config --libs gsl))
 
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -16,7 +16,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 
 #
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages

--- a/platform-options/Options.mk.pfe
+++ b/platform-options/Options.mk.pfe
@@ -1,5 +1,3 @@
-DESTDIR  = build/
-
 MPICC       =   mpicc
 MPICXX      =   mpicxx
 OPTIMIZE =  -fopenmp -O3 -g
@@ -7,7 +5,6 @@ GSL_INCL = -I$(HOME)/anaconda3/envs/3.5/include
 GSL_LIBS = $(HOME)/anaconda3/envs/3.5/lib/libgsl.a $(HOME)/anaconda3/envs/3.5/lib/libgslcblas.a
 #
 #--------------------------------------- Basic operation mode of code
-#OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 

--- a/platform-options/Options.mk.stampede2
+++ b/platform-options/Options.mk.stampede2
@@ -13,7 +13,6 @@ GSL_INCL = $(shell pkg-config --cflags gsl)
 GSL_LIBS = $(shell pkg-config --libs gsl)
 
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -11,7 +11,6 @@ SHELL = /bin/bash
 OPT += -DDEBUG
 
 #--------------------------------------- Basic operation mode of code
-OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR


### PR DESCRIPTION
This removes the DENSITY_INDEPENDENT_SPH compile time option and replaces it with a runtime option. Costs us two floats in sph_particle_data if it is enabled, but that seems worth it to me.

Lightly tested - it compiles and runs but there might be some bugs I have yet to find. I would like a review first.

One transition issue I had is this causing all config files for Lyman-alpha runs to suddenly switch to density independent SPH. So I have used the newly merged third state of the parameters to set an undefined DensityIndependentSph to zero iff kernel == cubic.