### PR TITLE
Runtimebh

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -19,8 +19,5 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #Disable openmp locking. This means no threading.
 #OPT += -DNO_OPENMP_SPINLOCK
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/README.rst
+++ b/README.rst
@@ -74,11 +74,9 @@ platform-options directory. For example, for Stampede 2 you should do:
     cp platform-options/Options.mk.stampede2 Options.mk
 
 You may also tweak the compilation options in Options.mk to enable various features.
-Unlike P-Gadget3, this is mostly unnecessary. Most options are now set at runtime.
-Remaining compule time flags are:
-There are still compile-time flags for:
-- BLACK_HOLES which is required if you want to enable the black hole model. You must also set the BlackHoleOn runtime flag.
-- SPH_GRAD_RHO which computes the SPH density gradient and is required for some advanced star formation routines.
+Unlike P-Gadget3, this is mostly unnecessary. Almost all options are now set at runtime.
+The single remaining science compile time flag is SPH_GRAD_RHO, which enables computation of
+the SPH density gradient and is required for some advanced star formation routines.
 
 There are also some options useful for code debugging:
 - DEBUG which enables various internal code consistency checks for debugging.

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -242,7 +242,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeBetweenSeedingSearch", OPTIONAL, 1e5, "Time Between Seeding Attempts: default to a a large value, meaning never.");
 
     /*Black holes*/
-    param_declare_int(ps, "BlackHoleOn", REQUIRED, 1, "Enable Blackhole ");
+    param_declare_int(ps, "BlackHoleOn", REQUIRED, 1, "Master switch to enable black hole formation and feedback. If this is on, type 5 particles are treated as black holes.");
     param_declare_double(ps, "BlackHoleAccretionFactor", OPTIONAL, 100, "BH accretion boosting factor relative to the rate from the Bondi accretion model.");
     param_declare_double(ps, "BlackHoleEddingtonFactor", OPTIONAL, 3, "Maximum Black hole accretion as a function of Eddington.");
     param_declare_double(ps, "SeedBlackHoleMass", OPTIONAL, 5e-5, "Mass of initial black hole seed in internal mass units.");
@@ -481,13 +481,6 @@ void read_parameter_file(char *fname)
         All.BlackHoleNgbFactor = param_get_double(ps, "BlackHoleNgbFactor");
         All.BlackHoleMaxAccretionRadius = param_get_double(ps, "BlackHoleMaxAccretionRadius");
 
-    #ifndef BLACK_HOLES
-
-        if(All.BlackHoleOn)
-        {
-            endrun(1, "Code was compiled with black holes switched off but BlackHoleOn = 1. This does not work!\n");
-        }
-    #endif
         if(All.StarformationOn == 0)
         {
             if(All.WindOn == 1) {
@@ -522,9 +515,7 @@ void read_parameter_file(char *fname)
     set_sfr_params(ps);
     set_winds_params(ps);
     set_fof_params(ps);
-#ifdef BLACK_HOLES
     set_blackhole_params(ps);
-#endif
 
     parameter_set_free(ps);
 }

--- a/libgadget/allvars.c
+++ b/libgadget/allvars.c
@@ -32,9 +32,7 @@ FILE 			/*!< file handle for info.txt log-file. */
 
 FILE *FdSfr;			/*!< file handle for sfr.txt log-file. */
 
-#ifdef BLACK_HOLES
 FILE *FdBlackHoles;		/*!< file handle for blackholes.txt log-file. */
-#endif
 
 /*! This structure contains data which is the SAME for all tasks (mostly code parameters read from the
  * parameter file).  Holding this data in a structure is convenient for writing/reading the restart file, and

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -83,9 +83,7 @@ extern FILE *FdEnergy,			/*!< file handle for energy.txt log-file. */
 
 extern FILE *FdSfr;		/*!< file handle for sfr.txt log-file. */
 
-#ifdef BLACK_HOLES
 extern FILE *FdBlackHoles;	/*!< file handle for blackholes.txt log-file. */
-#endif
 
 /*! This structure contains data which is the SAME for all tasks (mostly code parameters read from the
  * parameter file).  Holding this data in a structure is convenient for writing/reading the restart file, and

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -225,9 +225,19 @@ blackhole(ForceTree * tree, double * TimeNextSeedingCheck)
 
     /* Let's determine which particles may be swalled and calculate total feedback weights */
     SPH_SwallowID = mymalloc("SPH_SwallowID", SlotsManager->info[0].size * sizeof(MyIDType));
-    #pragma omp parallel for
-    for(i = 0; i < SlotsManager->info[0].size; i ++)
-        SPH_SwallowID[i] = -1;
+    if(ActiveParticle) {
+        #pragma omp parallel for
+        for(i = 0; i < NumActiveParticle; i ++) {
+            int p_i = ActiveParticle[i];
+            SPH_SwallowID[P[p_i].PI] = -1;
+        }
+    }
+    else {
+        #pragma omp parallel for
+        for(i = 0; i < SlotsManager->info[0].size; i ++) {
+            SPH_SwallowID[i] = -1;
+        }
+    }
 
     treewalk_run(tw_accretion, ActiveParticle, NumActiveParticle);
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -21,8 +21,6 @@
  *  \brief routines for gas accretion onto black holes, and black hole mergers
  */
 
-#ifdef BLACK_HOLES
-
 struct BlackholeParams
 {
     double BlackHoleAccretionFactor;	/*!< Fraction of BH bondi accretion rate */
@@ -277,7 +275,7 @@ blackhole(ForceTree * tree, double * TimeNextSeedingCheck)
     if(All.Time >= *TimeNextSeedingCheck)
     {
         /* Seeding */
-        fof_fof(tree, All.BoxSize, MPI_COMM_WORLD);
+        fof_fof(tree, All.BoxSize, All.BlackHoleOn, MPI_COMM_WORLD);
         fof_seed(MPI_COMM_WORLD);
         fof_finish();
         *TimeNextSeedingCheck = All.Time * blackhole_params.TimeBetweenSeedingSearch;
@@ -734,6 +732,8 @@ blackhole_feedback_reduce(int place, TreeWalkResultBHFeedback * remote, enum Tre
 }
 
 void blackhole_make_one(int index) {
+    if(!All.BlackHoleOn)
+        return;
     if(P[index].Type != 0)
         endrun(7772, "Only Gas turns into blackholes, what's wrong?");
 
@@ -787,5 +787,3 @@ decide_hsearch(double h)
     }
 }
 
-
-#endif

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -40,7 +40,7 @@ write_checkpoint(int WriteSnapshot, int WriteFOF, ForceTree * tree)
         /* Compute and save FOF*/
         message(0, "computing group catalogue...\n");
 
-        fof_fof(tree, All.BoxSize, MPI_COMM_WORLD);
+        fof_fof(tree, All.BoxSize, All.BlackHoleOn, MPI_COMM_WORLD);
         /* Tree is invalid now because of the exchange in FoF.*/
         force_tree_free(tree);
         fof_save_groups(snapnum, MPI_COMM_WORLD);

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -461,10 +461,8 @@ void density_check_neighbours (int i, TreeWalk * tw) {
 
     double desnumngb = All.DesNumNgb;
 
-#ifdef BLACK_HOLES
-    if(P[i].Type == 5)
+    if(All.BlackHoleOn && P[i].Type == 5)
         desnumngb = All.DesNumNgb * All.BlackHoleNgbFactor;
-#endif
 
     MyFloat * Left = DENSITY_GET_PRIV(tw)->Left;
     MyFloat * Right = DENSITY_GET_PRIV(tw)->Right;
@@ -538,14 +536,12 @@ void density_check_neighbours (int i, TreeWalk * tw) {
         if(P[i].Hsml < All.MinGasHsml)
             P[i].Hsml = All.MinGasHsml;
 
-#ifdef BLACK_HOLES
-        if(P[i].Type == 5)
+        if(All.BlackHoleOn && P[i].Type == 5)
             if(Left[i] > All.BlackHoleMaxAccretionRadius)
             {
                 /* this will stop the search for a new BH smoothing length in the next iteration */
                 P[i].Hsml = Left[i] = Right[i] = All.BlackHoleMaxAccretionRadius;
             }
-#endif
 
     }
     else {

--- a/libgadget/fof.h
+++ b/libgadget/fof.h
@@ -9,7 +9,7 @@ void set_fof_params(ParameterSet * ps);
 void fof_init(double DMMeanSeparation);
 
 /*Computes the Group structure, saved as a global array below*/
-void fof_fof(ForceTree * tree, double BoxSize, MPI_Comm Comm);
+void fof_fof(ForceTree * tree, double BoxSize, int BlackHoleInfo, MPI_Comm Comm);
 
 /*Frees the Group structure*/
 void
@@ -50,11 +50,11 @@ extern struct Group
     double Jmom[3]; /* sum M R_i x V_i  */
 
     double Sfr;
-#ifdef BLACK_HOLES
+    /*These are used for storing black hole properties*/
     double BH_Mass;
     double BH_Mdot;
     double MaxDens;
-#endif
+
     int seed_index;
     int seed_task;
 } * Group;

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -300,10 +300,8 @@ SIMPLE_PROPERTY(Mass, Group[i].Mass, float, 1)
 SIMPLE_PROPERTY(MassByType, Group[i].MassType[0], float, 6)
 SIMPLE_PROPERTY(LengthByType, Group[i].LenType[0], uint32_t , 6)
 SIMPLE_PROPERTY(StarFormationRate, Group[i].Sfr, float, 1)
-#ifdef BLACK_HOLES
 SIMPLE_PROPERTY(BlackholeMass, Group[i].BH_Mass, float, 1)
 SIMPLE_PROPERTY(BlackholeAccretionRate, Group[i].BH_Mdot, float, 1)
-#endif
 
 void fof_register_io_blocks() {
     IO_REG(GroupID, "u4", 1, PTYPE_FOF_GROUP);
@@ -318,8 +316,8 @@ void fof_register_io_blocks() {
     IO_REG(MassByType, "f4", 6, PTYPE_FOF_GROUP);
     if(All.StarformationOn)
         IO_REG(StarFormationRate, "f4", 1, PTYPE_FOF_GROUP);
-#ifdef BLACK_HOLES
-    IO_REG(BlackholeMass, "f4", 1, PTYPE_FOF_GROUP);
-    IO_REG(BlackholeAccretionRate, "f4", 1, PTYPE_FOF_GROUP);
-#endif
+    if(All.BlackHoleOn) {
+        IO_REG(BlackholeMass, "f4", 1, PTYPE_FOF_GROUP);
+        IO_REG(BlackholeAccretionRate, "f4", 1, PTYPE_FOF_GROUP);
+    }
 }

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -91,13 +91,11 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
         P[i].GravCost = 1;
         P[i].Ti_drift = P[i].Ti_kick = All.Ti_Current;
 
-#ifdef BLACK_HOLES
-        if(RestartSnapNum == -1 && P[i].Type == 5 )
+        if(All.BlackHoleOn && RestartSnapNum == -1 && P[i].Type == 5 )
         {
             /* Note: Gadget-3 sets this to the seed black hole mass.*/
             BHP(i).Mass = P[i].Mass;
         }
-#endif
         P[i].Key = PEANO(P[i].Pos, All.BoxSize);
 
         if(P[i].Type != 0) continue;
@@ -119,9 +117,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
         }
         SPHP(i).DelayTime = 0;
 
-#ifdef BLACK_HOLES
         SPHP(i).Injected_BH_Energy = 0;
-#endif
     }
 
     walltime_measure("/Init");
@@ -280,7 +276,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
         }
     }
 
-#ifdef BLACK_HOLES
     /* FIXME: move this inside the condition above and
       * save BHs in the snapshots to avoid this; */
     for(i = 0; i < PartManager->NumPart; i++)
@@ -290,7 +285,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
             P[i].Hsml = 0.01 * All.MeanSeparation[0];
             BHP(i).TimeBinLimit = -1;
         }
-#endif
 
     density(&Tree);
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -756,7 +756,6 @@ static void GTStarFormationRate(int i, float * out) {
     *out = get_starformation_rate(i)
         * ((All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR));
 }
-#ifdef BLACK_HOLES
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 5, BHP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BlackholeMass, BHP(i).Mass, float, 1)
 SIMPLE_PROPERTY(BlackholeAccretionRate, BHP(i).Mdot, float, 1)
@@ -764,7 +763,6 @@ SIMPLE_PROPERTY(BlackholeProgenitors, BHP(i).CountProgs, float, 1)
 SIMPLE_PROPERTY(BlackholeMinPotPos, BHP(i).MinPotPos[0], double, 3)
 SIMPLE_PROPERTY(BlackholeMinPotVel, BHP(i).MinPotVel[0], float, 3)
 SIMPLE_PROPERTY(BlackholeJumpToMinPot, BHP(i).JumpToMinPot, int, 1)
-#endif
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, P[i].GrNr, uint32_t, 1)
 static void GTNeutralHydrogenFraction(int i, float * out) {
@@ -839,9 +837,9 @@ static void register_io_blocks() {
     IO_REG_TYPE(StarFormationTime, "f4", 1, 4);
     IO_REG_TYPE(Metallicity,       "f4", 1, 0);
     IO_REG_TYPE(Metallicity,       "f4", 1, 4);
-   /* end SF */
-#ifdef BLACK_HOLES
-    /* Blackhole */
+    /* end SF */
+
+    /* Black hole */
     IO_REG_TYPE(StarFormationTime, "f4", 1, 5);
     IO_REG(BlackholeMass,          "f4", 1, 5);
     IO_REG(BlackholeAccretionRate, "f4", 1, 5);
@@ -849,7 +847,7 @@ static void register_io_blocks() {
     IO_REG(BlackholeMinPotPos, "f8", 3, 5);
     IO_REG(BlackholeMinPotVel,   "f4", 3, 5);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5);
-#endif
+
     if(All.SnapshotWithFOF)
         fof_register_io_blocks();
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -121,10 +121,8 @@ void run(DomainDecomp * ddecomp)
     /*Is gas physics enabled?*/
     int GasEnabled = All.NTotalInit[0] > 0;
 
-#ifdef BLACK_HOLES
     /* Stored scale factor of the next black hole seeding check*/
     double TimeNextSeedingCheck = All.Time;
-#endif
 
     walltime_measure("/Misc");
 
@@ -205,10 +203,8 @@ void run(DomainDecomp * ddecomp)
          * so mass conservation would be broken.*/
         if(GasEnabled)
         {
-    #ifdef BLACK_HOLES
             /* Black hole accretion and feedback */
             blackhole(&Tree, &TimeNextSeedingCheck);
-    #endif
             /**** radiative cooling and star formation *****/
             cooling_and_starformation(&Tree);
         }
@@ -432,13 +428,13 @@ open_outputfiles(int RestartSnapNum)
         endrun(1, "error in opening file '%s'\n", buf);
     free(buf);
 
-#ifdef BLACK_HOLES
-    buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, "blackholes.txt", postfix);
-    fastpm_path_ensure_dirname(buf);
-    if(!(FdBlackHoles = fopen(buf, mode)))
-        endrun(1, "error in opening file '%s'\n", buf);
-    free(buf);
-#endif
+    if(All.BlackHoleOn) {
+        buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, "blackholes.txt", postfix);
+        fastpm_path_ensure_dirname(buf);
+        if(!(FdBlackHoles = fopen(buf, mode)))
+            endrun(1, "error in opening file '%s'\n", buf);
+        free(buf);
+    }
 
 }
 
@@ -458,9 +454,8 @@ close_outputfiles(void)
 
     fclose(FdSfr);
 
-#ifdef BLACK_HOLES
-    fclose(FdBlackHoles);
-#endif
+    if(All.BlackHoleOn)
+        fclose(FdBlackHoles);
 }
 
 /*! Computes conversion factors between internal code units and the

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -68,7 +68,7 @@ void runfof(int RestartSnapNum, DomainDecomp * ddecomp)
     /*FoF needs a tree*/
     int HybridNuGrav = All.HybridNeutrinosOn && All.Time <= All.HybridNuPartTime;
     force_tree_rebuild(&Tree, ddecomp, All.BoxSize, HybridNuGrav);
-    fof_fof(&Tree, All.BoxSize, MPI_COMM_WORLD);
+    fof_fof(&Tree, All.BoxSize, All.BlackHoleOn, MPI_COMM_WORLD);
     force_tree_free(&Tree);
     fof_save_groups(RestartSnapNum, MPI_COMM_WORLD);
     fof_finish();

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -348,8 +348,7 @@ cooling_direct(int i) {
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
             GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 
-#ifdef BLACK_HOLES
-    if(SPHP(i).Injected_BH_Energy)
+    if(All.BlackHoleOn && SPHP(i).Injected_BH_Energy)
     {
         if(P[i].Mass == 0) {
             endrun(12, "Encoutered zero mass particle during sfr;"
@@ -370,7 +369,6 @@ cooling_direct(int i) {
 
         SPHP(i).Injected_BH_Energy = 0;
     }
-#endif
 
     double redshift = 1./All.Time - 1;
     struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
@@ -475,8 +473,7 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
     const double densityfac = pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double egycurrent = SPHP(i).Entropy *  densityfac;
 
-#ifdef BLACK_HOLES
-    if(SPHP(i).Injected_BH_Energy > 0)
+    if(All.BlackHoleOn && SPHP(i).Injected_BH_Energy > 0)
     {
         double redshift = 1./All.Time - 1;
         struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
@@ -501,7 +498,6 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
 
         SPHP(i).Injected_BH_Energy = 0;
     }
-#endif
 
     SPHP(i).Entropy =  (egyeff + (egycurrent - egyeff) * exp(-dtime / trelax)) /densityfac;
 

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -103,11 +103,10 @@ struct sph_particle_data
                    density normalized to the hydrogen number density. Gives
                    indirectly ionization state and mean molecular weight. */
 
-#ifdef BLACK_HOLES
     MyIDType SwallowID; /* Allows marking of a particle being eaten by a black hole. Used only in blackhole.c.
                            Set to -1 in init.c and only reinitialised if a merger takes place.*/
+    /*Used to store the BH feedback energy if black holes are on*/
     MyFloat       Injected_BH_Energy;
-#endif
 
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -103,8 +103,6 @@ struct sph_particle_data
                    density normalized to the hydrogen number density. Gives
                    indirectly ionization state and mean molecular weight. */
 
-    MyIDType SwallowID; /* Allows marking of a particle being eaten by a black hole. Used only in blackhole.c.
-                           Set to -1 in init.c and only reinitialised if a merger takes place.*/
     /*Used to store the BH feedback energy if black holes are on*/
     MyFloat       Injected_BH_Energy;
 

--- a/platform-options/Options.mk.BlueTides
+++ b/platform-options/Options.mk.BlueTides
@@ -18,8 +18,5 @@ GSL_LIBS = -L$(GSL_DIR)/lib -lgsl -lgslcblas
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.cori
+++ b/platform-options/Options.mk.cori
@@ -17,8 +17,5 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.coriknl
+++ b/platform-options/Options.mk.coriknl
@@ -18,8 +18,5 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.edison
+++ b/platform-options/Options.mk.edison
@@ -18,8 +18,5 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.coma
+++ b/platform-options/Options.mk.example.coma
@@ -10,7 +10,5 @@ GSL_LIBS = -L/opt/gsl/impi/lib64 -lgsl -lgslcblas
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.icc
+++ b/platform-options/Options.mk.example.icc
@@ -15,8 +15,5 @@ GSL_LIBS = $(filter-out -lm,$(shell pkg-config --libs gsl))
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -23,8 +23,5 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #Disable openmp locking. This means no threading. Required on mac.
 OPT += -DNO_OPENMP_SPINLOCK
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.pfe
+++ b/platform-options/Options.mk.pfe
@@ -10,7 +10,5 @@ GSL_LIBS = $(HOME)/anaconda3/envs/3.5/lib/libgsl.a $(HOME)/anaconda3/envs/3.5/li
 
 #OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.stampede2
+++ b/platform-options/Options.mk.stampede2
@@ -18,6 +18,3 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DDEBUG      # print a lot of debugging messages
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -15,8 +15,5 @@ OPT += -DDEBUG
 
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
-#-------------------------------------- AGN stuff
-OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
-
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
Remove the BLACK_HOLES runtime option. Overall cost is one float in sph_particle_data.

The BlackHoleOn parameter was a little strange before: if BLACK_HOLES was compiled but BlackHoleOn = 0 then existing type 5 particles would in places be treated as black holes. This would never really happen but I fixed it anyway, as there might be a performance hit for non black hole runs otherwise.