### PR TITLE
Runtime SPH_GRAD_RHO

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -15,7 +15,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 #Disable openmp locking. This means no threading.
 #OPT += -DNO_OPENMP_SPINLOCK
 

--- a/README.rst
+++ b/README.rst
@@ -73,16 +73,14 @@ platform-options directory. For example, for Stampede 2 you should do:
 
     cp platform-options/Options.mk.stampede2 Options.mk
 
-You may also tweak the compilation options in Options.mk to enable various features.
-Unlike P-Gadget3, this is mostly unnecessary. Almost all options are now set at runtime.
-The single remaining science compile time flag is SPH_GRAD_RHO, which enables computation of
-the SPH density gradient and is required for some advanced star formation routines.
+Compile-time options may be set in Options.mk. The remaining compile time options are generally only useful for development or debugging. All science options are set using a parameter file at runtime.
 
-There are also some options useful for code debugging:
 - DEBUG which enables various internal code consistency checks for debugging.
 - VALGRIND which if set disables the internal memory allocator and allocates memory from the system. This is required for debugging memory allocation errors with valgrind of the address sanitizer.
+- NO_ISEND_IRECV_IN_DOMAIN disables the use of asynchronous send and receive in our custom MPI_Alltoallv implementation, for buggy MPI libraries.
+- NO_OPENMP_SPINLOCK disables the use of OpenMP spinlocks and thus effectively disables threading. Necessary for platforms which do not provide an OpenMP header, such as Mac.
 
-If compilation fails with errors related to the GSL, you may also need to set the GSL_INC or GSL_LIB variables in Options.mk to the filesystem path contianing the GSL headers and libraries.
+If compilation fails with errors related to the GSL, you may also need to set the GSL_INC or GSL_LIB variables in Options.mk to the filesystem path containing the GSL headers and libraries.
 
 To run a N-Body sim, use IC files with no gas particles.
 
@@ -90,9 +88,9 @@ Now we are ready to build
 
 .. code:: bash
 
-    make -j 8
+    make -j
 
-It takes some time to build pfft, one of the bundled dependencies. 
+It takes some time to build pfft, a bundled dependency for pencil-based fast Fourier transforms.
 Other libraries are bigfile and mp-sort, which are written by Yu Feng and are quick to build. 
 
 In the end, we will have 2 binaries:

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -37,12 +37,6 @@ StarformationCriterionAction(ParameterSet * ps, char * name, void * data)
         message(1, "error: At least use SFR_CRITERION_DENSITY\n");
         return 1;
     }
-#if ! defined SPH_GRAD_RHO
-    if(HAS(v, SFR_CRITERION_MOLECULAR_H2)) {
-        message(1, "error: enable SPH_GRAD_RHO to use h2 criterion in sfr \n");
-        return 1;
-    }
-#endif
     return 0;
 }
 
@@ -270,8 +264,7 @@ create_gadget_parameter_set()
     static ParameterEnum StarformationCriterionEnum [] = {
         {"density", SFR_CRITERION_DENSITY}, /* SH03 density model for star formation*/
         {"h2", SFR_CRITERION_MOLECULAR_H2}, /* Form stars depending on the computed
-                                               molecular gas fraction as a function of metallicity.
-                                               Needs SPH_GRAD_RHO enabled at compile-time. */
+                                               molecular gas fraction as a function of metallicity. */
         {"selfgravity", SFR_CRITERION_SELFGRAVITY}, /* Form stars only when the gas is self-gravitating. From Phil Hopkins.*/
         {"convergent", SFR_CRITERION_CONVERGENT_FLOW}, /* Modify self-gravitating star formation to form stars only when the gas flow is convergent. From Phil Hopkins.*/
         {"continuous", SFR_CRITERION_CONTINUOUS_CUTOFF}, /* Modify self-gravitating star formation to smooth the star formation threshold. From Phil Hopkins.*/

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -280,9 +280,10 @@ density_reduce(int place, TreeWalkResultDensity * remote, enum TreeWalkReduceMod
         TREEWALK_REDUCE(SPHP(place).Rot[2], remote->Rot[2]);
 
         if(sfr_need_to_compute_sph_grad_rho()) {
-            TREEWALK_REDUCE(SPHP(place).GradRho[0], remote->GradRho[0]);
-            TREEWALK_REDUCE(SPHP(place).GradRho[1], remote->GradRho[1]);
-            TREEWALK_REDUCE(SPHP(place).GradRho[2], remote->GradRho[2]);
+            int pi = P[place].PI;
+            TREEWALK_REDUCE(SphP_scratch->GradRho[3*pi], remote->GradRho[0]);
+            TREEWALK_REDUCE(SphP_scratch->GradRho[3*pi+1], remote->GradRho[1]);
+            TREEWALK_REDUCE(SphP_scratch->GradRho[3*pi+2], remote->GradRho[2]);
         }
 
         /*Only used for density independent SPH*/

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -11,8 +11,6 @@
 #include "treewalk.h"
 #include "slotsmanager.h"
 #include "timestep.h"
-/* For sfr_need_to_compute_sph_grad_rho*/
-#include "sfr_eff.h"
 #include "winds.h"
 #include "utils.h"
 
@@ -279,7 +277,7 @@ density_reduce(int place, TreeWalkResultDensity * remote, enum TreeWalkReduceMod
         TREEWALK_REDUCE(SPHP(place).Rot[1], remote->Rot[1]);
         TREEWALK_REDUCE(SPHP(place).Rot[2], remote->Rot[2]);
 
-        if(sfr_need_to_compute_sph_grad_rho()) {
+        if(SphP_scratch->GradRho) {
             int pi = P[place].PI;
             TREEWALK_REDUCE(SphP_scratch->GradRho[3*pi], remote->GradRho[0]);
             TREEWALK_REDUCE(SphP_scratch->GradRho[3*pi+1], remote->GradRho[1]);
@@ -365,7 +363,7 @@ density_ngbiter(
         }
 
 
-        if(sfr_need_to_compute_sph_grad_rho()) {
+        if(SphP_scratch->GradRho) {
             if(r > 0)
             {
                 int d;

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -11,6 +11,8 @@
 #include "treewalk.h"
 #include "slotsmanager.h"
 #include "timestep.h"
+/* For sfr_need_to_compute_sph_grad_rho*/
+#include "sfr_eff.h"
 #include "winds.h"
 #include "utils.h"
 
@@ -49,10 +51,8 @@ typedef struct {
 
     int Ninteractions;
 
-
-#ifdef SPH_GRAD_RHO
+    /*Only used if sfr_need_to_compute_sph_grad_rho is true*/
     MyFloat GradRho[3];
-#endif
 } TreeWalkResultDensity;
 
 struct DensityPriv {
@@ -279,11 +279,11 @@ density_reduce(int place, TreeWalkResultDensity * remote, enum TreeWalkReduceMod
         TREEWALK_REDUCE(SPHP(place).Rot[1], remote->Rot[1]);
         TREEWALK_REDUCE(SPHP(place).Rot[2], remote->Rot[2]);
 
-#ifdef SPH_GRAD_RHO
-        TREEWALK_REDUCE(SPHP(place).GradRho[0], remote->GradRho[0]);
-        TREEWALK_REDUCE(SPHP(place).GradRho[1], remote->GradRho[1]);
-        TREEWALK_REDUCE(SPHP(place).GradRho[2], remote->GradRho[2]);
-#endif
+        if(sfr_need_to_compute_sph_grad_rho()) {
+            TREEWALK_REDUCE(SPHP(place).GradRho[0], remote->GradRho[0]);
+            TREEWALK_REDUCE(SPHP(place).GradRho[1], remote->GradRho[1]);
+            TREEWALK_REDUCE(SPHP(place).GradRho[2], remote->GradRho[2]);
+        }
 
         /*Only used for density independent SPH*/
         if(All.DensityIndependentSphOn) {
@@ -364,15 +364,15 @@ density_ngbiter(
         }
 
 
-#ifdef SPH_GRAD_RHO
-        if(r > 0)
-        {
-            int d;
-            for (d = 0; d < 3; d ++) {
-                O->GradRho[d] += mass_j * dwk * dist[d] / r;
+        if(sfr_need_to_compute_sph_grad_rho()) {
+            if(r > 0)
+            {
+                int d;
+                for (d = 0; d < 3; d ++) {
+                    O->GradRho[d] += mass_j * dwk * dist[d] / r;
+                }
             }
         }
-#endif
 
         if(r > 0)
         {

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -18,6 +18,7 @@
 #include "domain.h"
 #include "slotsmanager.h"
 #include "hydra.h"
+#include "sfr_eff.h"
 #include "exchange.h"
 #include "fof.h"
 #include "timestep.h"
@@ -286,6 +287,9 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
             BHP(i).TimeBinLimit = -1;
         }
 
+    /*Allocate the extra SPH data for transient SPH particle properties.*/
+    slots_allocate_sph_scratch_data(sfr_need_to_compute_sph_grad_rho(), SlotsManager->info[0].size);
+
     density(&Tree);
 
     /* for clean IC with U input only, we need to iterate to find entrpoy */
@@ -327,5 +331,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
     if(All.DensityIndependentSphOn)
         density_update(&Tree);
 
+    slots_free_sph_scratch_data(SphP_scratch);
     force_tree_free(&Tree);
 }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -211,8 +211,6 @@ void run(DomainDecomp * ddecomp)
             cooling_and_starformation(&Tree);
         }
 
-        slots_free_sph_scratch_data(SphP_scratch);
-
         /* Update velocity to Ti_Current; this synchonizes TiKick and TiDrift for the active particles */
 
         if(is_PM) {
@@ -252,6 +250,8 @@ void run(DomainDecomp * ddecomp)
         }
 
         write_checkpoint(WriteSnapshot, WriteFOF, &Tree);
+
+        slots_free_sph_scratch_data(SphP_scratch);
 
         write_cpu_log(NumCurrentTiStep);		/* produce some CPU usage info */
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -195,6 +195,8 @@ void run(DomainDecomp * ddecomp)
         ForceTree Tree = {0};
         force_tree_rebuild(&Tree, ddecomp, All.BoxSize, HybridNuGrav);
 
+        /*Allocate the extra SPH data for transient SPH particle properties.*/
+        slots_allocate_sph_scratch_data(sfr_need_to_compute_sph_grad_rho(), SlotsManager->info[0].size);
         /* update force to Ti_Current */
         compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled, HybridNuGrav, &Tree, ddecomp);
 
@@ -208,6 +210,8 @@ void run(DomainDecomp * ddecomp)
             /**** radiative cooling and star formation *****/
             cooling_and_starformation(&Tree);
         }
+
+        slots_free_sph_scratch_data(SphP_scratch);
 
         /* Update velocity to Ti_Current; this synchonizes TiKick and TiDrift for the active particles */
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -830,7 +830,14 @@ find_star_mass(int i)
  * You may need a license to run with these modess.
 
  * */
-#if defined SPH_GRAD_RHO
+
+int sfr_need_to_compute_sph_grad_rho(void)
+{
+    if (HAS(sfr_params.StarformationCriterion, SFR_CRITERION_MOLECULAR_H2)) {
+        return 1;
+    }
+    return 0;
+}
 static double ev_NH_from_GradRho(MyFloat gradrho[3], double hsml, double rho, double include_h)
 {
     /* column density from GradRho, copied from gadget-p; what is it
@@ -845,20 +852,14 @@ static double ev_NH_from_GradRho(MyFloat gradrho[3], double hsml, double rho, do
     }
     return gradrho_mag; // *(Z/Zsolar) add metallicity dependence
 }
-#endif
 
 static double get_sfr_factor_due_to_h2(int i) {
     /*  Krumholz & Gnedin fitting function for f_H2 as a function of local
      *  properties, from gadget-p; we return the enhancement on SFR in this
      *  function */
 
-#if ! defined SPH_GRAD_RHO
-    /* if SPH_GRAD_RHO is not enabled, disable H2 molecular gas
-     * this really shall not happen because begrun will check against the
-     * condition. Ditto if not metal tracking.
-     * */
-    return 1.0;
-#else
+    if(!sfr_need_to_compute_sph_grad_rho())
+        endrun(1, "Needed grad rho but not enabled! Should never happen!\n");
     double tau_fmol;
     double zoverzsun = SPHP(i).Metallicity/METAL_YIELD;
     tau_fmol = ev_NH_from_GradRho(SPHP(i).GradRho,P[i].Hsml,SPHP(i).Density,1) * All.cf.a2inv;
@@ -874,7 +875,6 @@ static double get_sfr_factor_due_to_h2(int i) {
 
     } // if(tau_fmol>0)
     return 1.0;
-#endif
 }
 
 static double get_sfr_factor_due_to_selfgravity(int i) {

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -862,7 +862,7 @@ static double get_sfr_factor_due_to_h2(int i) {
         endrun(1, "Needed grad rho but not enabled! Should never happen!\n");
     double tau_fmol;
     double zoverzsun = SPHP(i).Metallicity/METAL_YIELD;
-    tau_fmol = ev_NH_from_GradRho(SPHP(i).GradRho,P[i].Hsml,SPHP(i).Density,1) * All.cf.a2inv;
+    tau_fmol = ev_NH_from_GradRho(&(SphP_scratch->GradRho[3*P[i].PI]),P[i].Hsml,SPHP(i).Density,1) * All.cf.a2inv;
     tau_fmol *= (0.1 + zoverzsun);
     if(tau_fmol>0) {
         tau_fmol *= 434.78*All.UnitDensity_in_cgs*All.CP.HubbleParam*All.UnitLength_in_cm;

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -31,4 +31,6 @@ double get_starformation_rate(int i);
  * when on the equation of state calls them separately for the cold and hot gas.*/
 double get_neutral_fraction_sfreff(int i, double redshift);
 
+/* Return whether we are using a star formation model that needs grad rho computed for the gas particles*/
+int sfr_need_to_compute_sph_grad_rho(void);
 #endif

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -661,6 +661,8 @@ slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph)
 void
 slots_free_sph_scratch_data(struct sph_scratch_data * SphScratch)
 {
-    if(SphScratch->GradRho)
+    if(SphScratch->GradRho) {
         myfree(SphScratch->GradRho);
+        SphScratch->GradRho = NULL;
+    }
 }

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -643,3 +643,24 @@ slots_setup_id()
         BASESLOT(i)->IsGarbage = P[i].IsGarbage;
     }
 }
+
+/*Small structure of pointers*/
+static struct sph_scratch_data SphScratch;
+
+void
+slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph)
+{
+    /*Data is allocated high so that we can free the tree around it*/
+    if(sph_grad_rho)
+        SphScratch.GradRho = mymalloc2("SPH_GradRho", sizeof(MyFloat) * 3 * nsph);
+    else
+        SphScratch.GradRho = NULL;
+    SlotsManager->info[0].scratchdata = (char *) &SphScratch;
+}
+
+void
+slots_free_sph_scratch_data(struct sph_scratch_data * SphScratch)
+{
+    if(SphScratch->GradRho)
+        myfree(SphScratch->GradRho);
+}

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -13,6 +13,8 @@ extern struct slots_manager_type {
         int maxsize; /* max number of supported slots */
         int size; /* currently used slots*/
         size_t elsize; /* itemsize */
+        char * scratchdata; /* Pointer to struct of pointers that store optional data for this type, which persists through one time step,
+                             but not beyond. Currently only used for SPH data.*/
         int enabled;
     } info[6];
     double increase; /* Percentage amount to increase
@@ -108,8 +110,12 @@ struct sph_particle_data
 
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
+};
 
-    MyFloat GradRho[3];
+struct sph_scratch_data
+{
+    /* Gradient of the SPH density. 3x vector*/
+    MyFloat * GradRho;
 };
 
 /* shortcuts for accessing different slots directly by the index */
@@ -121,6 +127,9 @@ struct sph_particle_data
 #define SPHP(i) SphP[P[i].PI]
 #define BHP(i) BhP[P[i].PI]
 #define STARP(i) StarP[P[i].PI]
+
+/*Shortcut for the extra data*/
+#define SphP_scratch ((struct sph_scratch_data*) SlotsManager->info[0].scratchdata)
 
 extern MPI_Datatype MPI_TYPE_PARTICLE;
 extern MPI_Datatype MPI_TYPE_SLOT[6];
@@ -142,6 +151,9 @@ int slots_gc(int * compact_slots);
 void slots_gc_sorted(void);
 void slots_reserve(int where, int atleast[6]);
 void slots_check_id_consistency();
+
+void slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph);
+void slots_free_sph_scratch_data(struct sph_scratch_data * Scratch);
 
 typedef struct {
     EIBase base;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -109,9 +109,7 @@ struct sph_particle_data
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
 
-#ifdef SPH_GRAD_RHO
     MyFloat GradRho[3];
-#endif
 };
 
 /* shortcuts for accessing different slots directly by the index */

--- a/platform-options/Options.mk.BlueTides
+++ b/platform-options/Options.mk.BlueTides
@@ -16,7 +16,5 @@ GSL_LIBS = -L$(GSL_DIR)/lib -lgsl -lgslcblas
 #--------------------------------------- Basic operation mode of code
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.cori
+++ b/platform-options/Options.mk.cori
@@ -15,7 +15,6 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #--------------------------------------- Basic operation mode of code
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.coriknl
+++ b/platform-options/Options.mk.coriknl
@@ -16,7 +16,5 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.edison
+++ b/platform-options/Options.mk.edison
@@ -16,7 +16,5 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.coma
+++ b/platform-options/Options.mk.example.coma
@@ -8,7 +8,5 @@ GSL_LIBS = -L/opt/gsl/impi/lib64 -lgsl -lgslcblas
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.icc
+++ b/platform-options/Options.mk.example.icc
@@ -13,7 +13,5 @@ GSL_LIBS = $(filter-out -lm,$(shell pkg-config --libs gsl))
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -19,7 +19,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 #Disable openmp locking. This means no threading. Required on mac.
 OPT += -DNO_OPENMP_SPINLOCK
 

--- a/platform-options/Options.mk.pfe
+++ b/platform-options/Options.mk.pfe
@@ -8,7 +8,5 @@ GSL_LIBS = $(HOME)/anaconda3/envs/3.5/lib/libgsl.a $(HOME)/anaconda3/envs/3.5/li
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 
-#OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.stampede2
+++ b/platform-options/Options.mk.stampede2
@@ -19,5 +19,3 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -12,8 +12,5 @@ OPT += -DDEBUG
 
 #--------------------------------------- Basic operation mode of code
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-
-OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
-
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
This removes the compile flag SPH_GRAD_RHO which is the LAST COMPILE TIME SCIENCE FLAG!! Hooray! No longer will we need to recompile MP-Gadget for different tests! Everything is runtime.

If you agree with the approach for sph_extra_data I might move some other things that are recomputed every timestep into it. eg, VelPred.