### PR TITLE
Memoryopts

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -480,7 +480,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
-            O->SmoothedPressure += (mass_j * wk * PressurePred(other));
+            O->SmoothedPressure += (mass_j * wk * PressurePred(P[other].PI));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
             O->GasVel[0] += (mass_j * wk * SPHP(other).VelPred[0]);
             O->GasVel[1] += (mass_j * wk * SPHP(other).VelPred[1]);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -303,6 +303,8 @@ hydro_ngbiter(
             if(vsig > O->MaxSignalVel)
                 O->MaxSignalVel = vsig;
 
+            /* Note this uses the CurlVel of an inactive particle, which may not be
+             * at the present drift time*/
             const double f2 = fabs(SPHP(other).DivVel) / (fabs(SPHP(other).DivVel) +
                     SPHP(other).CurlVel + 0.0001 * soundspeed_j / fac_mu / P[other].Hsml);
 

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -67,7 +67,6 @@ struct particle_data
             /* used by fof.c which calls domain_exchange that doesn't uses peano_t */
             int64_t GrNr;
             int origintask;
-            int targettask;
         };
     };
 

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -100,7 +100,6 @@ struct sph_particle_data
     MyFloat       DhsmlDensityFactor;	/*!< correction factor needed in entropy formulation of SPH */
     MyFloat       DivVel;		/*!< local velocity divergence */
     MyFloat       CurlVel;     	        /*!< local velocity curl */
-    MyFloat       Rot[3];		/*!< local velocity curl */
     MyFloat Ne;  /*!< electron fraction, expressed as local electron number
                    density normalized to the hydrogen number density. Gives
                    indirectly ionization state and mean molecular weight. */

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -99,6 +99,8 @@ struct sph_particle_data
     MyFloat       HydroAccel[3];	/*!< acceleration due to hydrodynamical force */
     MyFloat       DhsmlDensityFactor;	/*!< correction factor needed in entropy formulation of SPH */
     MyFloat       DivVel;		/*!< local velocity divergence */
+    /* CurlVel has to be here and not in scratch because we re-use the
+     * CurlVel of inactive particles inside the artificial viscosity calculation.*/
     MyFloat       CurlVel;     	        /*!< local velocity curl */
     MyFloat Ne;  /*!< electron fraction, expressed as local electron number
                    density normalized to the hydrogen number density. Gives


### PR DESCRIPTION
Shrink sph_particle_data and particle_data by making some array elements local to other modules. Move EntVarPred into sph_scratch_data. This provides a modest speed win (10% of hydro) because of the temporary array for Pressure, but the big point is to enable future work. I have checked that these commits make no difference to output of a hydro example run.