### PR TITLE
Fixorder

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -481,7 +481,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             O->Rho += (mass_j * wk);
 
             O->SmoothedPressure += (mass_j * wk * PressurePred(P[other].PI));
-            O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
+            O->SmoothedEntropy += (mass_j * wk * SphP_scratch->EntVarPred[P[other].PI]);
             O->GasVel[0] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI]);
             O->GasVel[1] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI+1]);
             O->GasVel[2] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI+2]);

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -482,9 +482,9 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
 
             O->SmoothedPressure += (mass_j * wk * PressurePred(P[other].PI));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
-            O->GasVel[0] += (mass_j * wk * SPHP(other).VelPred[0]);
-            O->GasVel[1] += (mass_j * wk * SPHP(other).VelPred[1]);
-            O->GasVel[2] += (mass_j * wk * SPHP(other).VelPred[2]);
+            O->GasVel[0] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI]);
+            O->GasVel[1] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI+1]);
+            O->GasVel[2] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI+2]);
 
             /* here we have a gas particle; check for swallowing */
 

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -120,14 +120,6 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
         if(All.DensityIndependentSphOn)
             SPHP(i).EgyWtDensity *= densdriftfac;
 
-        /* Evolve entropy at drift time: evolved dlog a.
-         * Used to predict pressure and entropy for SPH*/
-        double dloga = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
-        SPHP(i).EntVarPred = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga;
-        /*Entropy limiter for the predicted entropy: makes sure entropy stays positive. */
-        if(dloga > 0 && SPHP(i).EntVarPred < 0.5*SPHP(i).Entropy)
-            SPHP(i).EntVarPred = 0.5 * SPHP(i).Entropy;
-        SPHP(i).EntVarPred = pow(SPHP(i).EntVarPred, 1/GAMMA);
         sph_VelPred(i, SPHP(i).VelPred);
         //      P[i].Hsml *= exp(0.333333333333 * SPHP(i).DivVel * ddrift);
         //---This was added

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -40,24 +40,6 @@ void drift_particle(int i, inttime_t ti1) {
     unlock_particle(i);
 }
 
-/*Get the predicted velocity for a particle
- * at the Force computation time, which always coincides with the Drift inttime.
- * for gravity and hydro forces.
- * This is mostly used for artificial viscosity.*/
-static void
-sph_VelPred(int i, MyFloat * VelPred)
-{
-    const int ti = P[i].Ti_drift;
-    const double Fgravkick2 = get_gravkick_factor(P[i].Ti_kick, ti);
-    const double Fhydrokick2 = get_hydrokick_factor(P[i].Ti_kick, ti);
-    const double FgravkickB = get_gravkick_factor(PM.Ti_kick, ti);
-    int j;
-    for(j = 0; j < 3; j++) {
-        VelPred[j] = P[i].Vel[j] + Fgravkick2 * P[i].GravAccel[j]
-            + P[i].GravPM[j] * FgravkickB + Fhydrokick2 * SPHP(i).HydroAccel[j];
-    }
-}
-
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
 {
     int j;
@@ -120,7 +102,6 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
         if(All.DensityIndependentSphOn)
             SPHP(i).EgyWtDensity *= densdriftfac;
 
-        sph_VelPred(i, SPHP(i).VelPred);
         //      P[i].Hsml *= exp(0.333333333333 * SPHP(i).DivVel * ddrift);
         //---This was added
         double fac = exp(0.333333333333 * SPHP(i).DivVel * ddrift);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -178,9 +178,9 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 {
     double soundspeed_i;
     /*Compute predicted velocity*/
-    input->Vel[0] = SPHP(place).VelPred[0];
-    input->Vel[1] = SPHP(place).VelPred[1];
-    input->Vel[2] = SPHP(place).VelPred[2];
+    input->Vel[0] = SphP_scratch->VelPred[3 * P[place].PI];
+    input->Vel[1] = SphP_scratch->VelPred[3 * P[place].PI + 1];
+    input->Vel[2] = SphP_scratch->VelPred[3 * P[place].PI + 2];
     input->Hsml = P[place].Hsml;
     input->Mass = P[place].Mass;
     input->Density = SPHP(place).Density;
@@ -279,7 +279,7 @@ hydro_ngbiter(
         double dv[3];
         int d;
         for(d = 0; d < 3; d++) {
-            dv[d] = I->Vel[d] - SPHP(other).VelPred[d];
+            dv[d] = I->Vel[d] - SphP_scratch->VelPred[3 * P[other].PI + d];
         }
 
         double vdotr = dotproduct(dist, dv);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -47,7 +47,7 @@ PressurePred(int PI)
         EOMDensity = SphP[PI].EgyWtDensity;
     else
         EOMDensity = SphP[PI].Density;
-    return pow(SphP[PI].EntVarPred * EOMDensity, GAMMA);
+    return pow(SphP_scratch->EntVarPred[PI] * EOMDensity, GAMMA);
 }
 
 struct HydraPriv {
@@ -187,7 +187,7 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 
     if(All.DensityIndependentSphOn) {
         input->EgyRho = SPHP(place).EgyWtDensity;
-        input->EntVarPred = SPHP(place).EntVarPred;
+        input->EntVarPred = SphP_scratch->EntVarPred[P[place].PI];
     }
 
     input->SPH_DhsmlDensityFactor = SPH_DhsmlDensityFactor(place);
@@ -330,7 +330,7 @@ hydro_ngbiter(
             /*This enables the grad-h corrections*/
             r1 = 0, r2 = 0;
             /* leading-order term */
-            double EntOther = SPHP(other).EntVarPred;
+            double EntOther = SphP_scratch->EntVarPred[P[other].PI];
 
             hfc += P[other].Mass *
                 (dwk_i*iter->p_over_rho2_i*EntOther/I->EntVarPred +

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -112,7 +112,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
         {
             SPHP(i).Density = -1;
             SPHP(i).EgyWtDensity = -1;
-            SPHP(i).EntVarPred = -1;
+            SPHP(i).Entropy = -1;
             SPHP(i).Ne = 1.0;
             SPHP(i).DivVel = 0;
         }
@@ -195,7 +195,6 @@ setup_density_indep_entropy(ForceTree * Tree, double u_init, double a3)
         {
             if(P[i].Type == 0) {
                 SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EgyWtDensity / a3 , GAMMA_MINUS1);
-                SPHP(i).EntVarPred = pow(SPHP(i).Entropy, 1/GAMMA);
                 olddensity[i] = SPHP(i).EgyWtDensity;
             }
         }
@@ -320,14 +319,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
     }
     /* snapshot already has EgyWtDensity; hope it is read in correctly.
      * (need a test on this!) */
-    /* regardless we initalize EntVarPred. This may be unnecessary*/
-#pragma omp parallel for
-    for(i = 0; i < PartManager->NumPart; i++) {
-        if(P[i].Type == 0) {
-            /* Convert from energy read in by the snapshot to entropy.*/
-            SPHP(i).EntVarPred = pow(SPHP(i).Entropy, 1./GAMMA);
-        }
-    }
     if(All.DensityIndependentSphOn)
         density_update(&Tree);
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -306,7 +306,12 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, int HybridN
 
     walltime_measure("/Misc");
 
-    /* We do this first so that the density is up to date for
+    /* density() happens before gravity because it also initializes the predicted variables.
+     * This ensures that prediction consistently uses the grav and hydro accel from the
+     * timestep before this one, which matches Gadget-2/3. It was tested to make a small difference,
+     * since prediction is only really used for artificial viscosity.
+     *
+     * Doing it first also means the density is up to date for
      * adaptive gravitational softenings. */
     if(GasEnabled)
     {

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -196,7 +196,8 @@ void run(DomainDecomp * ddecomp)
         force_tree_rebuild(&Tree, ddecomp, All.BoxSize, HybridNuGrav);
 
         /*Allocate the extra SPH data for transient SPH particle properties.*/
-        slots_allocate_sph_scratch_data(sfr_need_to_compute_sph_grad_rho(), SlotsManager->info[0].size);
+        if(GasEnabled)
+            slots_allocate_sph_scratch_data(sfr_need_to_compute_sph_grad_rho(), SlotsManager->info[0].size);
         /* update force to Ti_Current */
         compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled, HybridNuGrav, &Tree, ddecomp);
 
@@ -251,7 +252,8 @@ void run(DomainDecomp * ddecomp)
 
         write_checkpoint(WriteSnapshot, WriteFOF, &Tree);
 
-        slots_free_sph_scratch_data(SphP_scratch);
+        if(GasEnabled)
+            slots_free_sph_scratch_data(SphP_scratch);
 
         write_cpu_log(NumCurrentTiStep);		/* produce some CPU usage info */
 

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -655,12 +655,14 @@ slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph)
         SphScratch.GradRho = mymalloc2("SPH_GradRho", sizeof(MyFloat) * 3 * nsph);
     else
         SphScratch.GradRho = NULL;
+    SphScratch.EntVarPred = mymalloc2("EntVarPred", sizeof(MyFloat) * nsph);
     SlotsManager->info[0].scratchdata = (char *) &SphScratch;
 }
 
 void
 slots_free_sph_scratch_data(struct sph_scratch_data * SphScratch)
 {
+    myfree(SphScratch->EntVarPred);
     if(SphScratch->GradRho) {
         myfree(SphScratch->GradRho);
         SphScratch->GradRho = NULL;

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -656,12 +656,14 @@ slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph)
     else
         SphScratch.GradRho = NULL;
     SphScratch.EntVarPred = mymalloc2("EntVarPred", sizeof(MyFloat) * nsph);
+    SphScratch.VelPred = mymalloc2("VelPred", sizeof(MyFloat) * 3 * nsph);
     SlotsManager->info[0].scratchdata = (char *) &SphScratch;
 }
 
 void
 slots_free_sph_scratch_data(struct sph_scratch_data * SphScratch)
 {
+    myfree(SphScratch->VelPred);
     myfree(SphScratch->EntVarPred);
     if(SphScratch->GradRho) {
         myfree(SphScratch->GradRho);

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -84,12 +84,6 @@ struct sph_particle_data
     MyFloat EgyWtDensity;           /*!< 'effective' rho to use in hydro equations */
     MyFloat DhsmlEgyDensityFactor;  /*!< correction factor for density-independent entropy formulation */
 
-    /* VelPred can always be derived from the current time and acceleration.
-     * However, doing so makes the SPH and hydro code much (a factor of two)
-     * slower. It requires computing get_gravkick_factor twice with different arguments,
-     * which defeats the lookup cache in timefac.c. Because VelPred is used multiple times,
-     * it is much quicker to compute it once and re-use this*/
-    MyFloat VelPred[3];            /*!< Predicted velocity at current particle drift time for SPH*/
     MyFloat Metallicity;		/*!< metallicity of gas particle */
     MyFloat Entropy;		/*!< Entropy (actually entropic function) at kick time of particle */
     MyFloat MaxSignalVel;           /*!< maximum signal velocity */
@@ -118,6 +112,12 @@ struct sph_scratch_data
     MyFloat * GradRho;
     /*!< Predicted entropy at current particle drift time for SPH computation*/
     MyFloat * EntVarPred;
+    /* VelPred can always be derived from the current time and acceleration.
+     * However, doing so makes the SPH and hydro code much (a factor of two)
+     * slower. It requires computing get_gravkick_factor twice with different arguments,
+     * which defeats the lookup cache in timefac.c. Because VelPred is used multiple times,
+     * it is much quicker to compute it once and re-use this*/
+    MyFloat * VelPred;            /*!< Predicted velocity at current particle drift time for SPH. 3x vector.*/
 };
 
 /* shortcuts for accessing different slots directly by the index */

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -84,7 +84,6 @@ struct sph_particle_data
     MyFloat EgyWtDensity;           /*!< 'effective' rho to use in hydro equations */
     MyFloat DhsmlEgyDensityFactor;  /*!< correction factor for density-independent entropy formulation */
 
-    MyFloat EntVarPred;         /*!< Predicted entropy at current particle drift time for SPH computation*/
     /* VelPred can always be derived from the current time and acceleration.
      * However, doing so makes the SPH and hydro code much (a factor of two)
      * slower. It requires computing get_gravkick_factor twice with different arguments,
@@ -117,6 +116,8 @@ struct sph_scratch_data
 {
     /* Gradient of the SPH density. 3x vector*/
     MyFloat * GradRho;
+    /*!< Predicted entropy at current particle drift time for SPH computation*/
+    MyFloat * EntVarPred;
 };
 
 /* shortcuts for accessing different slots directly by the index */

--- a/libgadget/timefac.c
+++ b/libgadget/timefac.c
@@ -215,6 +215,8 @@ double get_drift_factor(inttime_t ti0, inttime_t ti1)
  */
 double get_gravkick_factor(inttime_t ti0, inttime_t ti1)
 {
+  if(ti0 == ti1)
+      return 0;
   if(ti0 == gk_last_ti0 && ti1 == gk_last_ti1)
     return gk_last_value;
 


### PR DESCRIPTION
This PR changes output. Please review it quite carefully (after memoryopts is reviewed and merged) because I am not sure it is the right idea.

Commit 62bd178 and f982f91 make a difference to output because they fix a bug - before this commit dloga for EntVarPred and gravkick_factor for VelPred are computed from Ti_drift - Ti_kick, but Ti_drift has not yet been updated to the present timestep, so it is finding the predicted quantity at the drift time from the *last* timestep, not the current timestep. 

These commits move the predicted quantities to sph_scratch_data and their initialization to the init of density. At this time Ti_drift has already been updated, so the predicted quantities are computed for the current timestep.

Commit 2785d89 computes the densities after the gravitational forces. This matches what is done in bluetides-ii and in P-Gadget3. It means that because we do not need the sph_scratch_data allocated
during PM, there is a lot more memory available then.

However, UNLIKE bluetides-ii and P-Gadget3, it means that VelPred is computed using the gravitational acceleration from the current timestep, rather than the last timestep (in bluetides-ii VelPred was computed at kick time). This seems more consistent to me. It does mean that the HydroAccel in VelPred is from a different timestep than the GravAccel, but since GravAccel and HydroAccel are decoupled I think this should be ok and maybe more accurate. If you disagree let me know and I will drop the commit. I am not sure about this.

The place VelPred is actually used is to compute DivVel and CurlVel. These are both a little weird. Although they are computed using the velocity at the current drift time, they are only re-computed for active particles. So when they are used in hydra.c to compute artificial viscosity between two particles, if one of the particles is inactive the DivVel and CurlVel for the viscosity are strictly speaking being evaluated at an earlier time than the current drift. This doesn't make a lot of sense but is (probably) ok because if the velocity were changing significantly the particle would be active. My guess is that since viscosity is kind of wacky in SPH anyway the true fix is to switch to MFM.

I considered trying to compute density() and hydra() after adding the kick, so we wouldn't need velocity prediction at all, but I decided against it because it would make hydroaccel use a different timestepping scheme than gravaccel.