### PR TITLE
Injectedbhenergy

### DIFF
--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -117,8 +117,6 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
             SPHP(i).DivVel = 0;
         }
         SPHP(i).DelayTime = 0;
-
-        SPHP(i).Injected_BH_Energy = 0;
     }
 
     walltime_measure("/Init");

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -98,10 +98,6 @@ struct sph_particle_data
     MyFloat Ne;  /*!< electron fraction, expressed as local electron number
                    density normalized to the hydrogen number density. Gives
                    indirectly ionization state and mean molecular weight. */
-
-    /*Used to store the BH feedback energy if black holes are on*/
-    MyFloat       Injected_BH_Energy;
-
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
 };

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -459,9 +459,9 @@ get_timestep_ti(const int p, const inttime_t dti_max)
                 P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2]
               );
         if(P[p].Type == 0)
-            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g injected energy = %g\n",
+            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n",
                     SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb, SPH_EOMDensity(p),
-                    SPH_DhsmlDensityFactor(p), SPHP(p).Entropy, SPHP(p).DtEntropy, SPHP(p).Injected_BH_Energy);
+                    SPH_DhsmlDensityFactor(p), SPHP(p).Entropy, SPHP(p).DtEntropy);
     }
 
     return dti;


### PR DESCRIPTION
Instead of creating Injected_BH_Energy and adding it in the SFR code,
just add the BH feedback energy directly into blackhole.c

The previous code was doing something complicated: first it collected the total energy injected by the BH in a temporary variable, then it adds it to the total entropy when doing cooling. This means that the BH can never prevent a star forming region from being star forming. I think that this is unphysical: if you hit gas with a quasar it should stop forming stars.

Was there a reason we were doing it the previous way that I have missed?