### PR TITLE
Use the same velocities in snapshots as in Gadget-2/3 and as in ICs.

### DIFF
--- a/genic/params.c
+++ b/genic/params.c
@@ -142,6 +142,7 @@ void read_parameterfile(char *fname)
 
     /*Simulation parameters*/
     All.IO.UsePeculiarVelocity = param_get_int(ps, "UsePeculiarVelocity");
+    All.IO.UseGadgetVelocity = 1;
     All.BoxSize = param_get_double(ps, "BoxSize");
     All.Nmesh = param_get_int(ps, "Nmesh");
     All2.Ngrid = param_get_int(ps, "Ngrid");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -116,6 +116,7 @@ extern struct global_data_all_processes
         int EnableAggregatedIO;  /* Enable aggregated IO policy for small files.*/
         size_t AggregatedIOThreshold; /* bytes per writer above which to use non-aggregated IO (avoid OOM)*/
         int UsePeculiarVelocity;
+        int UseGadgetVelocity; /* If this is true, output velocities in the Gadget-2/3 format, which is physical velocity divided by a^{1/2}. This matches the units of MP-GenIC*/
     } IO;
 
     double PartAllocFactor;	/*!< in order to maintain work-load balance, the particle load will usually


### PR DESCRIPTION
This introduces a new header flag specifying whether Gadget-formatted
velocities are used, so that downstream analysis codes can tell the
difference. By default the velocities output are the same as those read
in the ICs. If the flag is not present in the ICs then it is assumed
the ICs have the 1/sqrt(a) factor, but the snapshots do not.