### PR TITLE
Make UsePeculiarVelocities = 1 the default.

### DIFF
--- a/genic/params.c
+++ b/genic/params.c
@@ -50,7 +50,7 @@ create_parameters()
     param_declare_double(ps, "MaxMemSizePerNode", OPTIONAL, 0.6, "Maximum memory per node, in fraction of total memory, or MB if > 1.");
     param_declare_double(ps, "CMBTemperature", OPTIONAL, 2.7255, "CMB temperature in K");
     param_declare_double(ps, "RadiationOn", OPTIONAL, 1, "Include radiation in the background.");
-    param_declare_int(ps, "UsePeculiarVelocity", OPTIONAL, 0, "Set up an run that uses Peculiar Velocity in IO");
+    param_declare_int(ps, "UsePeculiarVelocity", OPTIONAL, 1, "Snapshots will save peculiar velocities to the Velocity field. If 0, then v/sqrt(a) will be used in the ICs to match Gadget-2, but snapshots will save v * a.");
     param_declare_int(ps, "InvertPhase", OPTIONAL, 0, "Flip phase for paired simulation");
 
     param_declare_double(ps, "PrimordialAmp", OPTIONAL, 2.215e-9, "Ignored, but used by external CLASS script to set powr spectrum amplitude.");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -115,6 +115,11 @@ extern struct global_data_all_processes
         int MinNumWriters;        /* Min Number of concurrent writers, this caps number of writers */
         int EnableAggregatedIO;  /* Enable aggregated IO policy for small files.*/
         size_t AggregatedIOThreshold; /* bytes per writer above which to use non-aggregated IO (avoid OOM)*/
+        /* Changes the comoving factors of the snapshot outputs. Set in the ICs.
+         * If UsePeculiarVelocity = 1 then snapshots save to the velocity field the physical peculiar velocity, v = a dx/dt (where x is comoving distance).
+         * If UsePeculiarVelocity = 0 then the velocity field is a * v = a^2 dx/dt in snapshots
+         * and v / sqrt(a) = sqrt(a) dx/dt in the ICs. Note that snapshots never match Gadget-2, which
+         * saves physical peculiar velocity / sqrt(a) in both ICs and snapshots. */
         int UsePeculiarVelocity;
     } IO;
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -481,7 +481,10 @@ petaio_read_header_internal(BigFile * bf) {
         endrun(0, "Failed to read required cosmology from IC header\n");
     }
 
-    /* Fall back to use a**2 * dx/dt if UsePeculiarVelocity is not set in IC */
+    /* If UsePeculiarVelocity = 1 then snapshots save to the velocity field the physical peculiar velocity, v = a dx/dt (where x is comoving distance).
+     * If UsePeculiarVelocity = 0 then the velocity field is a * v = a^2 dx/dt in snapshots
+     * and v / sqrt(a) = sqrt(a) dx/dt in the ICs. Note that snapshots never match Gadget-2, which
+     * saves physical peculiar velocity / sqrt(a) in both ICs and snapshots. */
     All.IO.UsePeculiarVelocity = _get_attr_int(&bh, "UsePeculiarVelocity", 0);
 
     if(0 != big_block_get_attr(&bh, "TotNumPartInit", All.NTotalInit, "u8", 6)) {

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -314,18 +314,17 @@ do_the_short_range_kick(int i, inttime_t tistart, inttime_t tiend)
         }
 
         /* Code here imposes a hard limit (default to speed of light)
-         * on the gas velocity. Then a limit on the change in entropy
-         * FIXME: This should probably not be needed!*/
-        const double velfac = sqrt(All.cf.a3inv);
+         * on the gas velocity. This should rarely be hit.*/
         double vv=0;
         for(j=0; j < 3; j++)
             vv += P[i].Vel[j] * P[i].Vel[j];
         vv = sqrt(vv);
 
-        if(vv > All.MaxGasVel * velfac) {
+        if(vv/All.cf.a > All.MaxGasVel) {
+            message(1,"Gas Particle ID %ld exceeded the gas velocity limit: %g > %g\n",P[i].ID, vv / All.cf.a, All.MaxGasVel);
             for(j=0;j < 3; j++)
             {
-                P[i].Vel[j] *= All.MaxGasVel * velfac / vv;
+                P[i].Vel[j] *= All.MaxGasVel * All.cf.a / vv;
             }
         }
 


### PR DESCRIPTION
This replaces https://github.com/MP-Gadget/MP-Gadget/pull/300

Makes UsePeculiarVelocities = 1 the default, fixes the format conversion script and adds some comments on the velocity format.