### PR TITLE
Fixfofsegfault

### DIFF
--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -579,7 +579,7 @@ static void add_particle_to_group(struct Group * gdst, int i, double BoxSize, in
 
 
     if(P[index].Type == 0) {
-        gdst->Sfr += get_starformation_rate(index);
+        gdst->Sfr += SPHP(index).Sfr;
     }
     if(BlackHoleOn && P[index].Type == 5)
     {

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -173,7 +173,7 @@ static void fof_distribute_particles(MPI_Comm Comm) {
         int j = NpigLocal;
         if(P[i].GrNr < 0) continue;
         if(P[i].GrNr > GrNrMax) GrNrMax = P[i].GrNr;
-/* Yu: found it! this shall be int64 */
+        /* Yu: found it! this shall be int64 */
         // pi[j].origin =  ThisTask * PartManager->MaxPart + i;
         pi[j].origin = ((uint64_t) ThisTask) * PartManager->MaxPart + i;
         pi[j].sortKey = P[i].GrNr;

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -756,8 +756,7 @@ SIMPLE_PROPERTY_TYPE(Metallicity, 4, STARP(i).Metallicity, float, 1)
 SIMPLE_PROPERTY_TYPE(Metallicity, 0, SPHP(i).Metallicity, float, 1)
 static void GTStarFormationRate(int i, float * out) {
     /* Convert to Solar/year */
-    *out = get_starformation_rate(i)
-        * ((All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR));
+    *out = SPHP(i).Sfr * ((All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR));
 }
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 5, BHP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BlackholeMass, BHP(i).Mass, float, 1)

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -210,6 +210,9 @@ void run(DomainDecomp * ddecomp)
             blackhole(&Tree, &TimeNextSeedingCheck);
             /**** radiative cooling and star formation *****/
             cooling_and_starformation(&Tree);
+
+            /* Scratch data cannot be used checkpoint because FOF does an exchange.*/
+            slots_free_sph_scratch_data(SphP_scratch);
         }
 
         /* Update velocity to Ti_Current; this synchonizes TiKick and TiDrift for the active particles */
@@ -251,9 +254,6 @@ void run(DomainDecomp * ddecomp)
         }
 
         write_checkpoint(WriteSnapshot, WriteFOF, &Tree);
-
-        if(GasEnabled)
-            slots_free_sph_scratch_data(SphP_scratch);
 
         write_cpu_log(NumCurrentTiStep);		/* produce some CPU usage info */
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -563,18 +563,18 @@ starformation(int i, double *localsfr, double * sum_sm)
     int newstar = -1;
 
     struct sfr_eeqos_data sfr_data = get_sfr_eeqos(i, dtime);
-    double rateOfSF = get_starformation_rate_full(i, sfr_data);
+    SPHP(i).Sfr = get_starformation_rate_full(i, sfr_data);
     SPHP(i).Ne = sfr_data.ne;
 
     /* amount of stars expect to form */
 
-    double sm = rateOfSF * dtime;
+    double sm = SPHP(i).Sfr * dtime;
 
     double p = sm / P[i].Mass;
 
     *sum_sm += P[i].Mass * (1 - exp(-p));
     /* convert to Solar per Year.*/
-    *localsfr += rateOfSF * (All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR);
+    *localsfr += SPHP(i).Sfr * (All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR);
 
     double w = get_random_number(P[i].ID);
     SPHP(i).Metallicity += w * METAL_YIELD * (1 - exp(-p));
@@ -610,12 +610,6 @@ starformation(int i, double *localsfr, double * sum_sm)
         }
     }
     return newstar;
-}
-
-double get_starformation_rate(int i) {
-    /* returns SFR in internal units */
-    struct sfr_eeqos_data sfr_data = get_sfr_eeqos(i, 0);
-    return get_starformation_rate_full(i, sfr_data);
 }
 
 /* Get the parameters of the basic effective

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -858,7 +858,7 @@ static double get_sfr_factor_due_to_h2(int i) {
      *  properties, from gadget-p; we return the enhancement on SFR in this
      *  function */
 
-    if(!sfr_need_to_compute_sph_grad_rho())
+    if(!SphP_scratch->GradRho)
         endrun(1, "Needed grad rho but not enabled! Should never happen!\n");
     double tau_fmol;
     double zoverzsun = SPHP(i).Metallicity/METAL_YIELD;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -55,6 +55,21 @@ static struct SFRParams
     int Generations;
 } sfr_params;
 
+/* Structure storing the results of an evaluation of the star formation model*/
+struct sfr_eeqos_data
+{
+    /* Relaxation time*/
+    double trelax;
+    /* Star formation timescale*/
+    double tsfr;
+    /* Internal energy of the gas in the hot phase. */
+    double egyhot;
+    /* Fraction of the gas in the cold cloud phase. */
+    double cloudfrac;
+    /* Electron fraction after cooling. */
+    double ne;
+};
+
 /*Cooling only: no star formation*/
 static void cooling_direct(int i);
 
@@ -66,10 +81,11 @@ static int starformation(int i, double *localsfr, double * sum_sm);
 static int quicklyastarformation(int i);
 static double get_sfr_factor_due_to_selfgravity(int i);
 static double get_sfr_factor_due_to_h2(int i);
-static double get_starformation_rate_full(int i, double dtime, double * ne_new, double * trelax, double * egyhot_out, double * cloudfrac);
+static double get_starformation_rate_full(int i, struct sfr_eeqos_data sfr_data);
 static double find_star_mass(int i);
 /*Get enough memory for new star slots. This may be excessively slow! Don't do it too often.*/
 static int * sfr_reserve_slots(int * NewStars, int NumNewStar, ForceTree * tt);
+static struct sfr_eeqos_data get_sfr_eeqos(int i, double dtime);
 
 /*Set the parameters of the SFR module*/
 void set_sfr_params(ParameterSet * ps)
@@ -438,12 +454,10 @@ double get_neutral_fraction_sfreff(int i, double redshift)
          * fraction than the hot gas*/
         double dloga = get_dloga_for_bin(P[i].TimeBin);
         double dtime = dloga / All.cf.hubble;
-        double egyhot, cloudfrac;
-        double ne = SPHP(i).Ne;
-        get_starformation_rate_full(i, dtime, &ne, NULL, &egyhot, &cloudfrac);
-        double nh0cold = GetNeutralFraction(sfr_params.EgySpecCold, physdens, &uvbg, ne);
-        double nh0hot = GetNeutralFraction(egyhot, physdens, &uvbg, ne);
-        nh0 =  nh0cold * cloudfrac + (1-cloudfrac) * nh0hot;
+        struct sfr_eeqos_data sfr_data = get_sfr_eeqos(i, dtime);
+        double nh0cold = GetNeutralFraction(sfr_params.EgySpecCold, physdens, &uvbg, sfr_data.ne);
+        double nh0hot = GetNeutralFraction(sfr_data.egyhot, physdens, &uvbg, sfr_data.ne);
+        nh0 =  nh0cold * sfr_data.cloudfrac + (1-sfr_data.cloudfrac) * nh0hot;
     }
     return nh0;
 }
@@ -548,11 +562,9 @@ starformation(int i, double *localsfr, double * sum_sm)
     double dtime = dloga / All.cf.hubble;
     int newstar = -1;
 
-    double cloudfrac, trelax, egyhot;
-
-    double dblNe = -1;
-    double rateOfSF = get_starformation_rate_full(i, dtime, &dblNe, &trelax, &egyhot, &cloudfrac);
-    SPHP(i).Ne = dblNe;
+    struct sfr_eeqos_data sfr_data = get_sfr_eeqos(i, dtime);
+    double rateOfSF = get_starformation_rate_full(i, sfr_data);
+    SPHP(i).Ne = sfr_data.ne;
 
     /* amount of stars expect to form */
 
@@ -569,9 +581,9 @@ starformation(int i, double *localsfr, double * sum_sm)
 
     if(dloga > 0 && P[i].TimeBin)
     {
-        double egyeff = sfr_params.EgySpecCold * cloudfrac + (1 - cloudfrac) * egyhot;
+        double egyeff = sfr_params.EgySpecCold * sfr_data.cloudfrac + (1 - sfr_data.cloudfrac) * sfr_data.egyhot;
         /* upon start-up, we need to protect against dloga ==0 */
-        cooling_relaxed(i, egyeff, dtime, trelax);
+        cooling_relaxed(i, egyeff, dtime, sfr_data.trelax);
     }
 
     double mass_of_star = find_star_mass(i);
@@ -602,72 +614,60 @@ starformation(int i, double *localsfr, double * sum_sm)
 
 double get_starformation_rate(int i) {
     /* returns SFR in internal units */
-    return get_starformation_rate_full(i, 0, NULL, NULL, NULL, NULL);
+    struct sfr_eeqos_data sfr_data = get_sfr_eeqos(i, 0);
+    return get_starformation_rate_full(i, sfr_data);
 }
 
-static double get_starformation_rate_full(int i, double dtime, double * ne_new, double * trelax, double * egyhot_out, double * cloudfrac) {
-    double rateOfSF, tsfr;
-    double factorEVP, egyhot, ne, tcool, y, x, cloudmass;
+/* Get the parameters of the basic effective
+ * equation of state model for a particle.*/
+static struct sfr_eeqos_data get_sfr_eeqos(int i, double dtime)
+{
+    struct sfr_eeqos_data data;
+    /* Initialise data to something, just in case.*/
+    data.trelax = sfr_params.MaxSfrTimescale;
+    data.tsfr = sfr_params.MaxSfrTimescale;
+    data.egyhot = sfr_params.EgySpecCold;
+    data.cloudfrac = 0;
+    data.ne = 0;
 
-    if(!All.StarformationOn || !sfreff_on_eeqos(i)) {
-        /* this shall not happen but let's put in some safe
-         * numbers in case the code runs away!
-         *
-         * the only case trelax and egyeff are
-         * required is in starformation(i)
-         * */
-        if (trelax) {
-            *trelax = sfr_params.MaxSfrTimescale;
-        }
-        if (egyhot_out) {
-            *egyhot_out = sfr_params.EgySpecCold;
-        }
-        if (cloudfrac) {
-            *cloudfrac = 0;
-        }
+    /* This shall never happen, but just in case*/
+    if(!All.StarformationOn || !sfreff_on_eeqos(i))
+        return data;
 
-        return 0;
-    }
-
-    tsfr = sqrt(sfr_params.PhysDensThresh / (SPHP(i).Density * All.cf.a3inv)) * sfr_params.MaxSfrTimescale;
+    data.ne = SPHP(i).Ne;
+    data.tsfr = sqrt(sfr_params.PhysDensThresh / (SPHP(i).Density * All.cf.a3inv)) * sfr_params.MaxSfrTimescale;
     /*
      * gadget-p doesn't have this cap.
      * without the cap sm can be bigger than cloudmass.
     */
-    if(tsfr < dtime)
-        tsfr = dtime;
+    if(data.tsfr < dtime)
+        data.tsfr = dtime;
 
     double redshift = 1./All.Time - 1;
     struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
 
-    factorEVP = pow(SPHP(i).Density * All.cf.a3inv / sfr_params.PhysDensThresh, -0.8) * sfr_params.FactorEVP;
+    double factorEVP = pow(SPHP(i).Density * All.cf.a3inv / sfr_params.PhysDensThresh, -0.8) * sfr_params.FactorEVP;
 
-    egyhot = sfr_params.EgySpecSN / (1 + factorEVP) + sfr_params.EgySpecCold;
+    data.egyhot = sfr_params.EgySpecSN / (1 + factorEVP) + sfr_params.EgySpecCold;
 
-    ne = SPHP(i).Ne;
+    double tcool = GetCoolingTime(redshift, data.egyhot, SPHP(i).Density * All.cf.a3inv, &uvbg, &data.ne, SPHP(i).Metallicity);
+    double y = data.tsfr / tcool * data.egyhot / (sfr_params.FactorSN * sfr_params.EgySpecSN - (1 - sfr_params.FactorSN) * sfr_params.EgySpecCold);
 
-    tcool = GetCoolingTime(redshift, egyhot, SPHP(i).Density * All.cf.a3inv, &uvbg, &ne, SPHP(i).Metallicity);
-    y = tsfr / tcool * egyhot / (sfr_params.FactorSN * sfr_params.EgySpecSN - (1 - sfr_params.FactorSN) * sfr_params.EgySpecCold);
+    data.cloudfrac = 1 + 1 / (2 * y) - sqrt(1 / y + 1 / (4 * y * y));
 
-    x = 1 + 1 / (2 * y) - sqrt(1 / y + 1 / (4 * y * y));
+    data.trelax = data.tsfr * (1 - data.cloudfrac) / data.cloudfrac / (sfr_params.FactorSN * (1 + factorEVP));
+    return data;
+}
 
-    cloudmass = x * P[i].Mass;
-
-    rateOfSF = (1 - sfr_params.FactorSN) * cloudmass / tsfr;
-
-    if (ne_new ) {
-        *ne_new = ne;
+static double get_starformation_rate_full(int i, struct sfr_eeqos_data sfr_data)
+{
+    if(!All.StarformationOn || !sfreff_on_eeqos(i)) {
+        return 0;
     }
 
-    if (trelax) {
-        *trelax = tsfr * (1 - x) / x / (sfr_params.FactorSN * (1 + factorEVP));
-    }
-    if (cloudfrac) {
-        *cloudfrac = x;
-    }
-    if(egyhot_out) {
-        *egyhot_out = egyhot;
-    }
+    double cloudmass = sfr_data.cloudfrac * P[i].Mass;
+
+    double rateOfSF = (1 - sfr_params.FactorSN) * cloudmass / sfr_data.tsfr;
 
     if (HAS(sfr_params.StarformationCriterion, SFR_CRITERION_MOLECULAR_H2)) {
         rateOfSF *= get_sfr_factor_due_to_h2(i);

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -24,7 +24,6 @@ void set_sfr_params(ParameterSet * ps);
 void init_cooling_and_star_formation(void);
 /*Do the cooling and the star formation. The tree is required for the winds only.*/
 void cooling_and_starformation(ForceTree * tree);
-double get_starformation_rate(int i);
 
 /*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
  * This calls the cooling routines for the current internal energy when off the equation of state, but

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -664,7 +664,9 @@ void
 slots_free_sph_scratch_data(struct sph_scratch_data * SphScratch)
 {
     myfree(SphScratch->VelPred);
+    SphScratch->VelPred = NULL;
     myfree(SphScratch->EntVarPred);
+    SphScratch->EntVarPred = NULL;
     if(SphScratch->GradRho) {
         myfree(SphScratch->GradRho);
         SphScratch->GradRho = NULL;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -104,6 +104,8 @@ struct sph_particle_data
 
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
+    MyFloat Sfr; /* Star formation rate. Stored here because, if the H2 dependent star formation is used,
+                    it depends on the scratch variable GradRho and thus cannot be recomputed after a fof-exchange. */
 };
 
 struct sph_scratch_data


### PR DESCRIPTION
This PR fixes a segfault in the FOF code on particle write. The segfault was happening because the star formation rate calculation may use SPH.GradRho, and after the exchange in FOF SPH.GradRho may be on a different processor. There are two fixes needed. The first is to compute the neutral fraction without computing the star formation rate and the second is to store the star formation rate in the sph_particle_data struct again so that it goes with the FOF exchange.

Commit 1e47aad implements the first by refactoring the star formation rate code so that the effective equation of state parameters are computed in one function and the actual SFR in another. It does marginally change the output of the hydro run, slightly increasing the number of stars. Looking at sfr.txt it seems that the change is in particles with a small sfr, which have their sfrs scattered slightly and symmetrically with a median of exactly zero. I *think* therefore that this is just the fp optimizations being applied a bit differently, but please review carefully in case I missed something.