### PR TITLE
Injected bh

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -614,7 +614,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
     if(P[other].Type == 0) {
         if(r2 < iter->feedback_kernel.HH && P[other].Mass > 0) {
             double u = r * iter->feedback_kernel.Hinv;
-            double wk;
+            double wk = 1.0;
             double mass_j;
 
             lock_particle(other);
@@ -626,10 +626,8 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
             }
             if(HAS(blackhole_params.BlackHoleFeedbackMethod, BH_FEEDBACK_SPLINE))
                 wk = density_kernel_wk(&iter->feedback_kernel, u);
-            else
-            wk = 1.0;
 
-            if(I->FeedbackWeightSum > 0)
+            if(I->FeedbackWeightSum > 0 && I->FeedbackEnergy > 0)
             {
                 SphP_scratch->Injected_BH_Energy[P[other].PI] += (I->FeedbackEnergy * mass_j * wk / I->FeedbackWeightSum);
             }

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -117,8 +117,6 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
             SPHP(i).DivVel = 0;
         }
         SPHP(i).DelayTime = 0;
-
-        SPHP(i).Injected_BH_Energy = 0;
     }
 
     walltime_measure("/Init");

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -227,6 +227,10 @@ void cooling_and_starformation(ForceTree * tree)
     /*Done with the parents*/
     myfree(NewParents);
 
+    /* This is allocated high so has to be freed after the parents*/
+    if(All.BlackHoleOn)
+        myfree(SphP_scratch->Injected_BH_Energy);
+
     int64_t tot_spawned=0, tot_converted=0;
     sumup_large_ints(1, &stars_spawned, &tot_spawned);
     sumup_large_ints(1, &stars_converted, &tot_converted);
@@ -367,10 +371,9 @@ cooling_direct(int i) {
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
             GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 
-    if(All.BlackHoleOn && SPHP(i).Injected_BH_Energy)
+    if(All.BlackHoleOn && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
     {
-        unew = add_injected_BH_energy(unew, SPHP(i).Injected_BH_Energy, P[i].Mass);
-        SPHP(i).Injected_BH_Energy = 0;
+        unew = add_injected_BH_energy(unew, SphP_scratch->Injected_BH_Energy[P[i].PI], P[i].Mass);
     }
 
     double redshift = 1./All.Time - 1;
@@ -476,9 +479,9 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
     const double densityfac = pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double egycurrent = SPHP(i).Entropy *  densityfac;
 
-    if(All.BlackHoleOn && SPHP(i).Injected_BH_Energy > 0)
+    if(All.BlackHoleOn && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
     {
-        egycurrent = add_injected_BH_energy(egycurrent, SPHP(i).Injected_BH_Energy, P[i].Mass);
+        egycurrent = add_injected_BH_energy(egycurrent, SphP_scratch->Injected_BH_Energy[P[i].PI], P[i].Mass);
 
         if(egycurrent > egyeff)
         {
@@ -490,8 +493,6 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
             if(tcool < trelax && tcool > 0)
                 trelax = tcool;
         }
-
-        SPHP(i).Injected_BH_Energy = 0;
     }
 
     SPHP(i).Entropy =  (egyeff + (egycurrent - egyeff) * exp(-dtime / trelax)) /densityfac;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -228,8 +228,10 @@ void cooling_and_starformation(ForceTree * tree)
     myfree(NewParents);
 
     /* This is allocated high so has to be freed after the parents*/
-    if(All.BlackHoleOn)
+    if(SphP_scratch->Injected_BH_Energy) {
         myfree(SphP_scratch->Injected_BH_Energy);
+        SphP_scratch->Injected_BH_Energy = NULL;
+    }
 
     int64_t tot_spawned=0, tot_converted=0;
     sumup_large_ints(1, &stars_spawned, &tot_spawned);
@@ -371,7 +373,7 @@ cooling_direct(int i) {
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
             GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1));
 
-    if(All.BlackHoleOn && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
+    if(SphP_scratch->Injected_BH_Energy && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
     {
         unew = add_injected_BH_energy(unew, SphP_scratch->Injected_BH_Energy[P[i].PI], P[i].Mass);
     }
@@ -479,7 +481,7 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
     const double densityfac = pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double egycurrent = SPHP(i).Entropy *  densityfac;
 
-    if(All.BlackHoleOn && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
+    if(SphP_scratch->Injected_BH_Energy && SphP_scratch->Injected_BH_Energy[P[i].PI] > 0)
     {
         egycurrent = add_injected_BH_energy(egycurrent, SphP_scratch->Injected_BH_Energy[P[i].PI], P[i].Mass);
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -488,8 +488,22 @@ static void cooling_relaxed(int i, double egyeff, double dtime, double trelax) {
             double redshift = 1./All.Time - 1;
             struct UVBG uvbg = get_local_UVBG(redshift, P[i].Pos);
             double ne = SPHP(i).Ne;
+            /* In practice tcool << trelax*/
             double tcool = GetCoolingTime(redshift, egycurrent, SPHP(i).Density * All.cf.a3inv, &uvbg, &ne, SPHP(i).Metallicity);
 
+            /* If tcool is being used the exponential below is roughly zero. This could more compactly be written:
+             * if(Injected_BH_Energy && egycurrent > egyeff)
+             *      SPHP(i).Entropy = egyeff/densityfac.
+             * In other words, any star-forming gas which is heated by a black hole instantaneously cools
+             * to the effective equation of state temperature.
+             * This reduces the effect of black hole feedback marginally (a 5% reduction in star formation)
+             * and dates from the earliest versions of this code available.
+             * The effect is relatively small because star-forming gas cools onto the effective equation
+             * of state quickly anyway.
+             * It is not clear to me (SPB) what this is modelling but removing it causes hot dense particles
+             * with short timesteps to appear around the black holes and slows down the code.
+             * Someone might want to check at some point if removing this condition helps or hinders
+             * agreement with observations.*/
             if(tcool < trelax && tcool > 0)
                 trelax = tcool;
         }

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -655,6 +655,8 @@ slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph)
         SphScratch.GradRho = mymalloc2("SPH_GradRho", sizeof(MyFloat) * 3 * nsph);
     else
         SphScratch.GradRho = NULL;
+    /* Allocated in black hole, freed in sfr.*/
+    SphScratch.Injected_BH_Energy = NULL;
     SphScratch.EntVarPred = mymalloc2("EntVarPred", sizeof(MyFloat) * nsph);
     SphScratch.VelPred = mymalloc2("VelPred", sizeof(MyFloat) * 3 * nsph);
     SlotsManager->info[0].scratchdata = (char *) &SphScratch;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -98,10 +98,6 @@ struct sph_particle_data
     MyFloat Ne;  /*!< electron fraction, expressed as local electron number
                    density normalized to the hydrogen number density. Gives
                    indirectly ionization state and mean molecular weight. */
-
-    /*Used to store the BH feedback energy if black holes are on*/
-    MyFloat       Injected_BH_Energy;
-
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
 };
@@ -118,6 +114,8 @@ struct sph_scratch_data
      * which defeats the lookup cache in timefac.c. Because VelPred is used multiple times,
      * it is much quicker to compute it once and re-use this*/
     MyFloat * VelPred;            /*!< Predicted velocity at current particle drift time for SPH. 3x vector.*/
+    /*Used to store the BH feedback energy if black holes are on*/
+    MyFloat * Injected_BH_Energy;
 };
 
 /* shortcuts for accessing different slots directly by the index */

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -459,9 +459,9 @@ get_timestep_ti(const int p, const inttime_t dti_max)
                 P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2]
               );
         if(P[p].Type == 0)
-            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g injected energy = %g\n",
+            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n",
                     SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb, SPH_EOMDensity(p),
-                    SPH_DhsmlDensityFactor(p), SPHP(p).Entropy, SPHP(p).DtEntropy, SPHP(p).Injected_BH_Energy);
+                    SPH_DhsmlDensityFactor(p), SPHP(p).Entropy, SPHP(p).DtEntropy);
     }
 
     return dti;


### PR DESCRIPTION
This moves the SPH_injected_bh out of sph_particle data the *other* way, by moving into scratch. The slightly odd behaviour of heated star-forming gas is thus preserved. This keeps all the behaviour of the old code intact.