### PR TITLE
Clean up initialisation of the densities

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -288,9 +288,8 @@ density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw)
         I->Vel[0] = SphP_scratch->VelPred[3 * P[place].PI];
         I->Vel[1] = SphP_scratch->VelPred[3 * P[place].PI + 1];
         I->Vel[2] = SphP_scratch->VelPred[3 * P[place].PI + 2];
+        I->DelayTime = SPHP(place).DelayTime;
     }
-
-    I->DelayTime = SPHP(place).DelayTime;
 
 }
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -91,6 +91,7 @@ struct DensityPriv {
     int NIteration;
     int *NPLeft;
     int update_hsml;
+    int DoEgyDensity;
 };
 
 #define DENSITY_GET_PRIV(tw) ((struct DensityPriv*) ((tw)->priv))
@@ -130,29 +131,11 @@ static void density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw);
  * that one has to deal with substantially more than normal number of
  * neighbours.)
  */
-
-static void
-density_internal(int update_hsml, ForceTree * tree);
-
 void
-density(ForceTree * tree)
-{
-    /* recompute hsml and pre hydro quantities */
-    density_internal(1, tree);
-}
-
-void
-density_update(ForceTree * tree)
-{
-    /* recompute pre hydro quantities without computing hsml */
-    density_internal(0, tree);
-}
-
-static void
-density_internal(int update_hsml, ForceTree * tree)
+density(int update_hsml, int DoEgyDensity, ForceTree * tree)
 {
     if(!All.DensityOn)
-	return;
+        return;
 
     TreeWalk tw[1] = {{0}};
     struct DensityPriv priv[1];
@@ -183,6 +166,7 @@ density_internal(int update_hsml, ForceTree * tree)
     DENSITY_GET_PRIV(tw)->Right = (MyFloat *) mymalloc("DENSITY_GET_PRIV(tw)->Right", PartManager->NumPart * sizeof(MyFloat));
     DENSITY_GET_PRIV(tw)->Rot = (MyFloat (*) [3]) mymalloc("DENSITY_GET_PRIV(tw)->Rot", SlotsManager->info[0].size * sizeof(priv->Rot[0]));
     DENSITY_GET_PRIV(tw)->update_hsml = update_hsml;
+    DENSITY_GET_PRIV(tw)->DoEgyDensity = DoEgyDensity;
 
     DENSITY_GET_PRIV(tw)->NIteration = 0;
 
@@ -319,7 +303,7 @@ density_reduce(int place, TreeWalkResultDensity * remote, enum TreeWalkReduceMod
         }
 
         /*Only used for density independent SPH*/
-        if(All.DensityIndependentSphOn) {
+        if(DENSITY_GET_PRIV(tw)->DoEgyDensity) {
             TREEWALK_REDUCE(SPHP(place).EgyWtDensity, remote->EgyRho);
             TREEWALK_REDUCE(SPHP(place).DhsmlEgyDensityFactor, remote->DhsmlEgyDensity);
         }
@@ -390,7 +374,7 @@ density_ngbiter(
         double density_dW = density_kernel_dW(&iter->kernel, u, wk, dwk);
         O->DhsmlDensity += mass_j * density_dW;
 
-        if(All.DensityIndependentSphOn) {
+        if(DENSITY_GET_PRIV(lv->tw)->DoEgyDensity) {
             const double EntPred = SphP_scratch->EntVarPred[P[other].PI];
             O->EgyRho += mass_j * EntPred * wk;
             O->DhsmlEgyDensity += mass_j * EntPred * density_dW;
@@ -458,7 +442,7 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlDensityFactor = 1;
 
             /*Compute the EgyWeight factors, which are only useful for density independent SPH */
-            if(All.DensityIndependentSphOn) {
+            if(DENSITY_GET_PRIV(tw)->DoEgyDensity) {
                 const double EntPred = SphP_scratch->EntVarPred[P[i].PI];
                 if((EntPred > 0) && (SPHP(i).EgyWtDensity>0))
                 {

--- a/libgadget/density.h
+++ b/libgadget/density.h
@@ -3,8 +3,12 @@
 
 #include "forcetree.h"
 
-void density(ForceTree * tree);
-
-void density_update(ForceTree * tree);
+/* This routine computes the particle densities. If update_hsml is true
+ * it runs multiple times, changing the smoothing length until
+ * there are enough neighbours. If update_hsml is false (when initializing the EgyWtDensity)
+ * it just computes densities.
+ * If DoEgyDensity is true it also computes the entropy-weighted density for
+ * pressure-entropy SPH. */
+void density(int update_hsml, int DoEgyDensity, ForceTree * tree);
 
 #endif

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -285,7 +285,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
         }
 
     /*Allocate the extra SPH data for transient SPH particle properties.*/
-    slots_allocate_sph_scratch_data(sfr_need_to_compute_sph_grad_rho(), SlotsManager->info[0].size);
+    slots_allocate_sph_scratch_data(0, SlotsManager->info[0].size);
 
     density(&Tree);
 

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -240,26 +240,25 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
 
     if(RestartSnapNum == -1)
     {
-#pragma omp parallel for
+        /* quick hack to adjust for the baryon fraction
+         * only this fraction of mass is of that type.
+         * this won't work for non-dm non baryon;
+         * ideally each node shall have separate count of
+         * ptypes of each type.
+         *
+         * Eventually the iteration will fix this. */
+         const double massfactor = 0.04/0.26;
+
+        #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++)
         {
-            int no = force_get_father(i, &Tree);
-            /* Don't need smoothing lengths for DM particles*/
-            if(P[i].Type != 0 && P[i].Type != 4 && P[i].Type != 5)
+            /* These initial smoothing lengths are only used for SPH.
+             * BH is set elsewhere. */
+            if(P[i].Type != 0)
                 continue;
-            /* quick hack to adjust for the baryon fraction
-             * only this fraction of mass is of that type.
-             * this won't work for non-dm non baryon;
-             * ideally each node shall have separate count of
-             * ptypes of each type.
-             *
-             * Eventually the iteration will fix this. */
-            double massfactor;
-            if(P[i].Type == 0) {
-                massfactor = 0.04 / 0.26;
-            } else {
-                massfactor = 1.0 - 0.04 / 0.26;
-            }
+
+            int no = force_get_father(i, &Tree);
+
             while(10 * All.DesNumNgb * P[i].Mass > massfactor * Tree.Nodes[no].u.d.mass)
             {
                 int p = force_get_father(no, &Tree);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -97,6 +97,12 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
             /* Note: Gadget-3 sets this to the seed black hole mass.*/
             BHP(i).Mass = P[i].Mass;
             BHP(i).TimeBinLimit = -1;
+
+            /* Touch up potentially zero BH smoothing lengths, since they have historically not been saved in the snapshots.
+             * Anything non-zero would work, but since BH tends to be in high density region,
+             *  use a small number */
+            if(P[i].Hsml == 0)
+                P[i].Hsml = 0.01 * All.MeanSeparation[0];
         }
         P[i].Key = PEANO(P[i].Pos, All.BoxSize);
 
@@ -279,15 +285,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
                 P[i].Hsml = All.MeanSeparation[0];
         }
     }
-
-    /* FIXME: move this inside the condition above and
-      * save BHs in the snapshots to avoid this; */
-    for(i = 0; i < PartManager->NumPart; i++)
-        if(P[i].Type == 5) {
-            /* Anything non-zero would work, but since BH tends to be in high density region,
-             *  use a small number */
-            P[i].Hsml = 0.01 * All.MeanSeparation[0];
-        }
 
     /*Allocate the extra SPH data for transient SPH particle properties.*/
     slots_allocate_sph_scratch_data(0, SlotsManager->info[0].size);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -96,6 +96,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
         {
             /* Note: Gadget-3 sets this to the seed black hole mass.*/
             BHP(i).Mass = P[i].Mass;
+            BHP(i).TimeBinLimit = -1;
         }
         P[i].Key = PEANO(P[i].Pos, All.BoxSize);
 
@@ -286,7 +287,6 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
             /* Anything non-zero would work, but since BH tends to be in high density region,
              *  use a small number */
             P[i].Hsml = 0.01 * All.MeanSeparation[0];
-            BHP(i).TimeBinLimit = -1;
         }
 
     /*Allocate the extra SPH data for transient SPH particle properties.*/

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -254,7 +254,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
          * ptypes of each type.
          *
          * Eventually the iteration will fix this. */
-         const double massfactor = 0.04/0.26;
+         const double massfactor = All.CP.OmegaBaryon / All.CP.Omega0;
 
         #pragma omp parallel for
         for(i = 0; i < PartManager->NumPart; i++)

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -851,6 +851,9 @@ static void register_io_blocks() {
     IO_REG(BlackholeMinPotVel,   "f4", 3, 5);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5);
 
+    /* Smoothing lengths for black hole: this is a new addition*/
+    IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5);
+
     if(All.SnapshotWithFOF)
         fof_register_io_blocks();
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -318,7 +318,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled, int HybridN
         /***** density *****/
         message(0, "Start density computation...\n");
 
-        density(tree);  /* computes density, and pressure */
+        density(1, All.DensityIndependentSphOn, tree);  /* computes density, and pressure */
 
         /***** update smoothing lengths in tree *****/
         force_update_hmax(ActiveParticle, NumActiveParticle, tree);


### PR DESCRIPTION
This PR cleanups up the convoluted code in init, so that the initializations are now done in init.c instead of via opaque conditionals in density.c.

Apart from 3899ac2, which changes the hard-coded baryon fraction to the true one, it makes no difference to output (except that, according to a very old fixme, the black hole smoothing length is now saved). It has a very marginal positive effect on the simulation speed.