### PR TITLE
Pass some of the errors as return values.

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -359,8 +359,8 @@ void read_parameter_file(char *fname)
         if(0 != param_parse_file(ps, fname, &error)) {
             endrun(1, "Parsing %s failed: %s\n", fname, error);
         }
-        if(0 != param_validate(ps)) {
-            endrun(1, "Validation of %s failed.\n", fname);
+        if(0 != param_validate(ps, &error)) {
+            endrun(1, "Validation of %s failed: %s\n", fname, error);
         }
 
         message(1, "----------- Running with Parameters ----------\n");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -355,11 +355,12 @@ void read_parameter_file(char *fname)
 
     if(ThisTask == 0) {
 
-        if(0 != param_parse_file(ps, fname)) {
-            endrun(1, "Parsing %s failed.", fname);
+        char * error;
+        if(0 != param_parse_file(ps, fname, &error)) {
+            endrun(1, "Parsing %s failed: %s\n", fname, error);
         }
         if(0 != param_validate(ps)) {
-            endrun(1, "Validation of %s failed.", fname);
+            endrun(1, "Validation of %s failed.\n", fname);
         }
 
         message(1, "----------- Running with Parameters ----------\n");

--- a/genic/params.c
+++ b/genic/params.c
@@ -74,12 +74,13 @@ void read_parameterfile(char *fname)
     /* read parameter file on all processes for simplicty */
 
     ParameterSet * ps = create_parameters();
+    char * error;
 
-    if(0 != param_parse_file(ps, fname)) {
-        endrun(0, "Parsing %s failed.", fname);
+    if(0 != param_parse_file(ps, fname, &error)) {
+        endrun(0, "Parsing %s failed: %s\n", fname, *error);
     }
     if(0 != param_validate(ps)) {
-        endrun(0, "Validation of %s failed.", fname);
+        endrun(0, "Validation of %s failed.\n", fname);
     }
 
     message(0, "----------- Running with Parameters ----------\n");

--- a/genic/params.c
+++ b/genic/params.c
@@ -79,8 +79,8 @@ void read_parameterfile(char *fname)
     if(0 != param_parse_file(ps, fname, &error)) {
         endrun(0, "Parsing %s failed: %s\n", fname, *error);
     }
-    if(0 != param_validate(ps)) {
-        endrun(0, "Validation of %s failed.\n", fname);
+    if(0 != param_validate(ps, &error)) {
+        endrun(0, "Validation of %s failed: %s\n", fname, *error);
     }
 
     message(0, "----------- Running with Parameters ----------\n");

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -169,7 +169,7 @@ int param_validate(ParameterSet * ps, char **error)
     for(i = 0; i < ps->size; i ++) {
         ParameterSchema * p = &ps->p[i];
         if(p->required == REQUIRED && ps->value[p->index].nil) {
-            char error1 = fastpm_strdup_printf("Parameter `%s` is required, but not set.", p->name);
+            char * error1 = fastpm_strdup_printf("Parameter `%s` is required, but not set.", p->name);
             char * tmp = fastpm_strappend(*error, "\n", error1);
             free(error1);
             if(*error) free(*error);
@@ -212,13 +212,13 @@ int param_parse (ParameterSet * ps, char * content, char **error)
         if(*p == '\n' || *p == 0) {
             char * error1;
             int flag1 = param_emit(ps, p1, p - p1, lineno, &error1);
-            flag |= flag1;
-            if(flag1) {
+            if(flag1 != 0) {
                 char * tmp = fastpm_strappend(*error, "\n", error1);
                 free(error1);
                 if(*error) free(*error);
                 *error = tmp;
             }
+            flag |= flag1;
             if(*p == 0) break;
             p++;
             p1 = p;

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -52,8 +52,8 @@ param_get_enum(ParameterSet * ps, char * name);
 char *
 param_format_value(ParameterSet * ps, char * name);
 
-int param_parse (ParameterSet * ps, char * content);
-int param_parse_file (ParameterSet * ps, const char * filename);
+int param_parse (ParameterSet * ps, char * content, char **error);
+int param_parse_file (ParameterSet * ps, const char * filename, char **error);
 int param_validate(ParameterSet * ps); /* 0 for good, 1 for bad; prints messages. */
 void param_dump(ParameterSet * ps, FILE * stream);
 

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -53,8 +53,10 @@ char *
 param_format_value(ParameterSet * ps, char * name);
 
 int param_parse (ParameterSet * ps, char * content, char **error);
+/* returns 0 on no error; 1 on error, and *error needs to be freed by the caller with free() */
 int param_parse_file (ParameterSet * ps, const char * filename, char **error);
-int param_validate(ParameterSet * ps, char **error); /* 0 for good, 1 for bad */
+/* returns 0 on no error; 1 on error, and *error needs to be freed by the caller with free() */
+int param_validate(ParameterSet * ps, char **error);
 void param_dump(ParameterSet * ps, FILE * stream);
 
 ParameterSet *

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -54,7 +54,7 @@ param_format_value(ParameterSet * ps, char * name);
 
 int param_parse (ParameterSet * ps, char * content, char **error);
 int param_parse_file (ParameterSet * ps, const char * filename, char **error);
-int param_validate(ParameterSet * ps); /* 0 for good, 1 for bad; prints messages. */
+int param_validate(ParameterSet * ps, char **error); /* 0 for good, 1 for bad */
 void param_dump(ParameterSet * ps, FILE * stream);
 
 ParameterSet *

--- a/libgadget/utils/string.c
+++ b/libgadget/utils/string.c
@@ -69,7 +69,7 @@ fastpm_strdup(const char * str)
 char *
 fastpm_strappend(const char * base, const char * delim, const char * next)
 {
-    if(base == NULL) return next;
+    if(base == NULL) return fastpm_strdup(next);
     return fastpm_strdup_printf("%s%s%s", base, delim, next);
 }
 

--- a/libgadget/utils/string.c
+++ b/libgadget/utils/string.c
@@ -67,6 +67,13 @@ fastpm_strdup(const char * str)
 }
 
 char *
+fastpm_strappend(const char * base, const char * delim, const char * next)
+{
+    if(base == NULL) return next;
+    return fastpm_strdup_printf("%s%s%s", base, delim, next);
+}
+
+char *
 fastpm_strdup_printf(const char * fmt, ...)
 {
     va_list va;

--- a/libgadget/utils/string.h
+++ b/libgadget/utils/string.h
@@ -18,6 +18,9 @@ fastpm_strdup_printf(const char * fmt, ...);
 char *
 fastpm_strdup_vprintf(const char * fmt, va_list va);
 
+char *
+fastpm_strappend(const char * base, const char * delim, const char * next);
+
 void
 fastpm_path_ensure_dirname(const char * path);
 


### PR DESCRIPTION
Then they can be printed with endrun / message, thus not swallowed
by the super computers at crash.