### PR TITLE
Add a density test and fix a bunch of density bugs

### DIFF
--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -60,6 +60,7 @@ TESTED = hci \
 	neutrinos_lra \
 	omega_nu_single \
 	cooling_rates \
+	density \
 	exchange
 
 MPI_TESTED = exchange
@@ -131,8 +132,12 @@ all: libgadget.a libgadget-utils.a
 .objs/test_cooling_rates: tests/test_cooling_rates.c .objs/cooling_rates.o .objs/cooling_uvfluc.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
 
+.objs/test_density: tests/test_density.c .objs/density.o libgadget.a ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
+	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
+
 .objs/test_cooling: tests/test_cooling.c .objs/cooling.o .objs/cooling_rates.o .objs/cooling_uvfluc.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
+
 build-tests: $(TESTBIN)
 
 test : build-tests

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -510,11 +510,9 @@ void density_check_neighbours (int i, TreeWalk * tw) {
         }
 
         /* If we need more neighbours, move the lower bound up. If we need fewer, move the upper bound down.*/
-        if(P[i].NumNgb < (desnumngb - All.MaxNumNgbDeviation)) {
-            if(Left[i] < P[i].Hsml)
+        if(P[i].NumNgb < desnumngb) {
                 Left[i] = P[i].Hsml;
         } else {
-            if(Right[i] > P[i].Hsml)
                 Right[i] = P[i].Hsml;
         }
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -494,8 +494,7 @@ void density_check_neighbours (int i, TreeWalk * tw) {
     MyFloat * Right = DENSITY_GET_PRIV(tw)->Right;
 
     if(P[i].NumNgb < (desnumngb - All.MaxNumNgbDeviation) ||
-            (P[i].NumNgb > (desnumngb + All.MaxNumNgbDeviation)
-             && P[i].Hsml > (1.01 * All.MinGasHsml)))
+            (P[i].NumNgb > (desnumngb + All.MaxNumNgbDeviation)))
     {
         /* need to redo this particle */
         if(P[i].DensityIterationDone) {
@@ -570,18 +569,25 @@ void density_check_neighbours (int i, TreeWalk * tw) {
             }
         }
 
-        if(P[i].Hsml < All.MinGasHsml)
-            P[i].Hsml = All.MinGasHsml;
-
         if(All.BlackHoleOn && P[i].Type == 5)
             if(Left[i] > All.BlackHoleMaxAccretionRadius)
             {
-                /* this will stop the search for a new BH smoothing length in the next iteration */
-                P[i].Hsml = Left[i] = Right[i] = All.BlackHoleMaxAccretionRadius;
+                P[i].Hsml = All.BlackHoleMaxAccretionRadius;
+                P[i].DensityIterationDone = 1;
             }
 
+        if(Right[i] < All.MinGasHsml) {
+            P[i].Hsml = All.MinGasHsml;
+            P[i].DensityIterationDone = 1;
+        }
     }
     else {
+        /* We might have got here by serendipity, without bounding.*/
+        if(All.BlackHoleOn && P[i].Type == 5)
+            if(P[i].Hsml > All.BlackHoleMaxAccretionRadius)
+                P[i].Hsml = All.BlackHoleMaxAccretionRadius;
+        if(P[i].Hsml < All.MinGasHsml)
+            P[i].Hsml = All.MinGasHsml;
         P[i].DensityIterationDone = 1;
     }
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -375,17 +375,25 @@ density_ngbiter(
                   " We haven't implemented tracer particles and this shall not happen\n");
     }
 
+    /* some performance measures*/
+    O->Ninteractions ++;
+
     if(r2 < iter->kernel.HH)
     {
-
         const double u = r * iter->kernel.Hinv;
         const double wk = density_kernel_wk(&iter->kernel, u);
+        O->Ngb += wk * iter->kernel_volume;
+
+        /* For the BH only Ngb is used. BH density is
+         * computed during accretion.*/
+        if(I->Type == 5)
+            return;
+
         const double dwk = density_kernel_dwk(&iter->kernel, u);
 
         const double mass_j = P[other].Mass;
 
         O->Rho += (mass_j * wk);
-        O->Ngb += wk * iter->kernel_volume;
 
         /* Hinv is here because O->DhsmlDensity is drho / dH.
          * nothing to worry here */
@@ -426,9 +434,6 @@ density_ngbiter(
             }
         }
     }
-
-    /* some performance measures not currently used */
-    O->Ninteractions ++;
 }
 
 static int

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -279,6 +279,7 @@ density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw)
         I->Vel[0] = P[place].Vel[0];
         I->Vel[1] = P[place].Vel[1];
         I->Vel[2] = P[place].Vel[2];
+        I->DelayTime = 0;
     }
     else
     {
@@ -365,7 +366,7 @@ density_ngbiter(
 
     if(All.WindOn) {
         if(winds_is_particle_decoupled(other))
-            if(!(I->DelayTime > 0))	/* if I'm not wind, then ignore the wind particle */
+            if(!(I->Type == 0 && I->DelayTime > 0))	/* if I'm not wind, then ignore the wind particle */
                 return;
     }
 

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -511,9 +511,15 @@ void density_check_neighbours (int i, TreeWalk * tw) {
             endrun(999993, "Already has DensityIterationDone set, bad memory intialization.");
         }
 
+        /* This condition is here to prevent the density code looping forever if it encounters
+         * multiple particles at the same position. If this happens you likely have worse
+         * problems anyway, so warn also. */
         if((Right[i] - Left[i]) < 1.0e-3 * Left[i])
         {
-            /* this one should be ok */
+            /* If this happens probably the exchange is screwed up and all your particles have moved to (0,0,0)*/
+            message(1, "Very tight Hsml bounds for i=%d ID=%lu Hsml=%g Left=%g Right=%g Ngbs=%g Right-Left=%g pos=(%g|%g|%g)\n",
+             i, P[i].ID, P[i].Hsml, Left[i], Right[i], P[i].NumNgb, Right[i] - Left[i], P[i].Pos[0], P[i].Pos[1], P[i].Pos[2]);
+            P[i].Hsml = Right[i];
             P[i].DensityIterationDone = 1;
             return;
         }
@@ -600,9 +606,9 @@ void density_check_neighbours (int i, TreeWalk * tw) {
 
     if(DENSITY_GET_PRIV(tw)->NIteration >= MAXITER - 10)
     {
-         message(1, "i=%d task=%d ID=%lu Hsml=%g Left=%g Right=%g Ngbs=%g Right-Left=%g\n   pos=(%g|%g|%g)\n",
-             i, ThisTask, P[i].ID, P[i].Hsml, Left[i], Right[i],
-             (float) P[i].NumNgb, Right[i] - Left[i], P[i].Pos[0], P[i].Pos[1], P[i].Pos[2]);
+         message(1, "i=%d ID=%lu Hsml=%g Left=%g Right=%g Ngbs=%g Right-Left=%g\n   pos=(%g|%g|%g)\n",
+             i, P[i].ID, P[i].Hsml, Left[i], Right[i],
+             P[i].NumNgb, Right[i] - Left[i], P[i].Pos[0], P[i].Pos[1], P[i].Pos[2]);
     }
 
     if(!P[i].DensityIterationDone) {

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -517,7 +517,7 @@ void density_check_neighbours (int i, TreeWalk * tw) {
         }
 
         /* Next step is geometric mean of previous. */
-        if(Right[i] < All.BoxSize && Left[i] > 0)
+        if(Right[i] < 0.99 * All.BoxSize && Left[i] > 0)
             P[i].Hsml = pow(0.5 * (pow(Left[i], 3) + pow(Right[i], 3)), 1.0 / 3);
         else
         {

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -988,6 +988,10 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
     tree->Nodes[no].u.d.MaxSoftening = -1;
     tree->Nodes[no].f.MixedSofteningsInNode = 0;
 
+    /* This happens if we have a trivial domain with only one entry*/
+    if(!tree->Nodes[no].f.InternalTopLevel)
+        return;
+
     p = tree->Nodes[no].u.d.nextnode;
 
     /* since we are dealing with top-level nodes, we know that there are 8 consecutive daughter nodes */

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -1,0 +1,334 @@
+/*Simple test for the tree building functions*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <math.h>
+#include <mpi.h>
+#include <stdio.h>
+#include <time.h>
+#include <gsl/gsl_rng.h>
+
+#include <libgadget/allvars.h>
+#include <libgadget/partmanager.h>
+#include <libgadget/slotsmanager.h>
+#include <libgadget/utils/mymalloc.h>
+#include <libgadget/density.h>
+#include <libgadget/domain.h>
+#include <libgadget/forcetree.h>
+#include <libgadget/timestep.h>
+
+#include "stub.h"
+
+/* The true struct for the state variable*/
+struct forcetree_testdata
+{
+    DomainDecomp ddecomp;
+    gsl_rng * r;
+};
+
+static void set_init_hsml(ForceTree * Tree)
+{
+    int i;
+    #pragma omp parallel for
+    for(i = 0; i < PartManager->NumPart; i++)
+    {
+        int no = force_get_father(i, Tree);
+
+        while(10 * All.DesNumNgb * P[i].Mass > Tree->Nodes[no].u.d.mass)
+        {
+            int p = force_get_father(no, Tree);
+
+            if(p < 0)
+                break;
+
+            no = p;
+        }
+
+        P[i].Hsml =
+            pow(3.0 / (4 * M_PI) * All.DesNumNgb * P[i].Mass / (Tree->Nodes[no].u.d.mass),
+                    1.0 / 3) * Tree->Nodes[no].len;
+    }
+}
+
+/* Perform some simple checks on the densities*/
+static void check_densities(void)
+{
+    int i;
+    double maxHsml=P[0].Hsml, minHsml= P[0].Hsml;
+    #pragma omp parallel for reduction(min:minHsml) reduction(max:maxHsml)
+    for(i=0; i<PartManager->NumPart; i++) {
+        assert_true(isfinite(P[i].Hsml));
+        assert_true(isfinite(SPHP(i).Density));
+        assert_true(SPHP(i).Density > 0);
+        if(P[i].Hsml < minHsml)
+            minHsml = P[i].Hsml;
+        if(P[i].Hsml > maxHsml)
+            maxHsml = P[i].Hsml;
+    }
+    assert_true(isfinite(minHsml));
+    assert_true(minHsml >= All.MinGasHsml);
+    assert_true(maxHsml <= All.BoxSize);
+
+}
+
+static void do_density_test(void ** state, const int numpart, double expectedhsml, double hsmlerr)
+{
+    int i, npbh=0;
+    #pragma omp parallel for reduction(+: npbh)
+    for(i=0; i<numpart; i++) {
+        int j;
+        P[i].Key = PEANO(P[i].Pos, All.BoxSize);
+        P[i].Mass = 1;
+        P[i].TimeBin = 0;
+        P[i].GravCost = 1;
+        P[i].Ti_drift = 0;
+        P[i].Ti_kick = 0;
+        for(j=0; j<3; j++)
+            P[i].Vel[j] = 1.5;
+        if(P[i].Type == 0) {
+            SPHP(i).Entropy = 1;
+            SPHP(i).DtEntropy = 0;
+            SPHP(i).Density = 1;
+        }
+        if(P[i].Type == 5)
+            npbh++;
+    }
+
+    SlotsManager->info[0].size = numpart-npbh;
+    SlotsManager->info[5].size = npbh;
+    PartManager->NumPart = numpart;
+    NumActiveParticle = numpart;
+    struct forcetree_testdata * data = * (struct forcetree_testdata **) state;
+    DomainDecomp ddecomp = data->ddecomp;
+    ddecomp.TopLeaves[0].topnode = PartManager->MaxPart;
+
+    ForceTree tree = {0};
+    force_tree_rebuild(&tree, &ddecomp, All.BoxSize, 0);
+    set_init_hsml(&tree);
+    /*Time doing the density finding*/
+    double start, end;
+    start = MPI_Wtime();
+    /*Find the density*/
+    density(1, 0, &tree);
+    end = MPI_Wtime();
+    double ms = (end - start)*1000;
+    message(0, "Found densities in %.3g ms\n", ms);
+    check_densities();
+
+    double avghsml = 0;
+    #pragma omp parallel for reduction(+:avghsml)
+    for(i=0; i<numpart; i++) {
+        avghsml += P[i].Hsml;
+    }
+    message(0, "Average Hsml: %g Expected %g +- %g\n",avghsml/numpart, expectedhsml, hsmlerr);
+    assert_true(fabs(avghsml/numpart - expectedhsml) < hsmlerr);
+    /* Make MaxNumNgbDeviation smaller and check we get a consistent result.*/
+    double * Hsml = mymalloc("Hsml", numpart * sizeof(double));
+    #pragma omp parallel for
+    for(i=0; i<numpart; i++) {
+        Hsml[i] = P[i].Hsml;
+    }
+    All.MaxNumNgbDeviation = 1;
+
+    start = MPI_Wtime();
+    /*Find the density*/
+    density(1, 0, &tree);
+    end = MPI_Wtime();
+    ms = (end - start)*1000;
+    message(0, "Found 1 dev densities in %.3g ms\n", ms);
+    double diff = 0;
+    #pragma omp parallel for reduction(max:diff)
+    for(i=0; i<numpart; i++) {
+        assert_true(fabs(Hsml[i]/P[i].Hsml-1) < All.MaxNumNgbDeviation / All.DesNumNgb);
+        if(fabs(Hsml[i] - P[i].Hsml) > diff)
+            diff = fabs(Hsml[i] - P[i].Hsml);
+    }
+    message(0, "Max diff between Hsml: %g\n",diff);
+    myfree(Hsml);
+
+    check_densities();
+    force_tree_free(&tree);
+}
+
+static void test_density_flat(void ** state) {
+    /*Set up the particle data*/
+    int ncbrt = 32;
+    int numpart = ncbrt*ncbrt*ncbrt;
+    /* Create a regular grid of particles, 8x8x8, all of type 1,
+     * in a box 8 kpc across.*/
+    int i;
+    #pragma omp parallel for
+    for(i=0; i<numpart; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = 1.5*All.BoxSize/cbrt(numpart);
+        P[i].Pos[0] = (All.BoxSize/ncbrt) * (i/ncbrt/ncbrt);
+        P[i].Pos[1] = (All.BoxSize/ncbrt) * ((i/ncbrt) % ncbrt);
+        P[i].Pos[2] = (All.BoxSize/ncbrt) * (i % ncbrt);
+    }
+    do_density_test(state, numpart, 0.508875, 1e-4);
+}
+
+static void test_density_close(void ** state) {
+    /*Set up the particle data*/
+    int ncbrt = 32;
+    int numpart = ncbrt*ncbrt*ncbrt;
+    double close = 500.;
+    int i;
+    /* A few particles scattered about the place so the tree is not sparse*/
+    #pragma omp parallel for
+    for(i=0; i<numpart/8; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = 4*All.BoxSize/cbrt(numpart/8);
+        P[i].Pos[0] = (All.BoxSize/ncbrt) * (i/(ncbrt/2.)/(ncbrt/2.));
+        P[i].Pos[1] = (All.BoxSize/ncbrt) * ((i*2/ncbrt) % (ncbrt/2));
+        P[i].Pos[2] = (All.BoxSize/ncbrt) * (i % (ncbrt/2));
+    }
+
+    /* Create particles clustered in one place, all of type 0.*/
+    #pragma omp parallel for
+    for(i=numpart/4; i<numpart; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = 2*ncbrt/close;
+        P[i].Pos[0] = 4.1 + (i/ncbrt/ncbrt)/close;
+        P[i].Pos[1] = 4.1 + ((i/ncbrt) % ncbrt) /close;
+        P[i].Pos[2] = 4.1 + (i % ncbrt)/close;
+    }
+    P[numpart-1].Type = 5;
+
+    do_density_test(state, numpart, 0.127294, 1e-4);
+}
+
+void do_random_test(void **state, gsl_rng * r, const int numpart)
+{
+    /* Create a randomly space set of particles, 8x8x8, all of type 0. */
+    int i;
+    for(i=0; i<numpart/4; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = All.BoxSize/cbrt(numpart);
+
+        int j;
+        for(j=0; j<3; j++)
+            P[i].Pos[j] = All.BoxSize * gsl_rng_uniform(r);
+    }
+    for(i=numpart/4; i<3*numpart/4; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = All.BoxSize/cbrt(numpart);
+        int j;
+        for(j=0; j<3; j++)
+            P[i].Pos[j] = All.BoxSize/2 + All.BoxSize/8 * exp(pow(gsl_rng_uniform(r)-0.5,2));
+    }
+    for(i=3*numpart/4; i<numpart; i++) {
+        P[i].Type = 0;
+        P[i].PI = i;
+        P[i].Hsml = All.BoxSize/cbrt(numpart);
+        int j;
+        for(j=0; j<3; j++)
+            P[i].Pos[j] = All.BoxSize*0.1 + All.BoxSize/32 * exp(pow(gsl_rng_uniform(r)-0.5,2));
+    }
+    do_density_test(state, numpart,0.1908, 1e-3);
+}
+
+static void test_density_random(void ** state) {
+    /*Set up the particle data*/
+    int ncbrt = 32;
+    struct forcetree_testdata * data = * (struct forcetree_testdata **) state;
+    gsl_rng * r = (gsl_rng *) data->r;
+    int numpart = ncbrt*ncbrt*ncbrt;
+    /*Allocate tree*/
+    /*Base pointer*/
+    int i;
+    for(i=0; i<2; i++) {
+        do_random_test(state, r, numpart);
+    }
+}
+
+
+/*Make a simple trivial domain for all data on a single processor*/
+void trivial_domain(DomainDecomp * ddecomp)
+{
+    /* The whole tree goes into one topnode.
+     * Set up just enough of the TopNode structure that
+     * domain_get_topleaf works*/
+    ddecomp->domain_allocated_flag = 1;
+    ddecomp->NTopNodes = 1;
+    ddecomp->NTopLeaves = 1;
+    ddecomp->TopNodes = mymalloc("topnode", sizeof(struct topnode_data));
+    ddecomp->TopNodes[0].Daughter = -1;
+    ddecomp->TopNodes[0].Leaf = 0;
+    ddecomp->TopLeaves = mymalloc("topleaf",sizeof(struct topleaf_data));
+    ddecomp->TopLeaves[0].Task = 0;
+    ddecomp->TopLeaves[0].topnode = 0;
+    /*These are not used*/
+    ddecomp->TopNodes[0].StartKey = 0;
+    ddecomp->TopNodes[0].Shift = BITS_PER_DIMENSION * 3;
+    /*To tell the code we are in serial*/
+    ddecomp->Tasks = mymalloc("task",sizeof(struct task_data));
+    ddecomp->Tasks[0].StartLeaf = 0;
+    ddecomp->Tasks[0].EndLeaf = 1;
+}
+
+static int teardown_density(void **state) {
+    slots_free_sph_scratch_data(SphP_scratch);
+    struct forcetree_testdata * data = (struct forcetree_testdata * ) *state;
+    myfree(data->ddecomp.Tasks);
+    myfree(data->ddecomp.TopLeaves);
+    myfree(data->ddecomp.TopNodes);
+    free(data->r);
+    myfree(data);
+    return 0;
+}
+
+static int setup_density(void **state) {
+    /*Set up the important parts of the All structure.*/
+    All.DensityOn = 1;
+    All.DensityResolutionEta = 1.;
+    All.BlackHoleNgbFactor = 2;
+    All.MaxNumNgbDeviation = 2;
+    All.DesNumNgb = 35;
+    All.DensityKernelType = DENSITY_KERNEL_CUBIC_SPLINE;
+    All.BoxSize = 8;
+    All.NumThreads = omp_get_max_threads();
+    All.MinGasHsml = 0.006;
+    All.BlackHoleMaxAccretionRadius = 99999.;
+    /*Reserve space for the slots*/
+    slots_init(0.01);
+    slots_set_enabled(0, sizeof(struct sph_particle_data));
+    int maxpart = pow(32,3);
+    int atleast[6] = {0};
+    atleast[0] = maxpart;
+    atleast[5] = 2;
+    particle_alloc_memory(maxpart);
+    slots_reserve(1, atleast);
+    slots_allocate_sph_scratch_data(0, maxpart);
+    ActiveParticle = NULL;
+    NumActiveParticle = maxpart;
+    int i;
+    for(i=0; i<6; i++)
+        GravitySofteningTable[i] = 0.1 / 2.8;
+
+    walltime_init(&All.CT);
+    init_forcetree_params(2, GravitySofteningTable);
+    /*Set up the top-level domain grid*/
+    struct forcetree_testdata *data = mymalloc("data", sizeof(struct forcetree_testdata));
+    trivial_domain(&data->ddecomp);
+    data->r = gsl_rng_alloc(gsl_rng_mt19937);
+    gsl_rng_set(data->r, 0);
+    *state = (void *) data;
+    return 0;
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_density_flat),
+        cmocka_unit_test(test_density_close),
+        cmocka_unit_test(test_density_random),
+    };
+    return cmocka_run_group_tests_mpi(tests, setup_density, teardown_density);
+}

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -22,6 +22,10 @@
 #include <libgadget/slotsmanager.c>
 #include "stub.h"
 
+double walltime_measure_full(char * name, char * file, int line) {
+    return MPI_Wtime();
+}
+
 struct part_manager_type PartManager[1] = {{0}};
 int NTask, ThisTask;
 int TotNumPart;

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -47,6 +47,10 @@ struct forcetree_testdata
 
 void dump_snapshot() { }
 
+double walltime_measure_full(char * name, char * file, int line) {
+    return MPI_Wtime();
+}
+
 /*End dummies*/
 
 static int

--- a/libgadget/timefac.c
+++ b/libgadget/timefac.c
@@ -229,6 +229,8 @@ double get_gravkick_factor(inttime_t ti0, inttime_t ti1)
 
 double get_hydrokick_factor(inttime_t ti0, inttime_t ti1)
 {
+  if(ti0 == ti1)
+      return 0;
   if(ti0 == hk_last_ti0 && ti1 == hk_last_ti1)
     return hk_last_value;
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -611,7 +611,7 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
 
     if(tw->preprocess) {
         int i;
-        #pragma omp parallel for if(tw->WorkSetSize > 64)
+        #pragma omp parallel for
         for(i = 0; i < tw->WorkSetSize; i ++) {
             const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;
             tw->preprocess(p_i, tw);
@@ -642,7 +642,7 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
 
     if(tw->postprocess) {
         int i;
-        #pragma omp parallel for if(tw->WorkSetSize > 64)
+        #pragma omp parallel for
         for(i = 0; i < tw->WorkSetSize; i ++) {
             const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;
             tw->postprocess(p_i, tw);

--- a/tests/stub.c
+++ b/tests/stub.c
@@ -51,9 +51,5 @@ void myfree_fullinfo(void * ptr, const char *func, const char *file, int line)
     free(ptr);
 }
 
-double walltime_measure_full(char * name, char * file, int line) {
-    return MPI_Wtime();
-}
-
 /*End dummies*/
 

--- a/tests/stub.c
+++ b/tests/stub.c
@@ -15,6 +15,10 @@
 int ThisTask;
 int NTask;
 
+#ifdef VALGRIND
+#define allocator_init allocator_malloc_init
+#endif
+
 int
 _cmocka_run_group_tests_mpi(const char * name, const struct CMUnitTest tests[], size_t size, void * p1, void * p2)
 {


### PR DESCRIPTION
This adds a test for density and then fixes a few bugs connected with it. It warns if the difference between the upper and lower HSML bounds < 0.1 % of the lower bound, which is a catchall stopping condition for the code. It should never be hit in practice unless it is hiding another bug.

I also found a bug in the stopping condition for too small Hsml values. If an intermediate Hsml value was less than MinGasHsml the code would stop, even if the true Hsml should have been larger. Then there is a roundoff error induced by using the wrong condition to choose Right and Left which was causing wrong Hsml values in a small number of particles in the hydro run.

Finally I build the density redo queue as we go, which should help large simulations a bit (although I cannot measure any speed change).