### PR TITLE
Locallocks

### DIFF
--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -44,6 +44,7 @@ utils/mymalloc.h \
 utils/system.h \
 utils/event.h \
 utils/openmpsort.h \
+utils/spinlocks.h \
 utils/string.h
 
 UTILS_TESTED = memory openmpsort interp
@@ -109,7 +110,8 @@ utils/system.o \
 utils/paramset.o \
 utils/event.o \
 utils/openmpsort.o \
-utils/string.o
+utils/string.o \
+utils/spinlocks.o
 
 
 GADGET_OBJS := $(GADGET_OBJS:%=.objs/%)

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -11,7 +11,6 @@
 #include "densitykernel.h"
 #include "treewalk.h"
 #include "slotsmanager.h"
-#include "drift.h"
 #include "fof.h"
 #include "blackhole.h"
 #include "timestep.h"

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -462,7 +462,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     {
         /* compute relative velocity of BHs */
 
-        lock_particle(other, spin);
+        lock_spinlock(other, spin);
         int d;
         double vrel[3];
         for(d = 0; d < 3; d++)
@@ -485,7 +485,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
                 }
             }
         }
-        unlock_particle(other, spin);
+        unlock_spinlock(other, spin);
     }
 
     if(P[other].Type == 0) {
@@ -505,7 +505,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
 
             /* here we have a gas particle; check for swallowing */
 
-            lock_particle(other, spin);
+            lock_spinlock(other, spin);
             /* compute accretion probability */
             double p, w;
 
@@ -531,7 +531,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
                     SPH_SwallowID[P[other].PI] = I->ID;
                 }
             }
-            unlock_particle(other, spin);
+            unlock_spinlock(other, spin);
         }
 
         if(r2 < iter->feedback_kernel.HH) {
@@ -603,7 +603,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
     {
         if(BHP(other).SwallowID != I->ID) return;
 
-        lock_particle(other, spin);
+        lock_spinlock(other, spin);
 
         int d;
         for(d = 0; d < 3; d++)
@@ -620,7 +620,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
         slots_mark_garbage(other);
         BHP(other).Mdot = 0;
-        unlock_particle(other, spin);
+        unlock_spinlock(other, spin);
 
         #pragma omp atomic
         BH_GET_PRIV(lv->tw)->N_BH_swallowed++;
@@ -644,9 +644,9 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
                 if(HAS(blackhole_params.BlackHoleFeedbackMethod, BH_FEEDBACK_SPLINE))
                     wk = density_kernel_wk(&iter->feedback_kernel, u);
 
-                lock_particle(other, spin);
+                lock_spinlock(other, spin);
                 SphP_scratch->Injected_BH_Energy[P[other].PI] += (I->FeedbackEnergy * mass_j * wk / I->FeedbackWeightSum);
-                unlock_particle(other, spin);
+                unlock_spinlock(other, spin);
             }
         }
     }
@@ -658,7 +658,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
         if(SPH_SwallowID[P[other].PI] != I->ID) return;
 
-        lock_particle(other, spin);
+        lock_spinlock(other, spin);
 
         int d;
         for(d = 0; d < 3; d++)
@@ -670,7 +670,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
         P[other].Mass = 0;
 
         slots_mark_garbage(other);
-        unlock_particle(other, spin);
+        unlock_spinlock(other, spin);
 
         #pragma omp atomic
         BH_GET_PRIV(lv->tw)->N_sph_swallowed++;

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -14,30 +14,21 @@
 
 #define MAXHSML 30000.0
 
+
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
 
-void lock_particle(int i) {
-#ifndef NO_OPENMP_SPINLOCK
-    pthread_spin_lock(&P[i].SpinLock);
-#endif
-}
-void unlock_particle(int i) {
-#ifndef NO_OPENMP_SPINLOCK
-    pthread_spin_unlock(&P[i].SpinLock);
-#endif
-}
-
-void drift_particle(int i, inttime_t ti1) {
+/* Updates a single particle to the current drift time*/
+void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
     if(P[i].Ti_drift == ti1) return;
 
-    lock_particle(i);
+    lock_particle(i, spin);
     inttime_t ti0 = P[i].Ti_drift;
     if(ti0 != ti1) {
         const double ddrift = get_drift_factor(ti0, ti1);
         real_drift_particle(i, ti1, ddrift);
 #pragma omp flush
     }
-    unlock_particle(i);
+    unlock_particle(i, spin);
 }
 
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift)

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -21,14 +21,14 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
 void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
     if(P[i].Ti_drift == ti1) return;
 
-    lock_particle(i, spin);
+    lock_spinlock(i, spin);
     inttime_t ti0 = P[i].Ti_drift;
     if(ti0 != ti1) {
         const double ddrift = get_drift_factor(ti0, ti1);
         real_drift_particle(i, ti1, ddrift);
 #pragma omp flush
     }
-    unlock_particle(i, spin);
+    unlock_spinlock(i, spin);
 }
 
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift)

--- a/libgadget/drift.h
+++ b/libgadget/drift.h
@@ -1,10 +1,7 @@
 #ifndef __DRIFT_H
 #define __DRIFT_H
 
-void drift_particle(int i, inttime_t ti1);
-void lock_particle(int i);
-void unlock_particle(int i);
-
+/* Updates all particles to the current drift time*/
 void drift_all_particles(inttime_t ti1);
 
 #endif

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -277,10 +277,10 @@ HEADl(int stop, int i, int locked, int * Head, struct SpinLocks * spin)
      * makes the locking code less clear, and doesn't lead to much of a speedup: the splay
      * means that the tree is shallow.*/
     if(locked < 0 || i < locked) {
-        lock_particle(i, spin);
+        lock_spinlock(i, spin);
     }
     else{
-        if(try_lock_particle(i, spin)) {
+        if(try_lock_spinlock(i, spin)) {
             /*This means some other thread already has the lock.
              *To avoid deadlocks we need to back off, unlock both particles and then retry.*/
             return -2;
@@ -298,7 +298,7 @@ HEADl(int stop, int i, int locked, int * Head, struct SpinLocks * spin)
     }
     /* this is not the root, keep going, but unlock first, since even if the root is modified by
      * another thread, what we get here is on the path, */
-    unlock_particle(i, spin);
+    unlock_spinlock(i, spin);
 //    printf("unlocking %d by %d in HEADl\n", i, omp_get_thread_num());
     r = HEADl(stop, next, locked, Head, spin);
     return r;
@@ -457,7 +457,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
         /* We had a lock already taken on h2 by another thread.
          * We need to unlock h1 and retry to avoid deadlock loops.*/
         if(h2 == -2)
-            unlock_particle(h1, spin);
+            unlock_spinlock(h1, spin);
     } while(h2 == -2);
 
     if(h2 >=0)
@@ -472,7 +472,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
             HaloLabel[h1].MinIDTask = HaloLabel[h2].MinIDTask;
         }
         //printf("unlocking %d by %d in merge\n", h2, omp_get_thread_num());
-        unlock_particle(h2, spin);
+        unlock_spinlock(h2, spin);
     }
 
     /* h1 must be the root of other and target both:
@@ -484,7 +484,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
     update_root(other, h1, Head);
 
     //printf("unlocking %d by %d in merge\n", h1, omp_get_thread_num());
-    unlock_particle(h1, spin);
+    unlock_spinlock(h1, spin);
 }
 
 static void
@@ -512,14 +512,14 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
     {
             struct SpinLocks * spin = FOF_PRIMARY_GET_PRIV(tw)->spin;
 //        printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        lock_particle(other, spin);
+        lock_spinlock(other, spin);
         if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
         {
             HaloLabel[HEAD(other, tw)].MinID = I->MinID;
             HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
         }
 //        printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        unlock_particle(other, spin);
+        unlock_spinlock(other, spin);
     }
 }
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -15,7 +15,6 @@
 #include "walltime.h"
 #include "sfr_eff.h"
 #include "blackhole.h"
-#include "drift.h"
 #include "domain.h"
 
 #include "forcetree.h"

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -240,6 +240,7 @@ fof_finish()
 
 struct FOFPrimaryPriv {
     int * Head;
+    struct SpinLocks * spin;
     char * PrimaryActive;
     MyIDType * OldMinID;
 };
@@ -265,7 +266,7 @@ struct FOFPrimaryPriv {
  *      -2 if locking might have deadlocked.
  */
 static int
-HEADl(int stop, int i, int locked, int * Head)
+HEADl(int stop, int i, int locked, int * Head, struct SpinLocks * spin)
 {
     int r, next;
     if (i == stop) {
@@ -277,10 +278,10 @@ HEADl(int stop, int i, int locked, int * Head)
      * makes the locking code less clear, and doesn't lead to much of a speedup: the splay
      * means that the tree is shallow.*/
     if(locked < 0 || i < locked) {
-        lock_particle(i);
+        lock_particle(i, spin);
     }
     else{
-        if(pthread_spin_trylock(&P[i].SpinLock)) {
+        if(try_lock_particle(i, spin)) {
             /*This means some other thread already has the lock.
              *To avoid deadlocks we need to back off, unlock both particles and then retry.*/
             return -2;
@@ -298,9 +299,9 @@ HEADl(int stop, int i, int locked, int * Head)
     }
     /* this is not the root, keep going, but unlock first, since even if the root is modified by
      * another thread, what we get here is on the path, */
-    unlock_particle(i);
+    unlock_particle(i, spin);
 //    printf("unlocking %d by %d in HEADl\n", i, omp_get_thread_num());
-    r = HEADl(stop, next, locked, Head);
+    r = HEADl(stop, next, locked, Head, spin);
     return r;
 }
 
@@ -398,6 +399,7 @@ void fof_label_primary(ForceTree * tree, MPI_Comm Comm)
         HaloLabel[i].MinIDTask = ThisTask;
     }
 
+    priv[0].spin = init_spinlocks(PartManager->NumPart);
     do
     {
         t0 = second();
@@ -425,6 +427,8 @@ void fof_label_primary(ForceTree * tree, MPI_Comm Comm)
     }
     while(link_across_tot > 0);
 
+    free_spinlocks(priv[0].spin);
+
     /* Update MinID of all linked (primary-linked) particles */
     for(i = 0; i < PartManager->NumPart; i++)
     {
@@ -444,16 +448,17 @@ fofp_merge(int target, int other, TreeWalk * tw)
 {
     /* this will lock h1 */
     int * Head = FOF_PRIMARY_GET_PRIV(tw)->Head;
+    struct SpinLocks * spin = FOF_PRIMARY_GET_PRIV(tw)->spin;
     int h1, h2;
 
     do {
-        h1 = HEADl(-1, target, -1, Head);
+        h1 = HEADl(-1, target, -1, Head, spin);
         /* stop looking if we find h1 along the path (because it is already owned by us) */
-        h2 = HEADl(h1, other, h1, Head);
+        h2 = HEADl(h1, other, h1, Head, spin);
         /* We had a lock already taken on h2 by another thread.
          * We need to unlock h1 and retry to avoid deadlock loops.*/
         if(h2 == -2)
-            unlock_particle(h1);
+            unlock_particle(h1, spin);
     } while(h2 == -2);
 
     if(h2 >=0)
@@ -468,7 +473,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
             HaloLabel[h1].MinIDTask = HaloLabel[h2].MinIDTask;
         }
         //printf("unlocking %d by %d in merge\n", h2, omp_get_thread_num());
-        unlock_particle(h2);
+        unlock_particle(h2, spin);
     }
 
     /* h1 must be the root of other and target both:
@@ -480,7 +485,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
     update_root(other, h1, Head);
 
     //printf("unlocking %d by %d in merge\n", h1, omp_get_thread_num());
-    unlock_particle(h1);
+    unlock_particle(h1, spin);
 }
 
 static void
@@ -506,15 +511,16 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
         }
     } else /* mode is 1, target is a ghost */
     {
+            struct SpinLocks * spin = FOF_PRIMARY_GET_PRIV(tw)->spin;
 //        printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        lock_particle(other);
+        lock_particle(other, spin);
         if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
         {
             HaloLabel[HEAD(other, tw)].MinID = I->MinID;
             HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
         }
 //        printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        unlock_particle(other);
+        unlock_particle(other, spin);
     }
 }
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include <pthread.h>
 
 #include "slotsmanager.h"
 #include "partmanager.h"

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -424,7 +424,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         while(child >= tb.firstnode);
 
         /*Now lock this node.*/
-        lock_particle(this-tb.firstnode, spin);
+        lock_spinlock(this-tb.firstnode, spin);
 
         /*Check nothing changed when we took the lock*/
         #pragma omp atomic read
@@ -433,8 +433,8 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         while(child >= tb.firstnode)
         {
             /*Move the lock to the child*/
-            lock_particle(child-tb.firstnode, spin);
-            unlock_particle(this-tb.firstnode, spin);
+            lock_spinlock(child-tb.firstnode, spin);
+            unlock_spinlock(this-tb.firstnode, spin);
             this = child;
             /*New subnode*/
             subnode = get_subnode(&tb.Nodes[this], i);
@@ -453,7 +453,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         #pragma omp flush
 
         /*Unlock the parent*/
-        unlock_particle(this - tb.firstnode, spin);
+        unlock_spinlock(this - tb.firstnode, spin);
     }
     int totclose;
     MPI_Allreduce(&closepairs, &totclose, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -4,7 +4,6 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
-#include <pthread.h>
 
 #include "slotsmanager.h"
 #include "partmanager.h"
@@ -339,14 +338,6 @@ modify_internal_node(int parent, int subnode, int p_child, int p_toplace,
     return ret;
 }
 
-#ifndef NO_OPENMP_SPINLOCK
-#define LOCK_NODE(i) pthread_spin_lock(&SpinLocks[i])
-#define UNLOCK_NODE(i) pthread_spin_unlock(&SpinLocks[i])
-#else
-#define LOCK_NODE(i) (i)
-#define UNLOCK_NODE(i) (i)
-#endif
-
 /*! Does initial creation of the nodes for the gravitational oct-tree.
  **/
 int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * ddecomp, const double BoxSize)
@@ -391,15 +382,11 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
     /* Stores the last-seen node on this thread.
      * Since most particles are close to each other, this should save a number of tree walks.*/
     int this_acc = tb.firstnode;
-    /* now we insert all particles */
-#ifndef NO_OPENMP_SPINLOCK
     /*Initialise some spinlocks off*/
-    pthread_spinlock_t * SpinLocks = mymalloc("NodeSpinlocks", (tb.lastnode - tb.firstnode)*sizeof(pthread_spinlock_t));
-    for(i=0; i < tb.lastnode - tb.firstnode; i++) {
-        pthread_spin_init(&SpinLocks[i],PTHREAD_PROCESS_PRIVATE);
-    }
+    struct SpinLocks * spin = init_spinlocks(tb.lastnode - tb.firstnode);
+
+    /* now we insert all particles */
     #pragma omp parallel for firstprivate(nc, this_acc) reduction(+: closepairs)
-#endif
     for(i = 0; i < npart; i++)
     {
         /*Can't break from openmp for*/
@@ -437,7 +424,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         while(child >= tb.firstnode);
 
         /*Now lock this node.*/
-        LOCK_NODE(this-tb.firstnode);
+        lock_particle(this-tb.firstnode, spin);
 
         /*Check nothing changed when we took the lock*/
         #pragma omp atomic read
@@ -446,8 +433,8 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         while(child >= tb.firstnode)
         {
             /*Move the lock to the child*/
-            LOCK_NODE(child-tb.firstnode);
-            UNLOCK_NODE(this-tb.firstnode);
+            lock_particle(child-tb.firstnode, spin);
+            unlock_particle(this-tb.firstnode, spin);
             this = child;
             /*New subnode*/
             subnode = get_subnode(&tb.Nodes[this], i);
@@ -466,7 +453,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         #pragma omp flush
 
         /*Unlock the parent*/
-        UNLOCK_NODE(this - tb.firstnode);
+        unlock_particle(this - tb.firstnode, spin);
     }
     int totclose;
     MPI_Allreduce(&closepairs, &totclose, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
@@ -474,13 +461,8 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         message(0,"Found %d close particle pairs when building tree.\n",totclose);
     }
 
-#ifndef NO_OPENMP_SPINLOCK
-    for(i=0; i < tb.lastnode - tb.firstnode; i++)
-            pthread_spin_destroy(&SpinLocks[i]);
-    /*Avoid a warning about discarding volatile*/
-    int * ss = (int *) SpinLocks;
-    myfree(ss);
-#endif
+    free_spinlocks(spin);
+
     return nnext - tb.firstnode;
 }
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -10,7 +10,6 @@
 #include "utils.h"
 
 #include "allvars.h"
-#include "drift.h"
 #include "forcetree.h"
 #include "treewalk.h"
 #include "timestep.h"

--- a/libgadget/partmanager.c
+++ b/libgadget/partmanager.c
@@ -28,13 +28,5 @@ particle_alloc_memory(int MaxPart)
      * (memory lock etc?)
      * */
     memset(P, 0, sizeof(struct particle_data) * MaxPart);
-#ifndef NO_OPENMP_SPINLOCK
-    {
-        int i;
-        for(i = 0; i < MaxPart; i ++) {
-            pthread_spin_init(&P[i].SpinLock, 0);
-        }
-    }
-#endif
     message(0, "Allocated %g MByte for particle storage.\n", bytes / (1024.0 * 1024.0));
 }

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -1,8 +1,6 @@
 #ifndef _PART_DATA_H
 #define _PART_DATA_H
 
-#include <pthread.h>
-
 #include "types.h"
 #include "utils/peano.h"
 
@@ -11,10 +9,6 @@
  */
 struct particle_data
 {
-#ifndef NO_OPENMP_SPINLOCK
-    pthread_spinlock_t SpinLock;
-#endif
-
     float GravCost;     /*!< weight factor used for balancing the work-load */
 
     inttime_t Ti_drift;       /*!< current time of the particle position */

--- a/libgadget/utils.h
+++ b/libgadget/utils.h
@@ -20,4 +20,5 @@
 #include "utils/string.h"
 #include "utils/endrun.h"
 #include "utils/interp.h"
+#include "utils/spinlocks.h"
 #endif

--- a/libgadget/utils/spinlocks.c
+++ b/libgadget/utils/spinlocks.c
@@ -16,18 +16,18 @@ struct SpinLocks
 
 static struct SpinLocks spin;
 
-void lock_particle(int i, struct SpinLocks * spin) {
+void lock_spinlock(int i, struct SpinLocks * spin) {
 #ifndef NO_OPENMP_SPINLOCK
     pthread_spin_lock(&spin->SpinLocks[i]);
 #endif
 }
-void unlock_particle(int i,  struct SpinLocks * spin) {
+void unlock_spinlock(int i,  struct SpinLocks * spin) {
 #ifndef NO_OPENMP_SPINLOCK
     pthread_spin_unlock(&spin->SpinLocks[i]);
 #endif
 }
 
-int try_lock_particle(int i,  struct SpinLocks * spin)
+int try_lock_spinlock(int i,  struct SpinLocks * spin)
 {
 #ifndef NO_OPENMP_SPINLOCK
     return pthread_spin_trylock(&spin->SpinLocks[i]);

--- a/libgadget/utils/spinlocks.c
+++ b/libgadget/utils/spinlocks.c
@@ -1,0 +1,64 @@
+#include "spinlocks.h"
+#include "mymalloc.h"
+
+#ifndef NO_OPENMP_SPINLOCK
+#include <pthread.h>
+#endif
+
+/* Temporary array for spinlocks*/
+struct SpinLocks
+{
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spinlock_t * SpinLocks;
+#endif
+    int NumSpinLock;
+};
+
+static struct SpinLocks spin;
+
+void lock_particle(int i, struct SpinLocks * spin) {
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spin_lock(&spin->SpinLocks[i]);
+#endif
+}
+void unlock_particle(int i,  struct SpinLocks * spin) {
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spin_unlock(&spin->SpinLocks[i]);
+#endif
+}
+
+int try_lock_particle(int i,  struct SpinLocks * spin)
+{
+#ifndef NO_OPENMP_SPINLOCK
+    return pthread_spin_trylock(&spin->SpinLocks[i]);
+#else
+    return 0;
+#endif
+}
+
+struct SpinLocks * init_spinlocks(int NumLock)
+{
+#ifndef NO_OPENMP_SPINLOCK
+    int i;
+    /* Initialize the spinlocks*/
+    spin.SpinLocks = mymalloc("SpinLocks", NumLock * sizeof(pthread_spinlock_t));
+    #pragma omp parallel for
+    for(i = 0; i < NumLock; i ++) {
+        pthread_spin_init(&spin.SpinLocks[i], PTHREAD_PROCESS_PRIVATE);
+    }
+#endif
+    spin.NumSpinLock = NumLock;
+    return &spin;
+}
+
+void free_spinlocks(struct SpinLocks * spin)
+{
+#ifndef NO_OPENMP_SPINLOCK
+    int i;
+    for(i = 0; i < spin->NumSpinLock; i ++) {
+        pthread_spin_destroy(&(spin->SpinLocks[i]));
+    }
+    myfree((void *) spin->SpinLocks);
+#endif
+}
+

--- a/libgadget/utils/spinlocks.h
+++ b/libgadget/utils/spinlocks.h
@@ -1,0 +1,17 @@
+#ifndef __SPINLOCKS_H
+#define __SPINLOCKS_H
+/* Manages particle locking:
+ * init_spinlocks allocates and initialises an array of spinlocks.
+ * free_spinlocks destroys and frees them.
+ * (un)lock_particle locks and unlocks the i'th spinlock.
+ * try_lock_particle trys to lock the particle, returning 0 on success.
+ * Warning! If NO_OPENMP_SPINLOCK is defined, these functions do nothing!*/
+
+struct SpinLocks;
+
+struct SpinLocks * init_spinlocks(int NumLock);
+void free_spinlocks(struct SpinLocks * spin);
+void lock_particle(int i, struct SpinLocks * spin);
+void unlock_particle(int i, struct SpinLocks * spin);
+int try_lock_particle(int i, struct SpinLocks * spin);
+#endif

--- a/libgadget/utils/spinlocks.h
+++ b/libgadget/utils/spinlocks.h
@@ -3,15 +3,15 @@
 /* Manages particle locking:
  * init_spinlocks allocates and initialises an array of spinlocks.
  * free_spinlocks destroys and frees them.
- * (un)lock_particle locks and unlocks the i'th spinlock.
- * try_lock_particle trys to lock the particle, returning 0 on success.
+ * (un)lock_spinlock locks and unlocks the i'th spinlock.
+ * try_lock_spinlock trys to lock the particle, returning 0 on success.
  * Warning! If NO_OPENMP_SPINLOCK is defined, these functions do nothing!*/
 
 struct SpinLocks;
 
 struct SpinLocks * init_spinlocks(int NumLock);
 void free_spinlocks(struct SpinLocks * spin);
-void lock_particle(int i, struct SpinLocks * spin);
-void unlock_particle(int i, struct SpinLocks * spin);
-int try_lock_particle(int i, struct SpinLocks * spin);
+void lock_spinlock(int i, struct SpinLocks * spin);
+void unlock_spinlock(int i, struct SpinLocks * spin);
+int try_lock_spinlock(int i, struct SpinLocks * spin);
 #endif

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -179,6 +179,11 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
 
 static int* NPLeft;
 
+struct WindPriv {
+    struct SpinLocks * spin;
+};
+#define WIND_GET_PRIV(tw) ((struct WindPriv *) (tw->priv))
+
 /*Do a treewalk for the wind model. This only changes newly created star particles.*/
 void
 winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree)
@@ -224,6 +229,7 @@ winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree)
     int64_t totalleft = 0;
     sumup_large_ints(1, &NumNewStars, &totalleft);
     NPLeft = ta_malloc("NPLeft", int, NumThreads);
+
     while(totalleft > 0) {
         memset(NPLeft, 0, sizeof(int)*NumThreads);
 
@@ -243,8 +249,12 @@ winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree)
     tw->ngbiter = (TreeWalkNgbIterFunction) sfr_wind_feedback_ngbiter;
     tw->postprocess = NULL;
     tw->reduce = NULL;
+    struct WindPriv priv[1];
+    tw->priv = priv;
 
+    priv[0].spin = init_spinlocks(PartManager->NumPart);
     treewalk_run(tw, NewStars, NumNewStars);
+    free_spinlocks(priv[0].spin);
     myfree(Winddata);
     walltime_measure("/Cooling/Wind");
 }
@@ -442,7 +452,7 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     /* in this case the particle is already locked by the tree walker */
     /* we may want to add another lock to avoid this. */
     if(P[other].ID != I->base.ID)
-        lock_particle(other);
+        lock_particle(other, WIND_GET_PRIV(lv->tw)->spin);
 
     double wk = 1.0;
     double p = windeff * wk * I->Mass / I->TotalWeight;
@@ -452,7 +462,7 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     }
 
     if(P[other].ID != I->base.ID)
-        unlock_particle(other);
+        unlock_particle(other, WIND_GET_PRIV(lv->tw)->spin);
 
 }
 

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -6,7 +6,6 @@
 #include "winds.h"
 #include "physconst.h"
 #include "treewalk.h"
-#include "drift.h"
 #include "slotsmanager.h"
 #include "timebinmgr.h"
 #include "allvars.h"

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -451,7 +451,7 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     /* in this case the particle is already locked by the tree walker */
     /* we may want to add another lock to avoid this. */
     if(P[other].ID != I->base.ID)
-        lock_particle(other, WIND_GET_PRIV(lv->tw)->spin);
+        lock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
 
     double wk = 1.0;
     double p = windeff * wk * I->Mass / I->TotalWeight;
@@ -461,7 +461,7 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     }
 
     if(P[other].ID != I->base.ID)
-        unlock_particle(other, WIND_GET_PRIV(lv->tw)->spin);
+        unlock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
 
 }
 


### PR DESCRIPTION
This PR moves the spin locks out of struct particle_data and into their own little file. This has no measureable effect on performance or output, but it tidies up the pthread code and means we can use the same routines in the tree build.