### PR TITLE
Newtreebuild

### DIFF
--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -8,7 +8,13 @@
  * ------------------
  */
 
+/* Total allowed number of particle children for a node*/
 #define NMAXCHILD 11
+
+/* Defines for the type of node, classified by type of children.*/
+#define PARTICLE_NODE_TYPE 0
+#define NODE_NODE_TYPE 1
+#define PSEUDO_NODE_TYPE 2
 
 struct NODE
 {
@@ -21,7 +27,9 @@ struct NODE
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
-        unsigned int NodeIsDirty :1; /*Node is a toplevel node containing local mass, and its moments need updating*/
+        unsigned int NodeIsDirty :1; /* Node is a toplevel node containing local mass, and its moments need updating*/
+        unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
+                                    * (should be an enum, but not standard in C).*/
     } f;
     union
     {

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -8,6 +8,8 @@
  * ------------------
  */
 
+#define NMAXCHILD 11
+
 struct NODE
 {
     MyFloat len;			/*!< sidelength of treenode */
@@ -23,7 +25,14 @@ struct NODE
     } f;
     union
     {
-        int suns[8];		/*!< temporary pointers to daughter nodes */
+        struct
+        {
+            /*!< temporary pointers to daughter nodes or daughter particles. */
+            int suns[NMAXCHILD];
+            /* Number of daughter particles if node contains particles.
+             * During treebuild >= (1<<16) if node contains nodes.*/
+            int noccupied;
+        } s;
         struct
         {
             MyFloat s[3];		/*!< center of mass of node */

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -210,7 +210,7 @@ static int check_tree(const ForceTree * tb, const int nnodes, const int numpart)
         assert_int_equal(P[i].PI, 1);
     }
     printf("Tree filling factor: %g on %d nodes (wasted: %d empty: %d)\n", tot_empty/(8.*nrealnode), nrealnode, nnodes - nrealnode, sevens);
-    return nrealnode;
+    return nrealnode - sevens;
 }
 
 static void do_tree_test(const int numpart, const ForceTree tb, DomainDecomp * ddecomp)

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -27,7 +27,7 @@ ForceTree
 force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp);
 
 int
-force_update_node_parallel(const ForceTree * tree);
+force_update_node_parallel(const ForceTree * tree, const int HybridNuGrav);
 
 /*Particle data.*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -166,23 +166,31 @@ static int check_tree(const ForceTree * tb, const int nnodes, const int numpart)
     for(i=firstnode; i<nnodes+firstnode; i++)
     {
         struct NODE * pNode = &(tb->Nodes[i]);
-        int empty = 0;
         /*Just reserved free space with nothing in it*/
         if(pNode->father < -1.5)
             continue;
 
         int j;
-        for(j=0; j<8; j++) {
-            /*Check children*/
-            int child = pNode->u.suns[j];
-            if(child == -1) {
-                empty++;
-                continue;
+        /* Full of particles*/
+        if(pNode->u.s.noccupied < 1<<16) {
+            tot_empty += NMAXCHILD - pNode->u.s.noccupied;
+            if(pNode->u.s.noccupied == 0)
+                sevens++;
+            for(j=0; j<pNode->u.s.noccupied; j++) {
+                int child = pNode->u.s.suns[j];
+                assert_true(child >= 0);
+                assert_true(child < firstnode);
+                P[child].PI += 1;
+                assert_int_equal(force_get_father(child, tb), i);
             }
-            assert_true(child < firstnode+nnodes);
-            assert_true(child >= 0);
-            /*If an internal node*/
-            if(child > firstnode) {
+        }
+        /* Node is full of other nodes*/
+        else {
+            for(j=0; j<8; j++) {
+                /*Check children*/
+                int child = pNode->u.s.suns[j];
+                assert_true(child < firstnode+nnodes);
+                assert_true(child >= firstnode);
                 assert_true(fabs(tb->Nodes[child].len/pNode->len - 0.5) < 1e-4);
                 int k;
                 for(k=0; k<3; k++) {
@@ -192,34 +200,7 @@ static int check_tree(const ForceTree * tb, const int nnodes, const int numpart)
                         assert_true(tb->Nodes[child].center[k] <= pNode->center[k]);
                 }
             }
-            /*Particle*/
-            else {
-                /* if the first particle suffers, then all particles on the list
-                 * must be suffering from particle-coupling */
-                do {
-                    P[child].PI += 1;
-                    if(tb->Nextnode[child] > -1) {
-                        assert_int_equal(force_get_father(child, tb), force_get_father(tb->Nextnode[child], tb));
-                    }
-                    /*Check in right quadrant*/
-                    int k;
-                    for(k=0; k<3; k++) {
-                        if(j & (1<<k)) {
-                            assert_true(P[child].Pos[k] > pNode->center[k]);
-                        }
-                        else
-                            assert_true(P[child].Pos[k] <= pNode->center[k]);
-                    }
-                    child = force_get_next_node(child, tb);
-                } while(child > -1);
-            }
         }
-        /*All nodes should have at least one thing in them:
-         * maybe particles or other nodes.*/
-        if(empty > 6)
-            sevens++;
-        assert_true(empty <= 7);
-        tot_empty += empty;
         nrealnode++;
     }
     assert_true(nnodes - nrealnode < omp_get_max_threads()*NODECACHE_SIZE);
@@ -228,7 +209,7 @@ static int check_tree(const ForceTree * tb, const int nnodes, const int numpart)
     {
         assert_int_equal(P[i].PI, 1);
     }
-    printf("Tree filling factor: %g on %d nodes (wasted: %d seven empty: %d)\n", tot_empty/(8.*nrealnode), nrealnode, nnodes - nrealnode, sevens);
+    printf("Tree filling factor: %g on %d nodes (wasted: %d empty: %d)\n", tot_empty/(8.*nrealnode), nrealnode, nnodes - nrealnode, sevens);
     return nrealnode;
 }
 
@@ -259,7 +240,7 @@ static void do_tree_test(const int numpart, const ForceTree tb, DomainDecomp * d
     int nrealnode = check_tree(&tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
-    int tail = force_update_node_parallel(&tb);
+    int tail = force_update_node_parallel(&tb, 0);
     force_set_next_node(tail, -1, &tb);
 /*     assert_true(tail < nodes); */
     end = MPI_Wtime();
@@ -396,8 +377,8 @@ void trivial_domain(DomainDecomp * ddecomp)
 static int setup_tree(void **state) {
     /*Set up the important parts of the All structure.*/
     /*Particles should not be outside this*/
-    int i;
     BoxSize = 8;
+    int i;
     for(i=0; i<6; i++)
         GravitySofteningTable[i] = 0.1 / 2.8;
 


### PR DESCRIPTION
This modifies the tree build algorithm to both make the tree shallower and the tree build faster (prompted because the walking has gotten so much faster recently that build is noticeable again).

On a small run on my desktop this halves the treebuild time and speeds up density and hydro substantially (maybe 20-30%).

Instead of keeping adding each particle to a specific quadrant and splitting the quadrant when there are two such particles, this just adds each particle to an unordered list of NCHILD particles under the node. When the list is full, we create a layer of 8 child nodes and re-add the particles. This ensures that child nodes are close together, and it means that tree moment building doesn't have a hard-to-predict branch in it (each node either has nodes as children or particles). It also ensures that the relatively common case of two close particles doesn't cause the tree to balloon. It will balloon if we have more than 11 particles in the same place, but in that case we probably have bigger problems.

Once this is merged I might alter the treewalk a bit to make use of the fact that nodes either have node children or particle children and thus allow vectorization.