### PR TITLE
Treegarbagefix

### DIFF
--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -578,6 +578,8 @@ force_insert_pseudo_particles(const ForceTree * tree, const DomainDecomp * ddeco
         index = ddecomp->TopLeaves[i].treenode;
 
         if(ddecomp->TopLeaves[i].Task != ThisTask) {
+            if(tree->Nodes[index].u.suns[0] > -1)
+                endrun(1, "In node %d, want to overwrite child %d with pseudo particle %d\n", index, tree->Nodes[index].u.suns[0], i);
             tree->Nodes[index].u.suns[0] = firstpseudo + i;
             force_set_next_node(firstpseudo + i, -1, tree);
         }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -393,6 +393,9 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         if(nc.nnext_thread >= tb.lastnode-1)
             continue;
 
+        /* Do not add garbage particles to the tree*/
+        if(P[i].IsGarbage)
+            continue;
         /*First find the Node for the TopLeaf */
 
         int this;


### PR DESCRIPTION
This PR enforces that garbage particles are not added to the forcetree and adds an extra check to the tree build.