### PR TITLE
Nopthread

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -15,8 +15,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#Disable openmp locking. This means no threading.
-#OPT += -DNO_OPENMP_SPINLOCK
 
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,11 @@ platform-options directory. For example, for Stampede 2 you should do:
 
     cp platform-options/Options.mk.stampede2 Options.mk
 
-Compile-time options may be set in Options.mk. The remaining compile time options are generally only useful for development or debugging. All science options are set using a parameter file at runtime.
+Compile-time options may be set in Options.mk. The remaining compile time options are only useful for development or debugging. All science options are set using a parameter file at runtime.
 
 - DEBUG which enables various internal code consistency checks for debugging.
 - VALGRIND which if set disables the internal memory allocator and allocates memory from the system. This is required for debugging memory allocation errors with valgrind of the address sanitizer.
 - NO_ISEND_IRECV_IN_DOMAIN disables the use of asynchronous send and receive in our custom MPI_Alltoallv implementation, for buggy MPI libraries.
-- NO_OPENMP_SPINLOCK disables the use of OpenMP spinlocks and thus effectively disables threading. Necessary for platforms which do not provide an OpenMP header, such as Mac.
 
 If compilation fails with errors related to the GSL, you may also need to set the GSL_INC or GSL_LIB variables in Options.mk to the filesystem path containing the GSL headers and libraries.
 

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -63,12 +63,7 @@ int main(int argc, char **argv)
 
     message(0, "This is MP-Gadget, version %s.\n", GADGET_VERSION);
     message(0, "Running on %d MPI Ranks.\n", NTask);
-#ifdef NO_OPENMP_SPINLOCK
-    message(0,"Code compiled with NO_OPENMP_SPINLOCK (no locks), so no OpenMP threads.\n");
-    omp_set_num_threads(1);
-#else
     message(0, "           %d OpenMP Threads.\n", omp_get_max_threads());
-#endif
     message(0, "Code was compiled with settings:\n"
            "%s\n", GADGET_COMPILER_SETTINGS);
     message(0, "Size of particle structure       %td  [bytes]\n",sizeof(struct particle_data));

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -23,7 +23,6 @@
 #define BREAKPOINT raise(SIGTRAP)
 #ifdef _OPENMP
 #include <omp.h>
-#include <pthread.h>
 #else
 #ifndef __clang_analyzer__
 #error no OMP

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -26,7 +26,6 @@ void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
     if(ti0 != ti1) {
         const double ddrift = get_drift_factor(ti0, ti1);
         real_drift_particle(i, ti1, ddrift);
-#pragma omp flush
     }
     unlock_spinlock(i, spin);
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -449,9 +449,6 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
 
         modify_internal_node(this, subnode, child, i, tb, &nnext, &nc, minlen, &closepairs);
 
-        /* Add an explicit flush because we are not using openmp's critical sections */
-        #pragma omp flush
-
         /*Unlock the parent*/
         unlock_spinlock(this - tb.firstnode, spin);
     }

--- a/libgadget/utils/spinlocks.h
+++ b/libgadget/utils/spinlocks.h
@@ -5,7 +5,7 @@
  * free_spinlocks destroys and frees them.
  * (un)lock_spinlock locks and unlocks the i'th spinlock.
  * try_lock_spinlock trys to lock the particle, returning 0 on success.
- * Warning! If NO_OPENMP_SPINLOCK is defined, these functions do nothing!*/
+ */
 
 struct SpinLocks;
 

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -19,8 +19,6 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#Disable openmp locking. This means no threading. Required on mac.
-OPT += -DNO_OPENMP_SPINLOCK
 
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
This PR is a pure code cleanup which changes the calls to the pthread spinlock API into calls to OpenMP locks, since we require openmp 3 anyway now. This should improve mac compatibility but is mostly just a code cleanup. I haven't tested yet but I would be surprised if it had any effect on the code. The omp flush calls are not necessary anymore because they are implicit after an omp_unlock(). 