### PR TITLE
Revert "Merge pull request #323 from sbird/nopthread"

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -15,6 +15,8 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
+#Disable openmp locking. This means no threading.
+#OPT += -DNO_OPENMP_SPINLOCK
 
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/README.rst
+++ b/README.rst
@@ -73,11 +73,12 @@ platform-options directory. For example, for Stampede 2 you should do:
 
     cp platform-options/Options.mk.stampede2 Options.mk
 
-Compile-time options may be set in Options.mk. The remaining compile time options are only useful for development or debugging. All science options are set using a parameter file at runtime.
+Compile-time options may be set in Options.mk. The remaining compile time options are generally only useful for development or debugging. All science options are set using a parameter file at runtime.
 
 - DEBUG which enables various internal code consistency checks for debugging.
 - VALGRIND which if set disables the internal memory allocator and allocates memory from the system. This is required for debugging memory allocation errors with valgrind of the address sanitizer.
 - NO_ISEND_IRECV_IN_DOMAIN disables the use of asynchronous send and receive in our custom MPI_Alltoallv implementation, for buggy MPI libraries.
+- NO_OPENMP_SPINLOCK disables the use of OpenMP spinlocks and thus effectively disables threading. Necessary for platforms which do not provide an OpenMP header, such as Mac.
 
 If compilation fails with errors related to the GSL, you may also need to set the GSL_INC or GSL_LIB variables in Options.mk to the filesystem path containing the GSL headers and libraries.
 

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -63,7 +63,12 @@ int main(int argc, char **argv)
 
     message(0, "This is MP-Gadget, version %s.\n", GADGET_VERSION);
     message(0, "Running on %d MPI Ranks.\n", NTask);
+#ifdef NO_OPENMP_SPINLOCK
+    message(0,"Code compiled with NO_OPENMP_SPINLOCK (no locks), so no OpenMP threads.\n");
+    omp_set_num_threads(1);
+#else
     message(0, "           %d OpenMP Threads.\n", omp_get_max_threads());
+#endif
     message(0, "Code was compiled with settings:\n"
            "%s\n", GADGET_COMPILER_SETTINGS);
     message(0, "Size of particle structure       %td  [bytes]\n",sizeof(struct particle_data));

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -23,6 +23,7 @@
 #define BREAKPOINT raise(SIGTRAP)
 #ifdef _OPENMP
 #include <omp.h>
+#include <pthread.h>
 #else
 #ifndef __clang_analyzer__
 #error no OMP

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -26,6 +26,7 @@ void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
     if(ti0 != ti1) {
         const double ddrift = get_drift_factor(ti0, ti1);
         real_drift_particle(i, ti1, ddrift);
+#pragma omp flush
     }
     unlock_spinlock(i, spin);
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -472,6 +472,9 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         else
             endrun(2, "Tried to convert already converted node %d with nocc = %d\n", this, nocc);
 
+        /* Add an explicit flush because we are not using openmp's critical sections */
+        #pragma omp flush
+
         /*Unlock the parent*/
         unlock_spinlock(this - tb.firstnode, spin);
     }

--- a/libgadget/utils/spinlocks.c
+++ b/libgadget/utils/spinlocks.c
@@ -1,49 +1,64 @@
 #include "spinlocks.h"
 #include "mymalloc.h"
-#include "omp.h"
+
+#ifndef NO_OPENMP_SPINLOCK
+#include <pthread.h>
+#endif
 
 /* Temporary array for spinlocks*/
 struct SpinLocks
 {
-    omp_lock_t * SpinLocks;
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spinlock_t * SpinLocks;
+#endif
     int NumSpinLock;
 };
 
 static struct SpinLocks spin;
 
 void lock_spinlock(int i, struct SpinLocks * spin) {
-    omp_set_lock(&spin->SpinLocks[i]);
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spin_lock(&spin->SpinLocks[i]);
+#endif
 }
 void unlock_spinlock(int i,  struct SpinLocks * spin) {
-    omp_unset_lock(&spin->SpinLocks[i]);
+#ifndef NO_OPENMP_SPINLOCK
+    pthread_spin_unlock(&spin->SpinLocks[i]);
+#endif
 }
 
 int try_lock_spinlock(int i,  struct SpinLocks * spin)
 {
-    /* omp_test_lock returns true if it got the lock, false otherwise.
-     * pthread_spin_trylock returns 0 (false) if it got the lock, EBUSY (true) otherwise*/
-    return !omp_test_lock(&spin->SpinLocks[i]);
+#ifndef NO_OPENMP_SPINLOCK
+    return pthread_spin_trylock(&spin->SpinLocks[i]);
+#else
+    return 0;
+#endif
 }
 
 struct SpinLocks * init_spinlocks(int NumLock)
 {
+#ifndef NO_OPENMP_SPINLOCK
     int i;
     /* Initialize the spinlocks*/
-    spin.SpinLocks = mymalloc("SpinLocks", NumLock * sizeof(omp_lock_t));
+    spin.SpinLocks = mymalloc("SpinLocks", NumLock * sizeof(pthread_spinlock_t));
     #pragma omp parallel for
     for(i = 0; i < NumLock; i ++) {
-        omp_init_lock(&spin.SpinLocks[i]);
+        pthread_spin_init(&spin.SpinLocks[i], PTHREAD_PROCESS_PRIVATE);
     }
+#endif
     spin.NumSpinLock = NumLock;
     return &spin;
 }
 
 void free_spinlocks(struct SpinLocks * spin)
 {
+#ifndef NO_OPENMP_SPINLOCK
     int i;
     for(i = 0; i < spin->NumSpinLock; i ++) {
-        omp_destroy_lock(&(spin->SpinLocks[i]));
+        pthread_spin_destroy(&(spin->SpinLocks[i]));
     }
     myfree((void *) spin->SpinLocks);
+#endif
 }
 

--- a/libgadget/utils/spinlocks.h
+++ b/libgadget/utils/spinlocks.h
@@ -5,7 +5,7 @@
  * free_spinlocks destroys and frees them.
  * (un)lock_spinlock locks and unlocks the i'th spinlock.
  * try_lock_spinlock trys to lock the particle, returning 0 on success.
- */
+ * Warning! If NO_OPENMP_SPINLOCK is defined, these functions do nothing!*/
 
 struct SpinLocks;
 

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -19,6 +19,8 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
 #OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
+#Disable openmp locking. This means no threading. Required on mac.
+OPT += -DNO_OPENMP_SPINLOCK
 
 #-------------------------------------------- Things for special behaviour
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
I found that using OMP locks slows down the tree build by a factor of 200 (!) so that it now takes 85% of the simulation runtime. This only seems to happen on intel, so it affects stampede and frontera. About 60% of the time was spent in init_spinlocks, 30% spent in creating the nodes. This might be a bug with intel's openmp implementation, or it might be because it is using mutexes instead of spinlocks. godbolt suggests that icc does produce much longer code for init_spinlocks than gcc 

In any case, revert this because it is not worth the effort to root cause.

@rainwoodman : Any better ideas for this?