### PR TITLE
Fix a bug in the force tree opening criteria

### DIFF
--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -231,11 +231,11 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                     continue;
                 }
                 /* check in addition whether we lie inside the cell */
-                if(fabs(nop->center[0] - pos_x) < 0.60 * nop->len)
+                if(fabs(NEAREST(nop->center[0] - pos_x)) < 0.60 * nop->len)
                 {
-                    if(fabs(nop->center[1] - pos_y) < 0.60 * nop->len)
+                    if(fabs(NEAREST(nop->center[1] - pos_y)) < 0.60 * nop->len)
                     {
-                        if(fabs(nop->center[2] - pos_z) < 0.60 * nop->len)
+                        if(fabs(NEAREST(nop->center[2] - pos_z)) < 0.60 * nop->len)
                         {
                             no = nop->u.d.nextnode;
                             continue;


### PR DESCRIPTION
which does not take account of periodic boundary conditions, first discovered by 1907.03542.

In Illustris, Eagle, and IllustrisTNG there is a small number of galaxies with very low DM fraction
located directly at a boundary of the periodic box (but not the same boundary).

This flawed dynamics arises from an unlucky and rare combination of factors.
The dense stellar core experiences an unusually large force error because to compute the tree force
from material on the opposite side of the box a very large tree node is used.
This is deemed allowed by the code because the total accelerations within the dense stellar core are
quite large, so the estimated contribution to the relative error is small even for this large node.
However, this error is severely underestimated by the code in this particular case because the distance
to the closest edge of the node is very small while its center-of-mass is far away. So the code should
have better opened the node - but it didn't. The conditions that here lead to the large force error
in the tree are quite close to the worst case scenario
described in Salmon & Warren 1994 ( https://ui.adsabs.harvard.edu/abs/1994JCoPh.111..136S/abstract ).

Normally, the code protects against the possibility of such rare large force errors with a special additional
opening criterion, designed to avoid exactly this situation in which the multipole expansion breaks down
because a particle is too close to a node. More specifically, this opening criterion checks if
the distance between particle and geometric center of the node is smaller than 0.6 times the size of the node.

Before this commit this distance check lacked the periodic wrapping... i.e. even though the stellar particles
of the flawed galaxy are very close to a large node (which is seen as the nearest periodic image in the tree
force computation), this opening criterion is not triggered as the center of the node is on the other side
more than half a simulation box away.

This bug fix thanks to upstream, Rudiger Pakmor and Volker Springel.