### PR TITLE
Earlytamalloc

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -76,6 +76,8 @@ int main(int argc, char **argv)
     message(0, "Size of sph particle structure   %td  [bytes]\n",sizeof(struct sph_particle_data));
     message(0, "Size of star particle structure   %td  [bytes]\n",sizeof(struct star_particle_data));
 
+    tamalloc_init();
+
     read_parameter_file(argv[1]);	/* ... read in parameters for this run */
 
     int RestartFlag, RestartSnapNum;

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -112,6 +112,10 @@ int main(int argc, char **argv)
     /*Initialize the memory manager*/
     mymalloc_init(All.MaxMemSizePerNode);
 
+    /* Make sure memory has finished initialising on all ranks before doing more.
+     * This may improve stability */
+    MPI_Barrier(MPI_COMM_WORLD);
+
     /*The main domain object. Will be allocated in begrun.*/
     DomainDecomp ddecomp = {0};
     begrun(RestartSnapNum, &ddecomp);

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -40,11 +40,6 @@ StarformationCriterionAction(ParameterSet * ps, char * name, void * data)
     return 0;
 }
 
-int cmp_double(const void * a, const void * b)
-{
-    return ( *(double*)a - *(double*)b );
-}
-
 /*! This function parses a string containing a comma-separated list of variables,
  *  each of which is interpreted as a double.
  *  The purpose is to read an array of output times into the code.
@@ -95,7 +90,6 @@ OutputListAction(ParameterSet * ps, char * name, void * data)
 /*         message(1, "Output at: %g\n", All.OutputListTimes[count]); */
     }
     myfree(strtmp);
-    qsort(All.OutputListTimes, All.OutputListLength, sizeof(double), cmp_double);
     return 0;
 }
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -54,7 +54,7 @@ static int
 OutputListAction(ParameterSet * ps, char * name, void * data)
 {
     char * outputlist = param_get_string(ps, name);
-    char * strtmp=fastpm_strdup(outputlist);
+    char * strtmp = fastpm_strdup(outputlist);
     char * token;
     int count;
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -59,7 +59,7 @@ static int
 OutputListAction(ParameterSet * ps, char * name, void * data)
 {
     char * outputlist = param_get_string(ps, name);
-    char * strtmp=strdup(outputlist);
+    char * strtmp=fastpm_strdup(outputlist);
     char * token;
     int count;
 
@@ -94,7 +94,7 @@ OutputListAction(ParameterSet * ps, char * name, void * data)
         All.OutputListTimes[count] = a;
 /*         message(1, "Output at: %g\n", All.OutputListTimes[count]); */
     }
-    free(strtmp);
+    myfree(strtmp);
     qsort(All.OutputListTimes, All.OutputListLength, sizeof(double), cmp_double);
     return 0;
 }

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -370,13 +370,13 @@ void read_parameter_file(char *fname)
         All.NumThreads = omp_get_max_threads();
 
     /* Start reading the values */
-        param_get_string2(ps, "InitCondFile", All.InitCondFile);
-        param_get_string2(ps, "OutputDir", All.OutputDir);
-        param_get_string2(ps, "SnapshotFileBase", All.SnapshotFileBase);
-        param_get_string2(ps, "FOFFileBase", All.FOFFileBase);
-        param_get_string2(ps, "EnergyFile", All.EnergyFile);
+        param_get_string2(ps, "InitCondFile", All.InitCondFile, sizeof(All.InitCondFile));
+        param_get_string2(ps, "OutputDir", All.OutputDir, sizeof(All.OutputDir));
+        param_get_string2(ps, "SnapshotFileBase", All.SnapshotFileBase, sizeof(All.SnapshotFileBase));
+        param_get_string2(ps, "FOFFileBase", All.FOFFileBase, sizeof(All.FOFFileBase));
+        param_get_string2(ps, "EnergyFile", All.EnergyFile, sizeof(All.EnergyFile));
         All.OutputEnergyDebug = param_get_int(ps, "EnergyFile");
-        param_get_string2(ps, "CpuFile", All.CpuFile);
+        param_get_string2(ps, "CpuFile", All.CpuFile, sizeof(All.CpuFile));
 
         All.DensityKernelType = param_get_enum(ps, "DensityKernelType");
         All.CP.CMBTemperature = param_get_double(ps, "CMBTemperature");
@@ -457,9 +457,9 @@ void read_parameter_file(char *fname)
         All.StarformationOn = param_get_int(ps, "StarformationOn");
         All.WindOn = param_get_int(ps, "WindOn");
 
-        param_get_string2(ps, "TreeCoolFile", All.TreeCoolFile);
-        param_get_string2(ps, "UVFluctuationfile", All.UVFluctuationFile);
-        param_get_string2(ps, "MetalCoolFile", All.MetalCoolFile);
+        param_get_string2(ps, "TreeCoolFile", All.TreeCoolFile, sizeof(All.TreeCoolFile));
+        param_get_string2(ps, "UVFluctuationfile", All.UVFluctuationFile, sizeof(All.UVFluctuationFile));
+        param_get_string2(ps, "MetalCoolFile", All.MetalCoolFile, sizeof(All.MetalCoolFile));
 
         All.MinGasTemp = param_get_double(ps, "MinGasTemp");
         All.InitGasTemp = param_get_double(ps, "InitGasTemp");

--- a/genic/main.c
+++ b/genic/main.c
@@ -26,7 +26,8 @@ int main(int argc, char **argv)
   if(argc < 2)
     endrun(0,"Please pass a parameter file.\n");
 
-  /* fixme: make this a mpi bcast */
+  tamalloc_init();
+
   read_parameterfile(argv[1]);
 
   mymalloc_init(All.MaxMemSizePerNode);

--- a/genic/params.c
+++ b/genic/params.c
@@ -156,8 +156,8 @@ void read_parameterfile(char *fname)
     All2.Max_nuvel = param_get_double(ps, "Max_nuvel") * pow(1+Redshift, 1.5) * (All.UnitVelocity_in_cm_per_s/1e5);
     All2.Seed = param_get_int(ps, "Seed");
     All2.UnitaryAmplitude = param_get_int(ps, "UnitaryAmplitude");
-    param_get_string2(ps, "OutputDir", All.OutputDir);
-    param_get_string2(ps, "FileBase", All.InitCondFile);
+    param_get_string2(ps, "OutputDir", All.OutputDir, sizeof(All.OutputDir));
+    param_get_string2(ps, "FileBase", All.InitCondFile, sizeof(All.InitCondFile));
     All2.MakeGlassGas = param_get_int(ps, "MakeGlassGas");
     /* We want to use a baryon glass by default if we have different transfer functions,
      * since that is the way we reproduce the linear growth. Otherwise use a grid by default.*/

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -143,7 +143,7 @@ build-tests: $(TESTBIN)
 test : build-tests
 	trap 'err=1' ERR; for tt in $(SUITE) ; do \
 		if [[ "$(MPISUITE)" =~ .*$$tt.* ]]; then \
-			mpirun -np 4 .objs/$$tt ;  \
+			mpirun -np 4 --oversubscribe .objs/$$tt ;  \
 		else \
 			.objs/$$tt ; \
 		fi ;  \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -143,6 +143,7 @@ build-tests: $(TESTBIN)
 test : build-tests
 	trap 'err=1' ERR; for tt in $(SUITE) ; do \
 		if [[ "$(MPISUITE)" =~ .*$$tt.* ]]; then \
+            OMPI_MCA_rmaps_base_oversubscribe=1 \
 			mpirun -np 4 .objs/$$tt ;  \
 		else \
 			.objs/$$tt ; \

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -143,7 +143,7 @@ build-tests: $(TESTBIN)
 test : build-tests
 	trap 'err=1' ERR; for tt in $(SUITE) ; do \
 		if [[ "$(MPISUITE)" =~ .*$$tt.* ]]; then \
-			mpirun -np 4 --oversubscribe .objs/$$tt ;  \
+			mpirun -np 4 .objs/$$tt ;  \
 		else \
 			.objs/$$tt ; \
 		fi ;  \

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -282,7 +282,7 @@ extern struct global_data_all_processes
     /*Should we store the energy to EnergyFile on PM timesteps.*/
     int OutputEnergyDebug;
 
-    double OutputListTimes[8192];
+    double OutputListTimes[1024];
     int OutputListLength;
 
     int SnapshotWithFOF; /*Flag that doing FOF for snapshot outputs is on*/

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -66,22 +66,21 @@ write_snapshot(int num)
     walltime_measure("/Snapshot/Write");
 
     if(ThisTask == 0) {
-        char buf[1024];
-        sprintf(buf, "%s/Snapshots.txt", All.OutputDir);
+        char * buf = fastpm_strdup_printf("%s/Snapshots.txt", All.OutputDir);
         FILE * fd = fopen(buf, "a");
         fprintf(fd, "%03d %g\n", num, All.Time);
         fclose(fd);
+        myfree(buf);
     }
 }
 
 int
-find_last_snapnum()
+find_last_snapnum(void)
 {
     /* FIXME: this is very fragile; should be fine */
     int snapnumber = -1;
     if(ThisTask == 0) {
-        char buf[1024];
-        sprintf(buf, "%s/Snapshots.txt", All.OutputDir);
+        char * buf = fastpm_strdup_printf("%s/Snapshots.txt", All.OutputDir);
         FILE * fd = fopen(buf, "r");
         if(fd == NULL) {
             snapnumber = -1;
@@ -103,6 +102,7 @@ find_last_snapnum()
             }
             fclose(fd);
         }
+        myfree(buf);
     }
 
     MPI_Bcast(&snapnumber, 1, MPI_INT, 0, MPI_COMM_WORLD);

--- a/libgadget/checkpoint.h
+++ b/libgadget/checkpoint.h
@@ -5,6 +5,6 @@
 
 void write_checkpoint(int WriteSnapshot, int WriteFOF, ForceTree * tree);
 void dump_snapshot(void);
-int find_last_snapnum();
+int find_last_snapnum(void);
 
 #endif

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -340,7 +340,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, MPI_Comm Comm)
 
 #ifdef DEBUG
     domain_test_id_uniqueness();
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
 #endif
     walltime_measure("/Domain/exchange/finalize");
 

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -44,9 +44,8 @@ fof_petaio_select_func(int i)
 
 void fof_save_particles(int num, int SaveParticles, MPI_Comm Comm)
 {
-    char fname[4096];
     int i;
-    sprintf(fname, "%s/%s_%03d", All.OutputDir, All.FOFFileBase, num);
+    char * fname = fastpm_strdup_printf("%s/%s_%03d", All.OutputDir, All.FOFFileBase, num);
     message(0, "saving particle in group into %s\n", fname);
 
     /* sort the groups according to group-number */
@@ -57,6 +56,7 @@ void fof_save_particles(int num, int SaveParticles, MPI_Comm Comm)
     if(0 != big_file_mpi_create(&bf, fname, Comm)) {
         endrun(0, "Failed to open file at %s\n", fname);
     }
+    myfree(fname);
 
     MPIU_Barrier(Comm);
     fof_write_header(&bf, Comm);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -125,7 +125,7 @@ force_tree_rebuild(ForceTree * tree, DomainDecomp * ddecomp, const double BoxSiz
 
     MPIU_Barrier(MPI_COMM_WORLD);
     message(0, "Tree construction done.\n");
-    walltime_measure("/Tree/Build");
+    walltime_measure("/Tree/Build/Moments");
 }
 
 /*! This function is a driver routine for constructing the gravitational
@@ -505,11 +505,11 @@ static int
 force_tree_build_single(const ForceTree tb, const int npart, DomainDecomp * ddecomp, const double BoxSize, const int HybridNuGrav)
 {
     int nnext = force_tree_create_nodes(tb, npart, ddecomp, BoxSize);
+    walltime_measure("/Tree/Build/Nodes");
     if(nnext >= tb.lastnode - tb.firstnode)
     {
         return -1;
     }
-
     /* insert the pseudo particles that represent the mass distribution of other ddecomps */
     force_insert_pseudo_particles(&tb, ddecomp);
 
@@ -853,7 +853,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
             tails[j] = force_update_pseudo_node(p, nextsib, tree);
         /*Don't spawn a new task if we are deep enough that we already spawned a lot.
         Note: final clause is much slower for some reason. */
-        else if(childcnt > 1 && level < 128 * omp_get_num_threads()) {
+        else if(childcnt > 1 && level < 256) {
             /* We cannot use default(none) here because we need a const (HybridNuGrav),
             * which for gcc < 9 is default shared (and thus cannot be explicitly shared
             * without error) and for gcc == 9 must be explicitly shared. The other solution

--- a/libgadget/gdbtools.c
+++ b/libgadget/gdbtools.c
@@ -56,9 +56,9 @@ int GDB_find_garbage(int from) {
 }
 
 char * GDB_format_particle(int i) {
-    static char buf[4096];
+    static char buf[1024];
     char * p = buf;
-    int n = 4096;
+    int n = 1024;
 
 #define add(fmt, ...) \
         snprintf(p, n - 1, fmt, __VA_ARGS__ ); \

--- a/libgadget/neutrinos_lra.c
+++ b/libgadget/neutrinos_lra.c
@@ -18,6 +18,7 @@
 
 #include "utils/endrun.h"
 #include "utils/mymalloc.h"
+#include "utils/string.h"
 #include "petaio.h"
 #include "cosmology.h"
 #include "powerspectrum.h"
@@ -204,9 +205,8 @@ void delta_nu_from_power(struct _powerspectrum * PowerSpectrum, Cosmology * CP, 
 void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * OutputDir, const char * filename, const double Time)
 {
     int i;
-    char fname[1024];
+    char * fname = fastpm_strdup_printf("%s/%s-%0.4f.txt", OutputDir, filename, Time);
     /* Now save the neutrino power spectrum*/
-    snprintf(fname, 1024,"%s/%s-%0.4f.txt", OutputDir, filename, Time);
     FILE * fp = fopen(fname, "w");
     fprintf(fp, "# in Mpc/h Units \n");
     fprintf(fp, "# k P_nu(k) Nmodes\n");
@@ -216,6 +216,7 @@ void powerspectrum_nu_save(struct _powerspectrum * PowerSpectrum, const char * O
         fprintf(fp, "%g %g %ld\n", PowerSpectrum->kk[i], pow(delta_tot_table.delta_nu_last[i],2), PowerSpectrum->Nmodes[i]);
     }
     fclose(fp);
+    myfree(fname);
     /*Clean up the neutrino memory now we saved the power spectrum.*/
     gsl_interp_free(PowerSpectrum->nu_spline);
     gsl_interp_accel_free(PowerSpectrum->nu_acc);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -239,7 +239,7 @@ void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
     }
 
     /* so we can set up the memory topology of secondary slots */
-    slots_setup_topology();
+    slots_setup_topology(SlotsManager);
 
     for(i = 0; i < IOTable.used; i ++) {
         /* only process the particle blocks */
@@ -291,7 +291,7 @@ void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
     }
 
     /* now we have IDs, set up the ID consistency between slots. */
-    slots_setup_id();
+    slots_setup_id(SlotsManager);
 }
 void
 petaio_read_header(int num)

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -61,25 +61,13 @@ petaio_save_snapshot(const char *fmt, ...)
     va_list va;
     va_start(va, fmt);
 
-    char fname[4096];
-    vsprintf(fname, fmt, va);
+    char * fname = fastpm_strdup_vprintf(fmt, va);
     va_end(va);
     message(0, "saving snapshot into %s\n", fname);
 
     petaio_save_internal(fname);
+    myfree(fname);
 }
-
-/* this is unused.
-void petaio_save_restart() {
-    char fname[4096];
-    sprintf(fname, "%s/RESTART", All.OutputDir);
-    if(ThisTask == 0) {
-        printf("saving restart into %s\n", fname);
-        fflush(stdout);
-    }
-    petaio_save_internal(fname);
-}
-*/
 
 /* Build a list of the first particle of each type on the current processor.
  * This assumes that all particles are sorted!*/

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -702,11 +702,15 @@ void io_register_io_block(char * name,
         property_setter setter,
         int required
         ) {
+    if (IOTable.used == IOTable.allocated) {
+        IOTable.ent = myrealloc(IOTable.ent, 2*IOTable.allocated*sizeof(IOTableEntry));
+        IOTable.allocated *= 2;
+    }
     IOTableEntry * ent = &IOTable.ent[IOTable.used];
-    strcpy(ent->name, name);
+    strncpy(ent->name, name, 64);
     ent->zorder = IOTable.used;
     ent->ptype = ptype;
-    strcpy(ent->dtype, dtype);
+    strncpy(ent->dtype, dtype, 8);
     ent->getter = getter;
     ent->setter = setter;
     ent->items = items;
@@ -801,7 +805,9 @@ static int order_by_type(const void *a, const void *b)
 
 static void register_io_blocks() {
     int i;
-    memset(&IOTable, 0, sizeof(IOTable));
+    IOTable.used = 0;
+    IOTable.allocated = 100;
+    IOTable.ent = mymalloc("IOTable", IOTable.allocated* sizeof(IOTableEntry));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
         IO_REG(Position, "f8", 3, i);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -329,7 +329,7 @@ petaio_read_header(int num)
         endrun(0, "Failed to close snapshot at %s:%s\n", fname,
                     big_file_get_error_message());
     }
-    free(fname);
+    myfree(fname);
 }
 
 void
@@ -371,7 +371,7 @@ petaio_read_snapshot(int num, MPI_Comm Comm)
          * */
         petaio_read_internal(fname, 0, Comm);
     }
-    free(fname);
+    myfree(fname);
 }
 
 

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -109,8 +109,9 @@ static void name(int i, type * out) { \
  * currently 4096 entries are supported
  * */
 extern struct IOTable {
-    IOTableEntry ent[4096];
+    IOTableEntry * ent;
     int used;
+    int allocated;
 } IOTable;
 
 #endif

--- a/libgadget/powerspectrum.c
+++ b/libgadget/powerspectrum.c
@@ -90,8 +90,7 @@ void powerspectrum_sum(struct _powerspectrum * PowerSpectrum, const double BoxSi
 void powerspectrum_save(struct _powerspectrum * PowerSpectrum, const char * OutputDir, const char * filename, const double Time, const double D1)
 {
         int i;
-        char fname[1024];
-        sprintf(fname, "%s/%s-%0.4f.txt", OutputDir, filename, Time);
+        char * fname = fastpm_strdup_printf("%s/%s-%0.4f.txt", OutputDir, filename, Time);
         message(1, "Writing Power Spectrum to %s\n", fname);
         FILE * fp = fopen(fname, "w");
         if(!fp)
@@ -106,4 +105,5 @@ void powerspectrum_save(struct _powerspectrum * PowerSpectrum, const char * Outp
             }
             fclose(fp);
         }
+        myfree(fname);
 }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -91,7 +91,7 @@ void begrun(int RestartSnapNum, DomainDecomp * ddecomp)
     char * pidfile = fastpm_strdup_printf("%s/%s", All.OutputDir, "PIDs.txt");
 
     MPIU_write_pids(pidfile);
-    free(pidfile);
+    myfree(pidfile);
 
     enable_core_dumps_and_fpu_exceptions();
 #endif
@@ -434,28 +434,28 @@ open_outputfiles(int RestartSnapNum)
     fastpm_path_ensure_dirname(buf);
     if(!(FdCPU = fopen(buf, mode)))
         endrun(1, "error in opening file '%s'\n", buf);
-    free(buf);
+    myfree(buf);
 
     if(All.OutputEnergyDebug) {
         buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, All.EnergyFile, postfix);
         fastpm_path_ensure_dirname(buf);
         if(!(FdEnergy = fopen(buf, mode)))
             endrun(1, "error in opening file '%s'\n", buf);
-        free(buf);
+        myfree(buf);
     }
 
     buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, "sfr.txt", postfix);
     fastpm_path_ensure_dirname(buf);
     if(!(FdSfr = fopen(buf, mode)))
         endrun(1, "error in opening file '%s'\n", buf);
-    free(buf);
+    myfree(buf);
 
     if(All.BlackHoleOn) {
         buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, "blackholes.txt", postfix);
         fastpm_path_ensure_dirname(buf);
         if(!(FdBlackHoles = fopen(buf, mode)))
             endrun(1, "error in opening file '%s'\n", buf);
-        free(buf);
+        myfree(buf);
     }
 
 }

--- a/libgadget/shortrange-kernel.c
+++ b/libgadget/shortrange-kernel.c
@@ -1,6 +1,6 @@
 
 // # x(in mesh units) w_pot_1d(x)  w_force_1d(x) [erfc + other terms] w_pot_erf(x) w_force_erf(x) split=1.25
-const double shortrange_force_kernels[][5] = {
+static const double shortrange_force_kernels[][5] = {
 
 { 0.000000000000000e+00,1.000000000000000e+00,1.000000000000000e+00,1.000000000000000e+00,1.000000000000000e+00},
 { 2.446183953033465e-02,9.837775293677729e-01,9.999988674537058e-01,9.891582005837505e-01,9.999992953293793e-01},
@@ -516,5 +516,3 @@ const double shortrange_force_kernels[][5] = {
 { 1.250000000000001e+01,-1.383016973759626e-05,2.340030985340197e-05,1.651830916933130e-12,7.989179167688540e-11},
 
     };
-
-    

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -65,9 +65,9 @@ setup_particles(int NType[6])
             ptype++; itype = 0;
         }
     }
-    slots_setup_topology();
+    slots_setup_topology(SlotsManager);
 
-    slots_setup_id();
+    slots_setup_id(SlotsManager);
 
     MPI_Allreduce(&PartManager->NumPart, &TotNumPart, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
@@ -83,7 +83,7 @@ teardown_particles(void **state)
 
     assert_int_equal(TotNumPart2, TotNumPart);
 
-    slots_free();
+    slots_free(SlotsManager);
     myfree(P);
     MPI_Barrier(MPI_COMM_WORLD);
     return 0;
@@ -109,7 +109,7 @@ test_exchange(void **state)
 
     assert_all_true(!fail);
 
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
     domain_test_id_uniqueness();
 
     for(i = 0; i < PartManager->NumPart; i ++) {
@@ -133,7 +133,7 @@ test_exchange_zero_slots(void **state)
 
     assert_all_true(!fail);
 
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
     domain_test_id_uniqueness();
 
     for(i = 0; i < PartManager->NumPart; i ++) {
@@ -160,7 +160,7 @@ test_exchange_with_garbage(void **state)
     assert_all_true(!fail);
 
     domain_test_id_uniqueness();
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
 
     for(i = 0; i < PartManager->NumPart; i ++) {
         assert_true (P[i].ID % NTask == ThisTask);
@@ -200,7 +200,7 @@ test_exchange_uneven(void **state)
         assert_int_equal(SlotsManager->info[0].size, NUMPART1 * NTask);
     }
 
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
     domain_test_id_uniqueness();
 
     for(i = 0; i < PartManager->NumPart; i ++) {

--- a/libgadget/tests/test_hci.c
+++ b/libgadget/tests/test_hci.c
@@ -17,7 +17,7 @@ touch(char * prefix, char * b)
 {
     char * fn = fastpm_strdup_printf("%s/%s", prefix, b);
     FILE * fp = fopen(fn, "w");
-    free(fn);
+    myfree(fn);
     fclose(fp);
 }
 
@@ -26,7 +26,7 @@ exists(char * prefix, char * b)
 {
     char * fn = fastpm_strdup_printf("%s/%s", prefix, b);
     FILE * fp = fopen(fn, "r");
-    free(fn);
+    myfree(fn);
     if(fp) {
         fclose(fp);
         return 1;

--- a/libgadget/tests/test_slotsmanager.c
+++ b/libgadget/tests/test_slotsmanager.c
@@ -45,9 +45,9 @@ setup_particles(void ** state)
         P[i].ID = i;
         P[i].Type = i / (PartManager->NumPart / 6);
     }
-    slots_setup_topology();
+    slots_setup_topology(SlotsManager);
 
-    slots_setup_id();
+    slots_setup_id(SlotsManager);
 
     return 0;
 }
@@ -55,7 +55,7 @@ setup_particles(void ** state)
 static int
 teardown_particles(void **state)
 {
-    slots_free();
+    slots_free(SlotsManager);
     myfree(PartManager->Base);
     return 0;
 }
@@ -77,7 +77,7 @@ test_slots_gc(void **state)
     assert_int_equal(SlotsManager->info[4].size, 127);
     assert_int_equal(SlotsManager->info[5].size, 127);
 
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
     teardown_particles(state);
     return;
 }
@@ -97,7 +97,7 @@ test_slots_gc_sorted(void **state)
     assert_int_equal(SlotsManager->info[4].size, 127);
     assert_int_equal(SlotsManager->info[5].size, 127);
 
-    slots_check_id_consistency();
+    slots_check_id_consistency(SlotsManager);
     teardown_particles(state);
     return;
 }

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -7,7 +7,7 @@
 #include "utils.h"
 
 /*! table with desired sync points. All forces and phase space variables are synchonized to the same order. */
-static SyncPoint SyncPoints[8192];
+static SyncPoint * SyncPoints;
 static int NSyncPoints;    /* number of times stored in table of desired sync points */
 
 /* This function compiles
@@ -27,7 +27,10 @@ setup_sync_points(double TimeIC, double no_snapshot_until_time)
 {
     int i;
 
-    memset(&SyncPoints[0], -1, sizeof(SyncPoints[0]) * 8192);
+    if(NSyncPoints > 0)
+        myfree(SyncPoints);
+    SyncPoints = mymalloc("SyncPoints", sizeof(SyncPoints) * (All.OutputListLength+2));
+    memset(&SyncPoints[0], -1, sizeof(SyncPoints[0]) * All.OutputListLength);
 
     /* Set up first and last entry to SyncPoints; TODO we can insert many more! */
 

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -10,6 +10,11 @@
 static SyncPoint * SyncPoints;
 static int NSyncPoints;    /* number of times stored in table of desired sync points */
 
+int cmp_double(const void * a, const void * b)
+{
+    return ( *(double*)a - *(double*)b );
+}
+
 /* This function compiles
  *
  * All.OutputListTimes, All.TimeIC, All.TimeMax
@@ -26,6 +31,8 @@ void
 setup_sync_points(double TimeIC, double no_snapshot_until_time)
 {
     int i;
+
+    qsort_openmp(All.OutputListTimes, All.OutputListLength, sizeof(double), cmp_double);
 
     if(NSyncPoints > 0)
         myfree(SyncPoints);

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -723,7 +723,7 @@ static void print_timebin_statistics(int NumCurrentTiStep, int * TimeBinCountTyp
             tot_num_force += tot_count[i];
     }
 
-    char extra[1024] = {0};
+    char extra[20] = {0};
 
     if(is_PM_timestep(All.Ti_Current))
         strcat(extra, "PM-Step");

--- a/libgadget/utils/memory.c
+++ b/libgadget/utils/memory.c
@@ -21,7 +21,7 @@ struct BlockHeader {
 } ;
 
 int
-allocator_init(Allocator * alloc, char * name, size_t request_size, int zero, Allocator * parent)
+allocator_init(Allocator * alloc, const char * name, size_t request_size, int zero, Allocator * parent)
 {
     size_t size = (request_size / ALIGNMENT + 1) * ALIGNMENT;
 
@@ -46,7 +46,7 @@ allocator_init(Allocator * alloc, char * name, size_t request_size, int zero, Al
 }
 
 int
-allocator_malloc_init(Allocator * alloc, char * name, size_t request_size, int zero, Allocator * parent)
+allocator_malloc_init(Allocator * alloc, const char * name, size_t request_size, int zero, Allocator * parent)
 {
     /* max support 4096 blocks; ignore request_size */
     size_t size = ALIGNMENT * 4096;
@@ -85,7 +85,7 @@ allocator_reset(Allocator * alloc, int zero)
 }
 
 static void *
-allocator_alloc_va(Allocator * alloc, char * name, size_t request_size, int dir, char * fmt, va_list va)
+allocator_alloc_va(Allocator * alloc, const char * name, size_t request_size, int dir, char * fmt, va_list va)
 {
     size_t size = request_size;
 
@@ -144,7 +144,7 @@ allocator_alloc_va(Allocator * alloc, char * name, size_t request_size, int dir,
     return (void*) (cptr);
 }
 void *
-allocator_alloc(Allocator * alloc, char * name, size_t request_size, int dir, char * fmt, ...)
+allocator_alloc(Allocator * alloc, const char * name, size_t request_size, int dir, char * fmt, ...)
 {
     va_list va;
     va_start(va, fmt);

--- a/libgadget/utils/memory.h
+++ b/libgadget/utils/memory.h
@@ -45,21 +45,21 @@ struct AllocatorIter {
 };
 
 int
-allocator_init(Allocator * alloc, char * name, size_t size, int zero, Allocator * parent);
+allocator_init(Allocator * alloc, const char * name, size_t size, int zero, Allocator * parent);
 
 int
 allocator_malloc_init(Allocator * alloc,
-        char * name, size_t size, int zero, Allocator * parent
+        const char * name, size_t size, int zero, Allocator * parent
         );
 
 int
-allocator_split(Allocator * alloc, Allocator * parent, char * name, size_t request_size, int zero);
+allocator_split(Allocator * alloc, Allocator * parent, const char * name, size_t request_size, int zero);
 
 int
 allocator_destroy(Allocator * alloc);
 
 void *
-allocator_alloc(Allocator * alloc, char * name, size_t size, int dir, char * fmt, ...);
+allocator_alloc(Allocator * alloc, const char * name, size_t size, int dir, char * fmt, ...);
 
 void *
 allocator_realloc_int(Allocator * alloc, void * ptr, size_t size, char * fmt, ...);

--- a/libgadget/utils/mymalloc.c
+++ b/libgadget/utils/mymalloc.c
@@ -32,7 +32,7 @@ tamalloc_init(void)
     int NTask;
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
 
-    /* reserve 128 bytes per task and 128 bytes per thread for TEMP storage.*/
+    /* Reserve 4MB, 128 bytes per task and 128 bytes per thread for TEMP storage.*/
     size_t n = 4096 * 1024 + 128 * NTask + 128 * Nt * NTask;
 
     message(0, "Reserving %td bytes per rank for TEMP memory allocator. \n", n);

--- a/libgadget/utils/mymalloc.c
+++ b/libgadget/utils/mymalloc.c
@@ -46,6 +46,7 @@ tamalloc_init(void)
 void
 mymalloc_init(double MaxMemSizePerNode)
 {
+    /* Warning: this uses ta_malloc*/
     int Nhost = cluster_get_num_hosts();
 
     MPI_Comm comm = MPI_COMM_WORLD;

--- a/libgadget/utils/mymalloc.c
+++ b/libgadget/utils/mymalloc.c
@@ -8,6 +8,7 @@
 
 #include <omp.h>
 #include "mymalloc.h"
+#include "string.h"
 #include "memory.h"
 #include "system.h"
 #include "endrun.h"
@@ -92,11 +93,11 @@ void report_detailed_memory_usage(const char *label, const char * fmt, ...)
     highest_memory_usage = allocator_get_used_size(A_MAIN, ALLOC_DIR_BOTH);
 
     va_list va;
-    char buf[4096];
     va_start(va, fmt);
-    vsprintf(buf, fmt, va);
+    char * buf = fastpm_strdup_vprintf(fmt, va);
     va_end(va);
 
     message(1, "Peak Memory usage induced by %s\n", buf);
+    myfree(buf);
     allocator_print(A_MAIN);
 }

--- a/libgadget/utils/mymalloc.h
+++ b/libgadget/utils/mymalloc.h
@@ -6,7 +6,10 @@
 extern Allocator A_MAIN[1];
 extern Allocator A_TEMP[1];
 
+/* Initialize the main memory block*/
 void mymalloc_init(double MemoryMB);
+/* Initialize the small temporary memory block*/
+void tamalloc_init(void);
 void report_detailed_memory_usage(const char *label, const char * fmt, ...);
 
 #define  mymalloc(name, size)            allocator_alloc_bot(A_MAIN, name, size)

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -6,6 +6,7 @@
 #include "paramset.h"
 #include "string.h"
 #include "mymalloc.h"
+#include "endrun.h"
 
 #define INT 1
 #define DOUBLE 3
@@ -369,6 +370,8 @@ param_get_string2(ParameterSet * ps, char * name, char * dst, size_t len)
     if (param_is_nil(ps, name)) {
         printf("Accessing an undefined parameter `%s`.\n", p->name);
     }
+    if(strlen(ps->value[p->index].s) > len)
+        endrun(1, "Parameter string %s too long for storage (%d)\n", ps->value[p->index].s, len);
     strncpy(dst, ps->value[p->index].s, len);
     dst[len-1]='\0';
 }

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -475,14 +475,17 @@ parameter_set_new()
 
 void
 parameter_set_free(ParameterSet * ps) {
-    int i;
-    for(i = 0; i < ps->size; i ++) {
+    /* Just reset the temp heap,
+     * since that is where the paramset is allocated*/
+    ta_reset();
+    /*    int i;
+     for(i = 0; i < ps->size; i ++) {
         if(ps->p[i].help) {
             myfree(ps->p[i].help);
         }
         if(ps->p[i].type == STRING) {
             if(ps->p[i].defvalue.s) {
-/* FIXME: memory corruption */
+                // FIXME: memory corruption
 //                free(ps->p[i].defvalue.s);
             }
             if(ps->value[ps->p[i].index].s != ps->p[i].defvalue.s) {
@@ -493,5 +496,6 @@ parameter_set_free(ParameterSet * ps) {
         }
     }
     myfree(ps);
+    */
 }
 

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "paramset.h"
 #include "string.h"
@@ -40,6 +41,7 @@ static int parse_enum(ParameterEnum * table, const char * strchoices) {
     return value;
 }
 static char * format_enum(ParameterEnum * table, int value) {
+    int bleft = 2048;
     char buffer[2048];
     ParameterEnum * p;
     char * c = buffer;
@@ -52,11 +54,13 @@ static char * format_enum(ParameterEnum * table, int value) {
                 *(c++) = ' ';
             }
             first = 0;
-            strcpy(c, p->name);
-            c += strlen(p->name);
-            *c = 0;
-            if (c - buffer >= 2048-1)
+            strncpy(c, p->name, bleft);
+            bleft-= strlen(p->name);
+            if (bleft <= 0) {
+                *(c+bleft-1) = '\0';
                 break;
+            }
+            c += strlen(p->name);
         }
     }
     return fastpm_strdup(buffer);
@@ -352,13 +356,14 @@ param_get_string(ParameterSet * ps, char * name)
     return ps->value[p->index].s;
 }
 void
-param_get_string2(ParameterSet * ps, char * name, char * dst)
+param_get_string2(ParameterSet * ps, char * name, char * dst, size_t len)
 {
     ParameterSchema * p = param_get_schema(ps, name);
     if (param_is_nil(ps, name)) {
         printf("Accessing an undefined parameter `%s`.\n", p->name);
     }
-    strcpy(dst, ps->value[p->index].s);
+    strncpy(dst, ps->value[p->index].s, len);
+    dst[len-1]='\0';
 }
 
 int

--- a/libgadget/utils/paramset.c
+++ b/libgadget/utils/paramset.c
@@ -41,8 +41,9 @@ static int parse_enum(ParameterEnum * table, const char * strchoices) {
     return value;
 }
 static char * format_enum(ParameterEnum * table, int value) {
-    int bleft = 2048;
-    char buffer[2048];
+    int btotal = 200;
+    int bleft = btotal;
+    char * buffer = ta_malloc("formatbuffer", char, bleft);
     ParameterEnum * p;
     char * c = buffer;
     int first = 1;
@@ -54,16 +55,19 @@ static char * format_enum(ParameterEnum * table, int value) {
                 *(c++) = ' ';
             }
             first = 0;
-            strncpy(c, p->name, bleft);
             bleft-= strlen(p->name);
             if (bleft <= 0) {
-                *(c+bleft-1) = '\0';
+                int extra = (- bleft) + btotal;
+                buffer = myrealloc(buffer, btotal + extra);
+                btotal += extra;
+                bleft += extra;
                 break;
             }
+            strncpy(c, p->name, bleft);
             c += strlen(p->name);
         }
     }
-    return fastpm_strdup(buffer);
+    return buffer;
 }
 
 typedef struct ParameterValue {

--- a/libgadget/utils/paramset.h
+++ b/libgadget/utils/paramset.h
@@ -42,7 +42,7 @@ char *
 param_get_string(ParameterSet * ps, char * name);
 
 void
-param_get_string2(ParameterSet * ps, char * name, char * dest);
+param_get_string2(ParameterSet * ps, char * name, char * dest, size_t len);
 int
 param_get_int(ParameterSet * ps, char * name);
 

--- a/libgadget/utils/string.c
+++ b/libgadget/utils/string.c
@@ -33,6 +33,7 @@ fastpm_strdup(const char * str)
     size_t N = strlen(str);
     char * d = ta_malloc("strdup", char, N + 1);
     strcpy(d, str);
+    d[N] = '\0';
     return d;
 }
 
@@ -76,8 +77,9 @@ void
 fastpm_path_ensure_dirname(const char * path)
 {
     int i = strlen(path);
-    char * dup = alloca(strlen(path) + 1);
+    char * dup = ta_malloc("dirname", char, strlen(path) + 1);
     strcpy(dup, path);
+    dup[strlen(path)]='\0';
     char * p;
     for(p = i + dup; p >= dup && *p != '/'; p --) {
         continue;
@@ -88,13 +90,15 @@ fastpm_path_ensure_dirname(const char * path)
     /* p == '/', so set it to NULL, dup is the dirname */
     *p = 0;
     _mkdir(dup);
+    myfree(dup);
 }
 
 static void
 _mkdir(const char *dir)
 {
-    char * tmp = alloca(strlen(dir) + 1);
+    char * tmp= ta_malloc("dirname", char, strlen(dir) + 1);
     strcpy(tmp, dir);
+    tmp[strlen(dir)]='\0';
     char *p = NULL;
     size_t len;
 
@@ -108,6 +112,7 @@ _mkdir(const char *dir)
                     *p = '/';
             }
     mkdir(tmp, S_IRWXU | S_IRWXG | S_IRWXO);
+    myfree(tmp);
 }
 
 

--- a/libgadget/utils/string.c
+++ b/libgadget/utils/string.c
@@ -19,7 +19,7 @@ fastpm_file_get_content(const char * filename)
     fseek(fp, 0, SEEK_END);
     size_t file_length = ftell(fp);
 
-    char * buf = ta_malloc(filename, char, file_length + 1);
+    char * buf = ta_malloc2(filename, char, file_length + 1);
     fseek(fp, 0, SEEK_SET);
     file_length = fread(buf, 1, file_length, fp);
     fclose(fp);

--- a/libgadget/utils/string.c
+++ b/libgadget/utils/string.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include "string.h"
+#include "mymalloc.h"
 
 char *
 fastpm_file_get_content(const char * filename)
@@ -18,7 +19,7 @@ fastpm_file_get_content(const char * filename)
     fseek(fp, 0, SEEK_END);
     size_t file_length = ftell(fp);
 
-    char * buf = malloc(file_length + 1);
+    char * buf = ta_malloc(filename, char, file_length + 1);
     fseek(fp, 0, SEEK_SET);
     file_length = fread(buf, 1, file_length, fp);
     fclose(fp);
@@ -26,42 +27,11 @@ fastpm_file_get_content(const char * filename)
     return buf;
 }
 
-char **
-fastpm_strsplit(const char * str, const char * split)
-{
-    size_t N = 0;
-    const char * p1;
-    for(p1 = str; *p1; p1 ++) {
-        if(strchr(split, *p1)) N++;
-    }
-    N++;
-
-    char ** buf = malloc((N + 1) * sizeof(char*) + strlen(str) + 1);
-    /* The first part of the buffer is the pointer to the lines */
-    /* The second part of the buffer is the actually lines */
-    char * dup = (void*) (buf + (N + 1));
-    strcpy(dup, str);
-    ptrdiff_t i = 0;
-    char *p, *q = dup;
-    for(p = dup; *p; p ++) {
-        if(strchr(split, *p)) {
-            buf[i] = q;
-            i ++;
-            *p = 0;
-            q = p + 1;
-        }
-    }
-    buf[i] = q;
-    i++;
-    buf[i] = NULL;
-    return buf;
-}
-
 char *
 fastpm_strdup(const char * str)
 {
     size_t N = strlen(str);
-    char * d = malloc(N + 1);
+    char * d = ta_malloc("strdup", char, N + 1);
     strcpy(d, str);
     return d;
 }
@@ -92,7 +62,7 @@ fastpm_strdup_vprintf(const char * fmt, va_list va)
     char buf0[128];
     size_t N = vsnprintf(buf0, 1, fmt, va);
 
-    char * buf = malloc(N + 100);
+    char * buf = ta_malloc("strdup", char, N + 100);
     vsnprintf(buf, N + 1, fmt, va2);
     buf[N + 1] = 0;
     va_end(va2);

--- a/libgadget/utils/string.h
+++ b/libgadget/utils/string.h
@@ -6,9 +6,6 @@
 char *
 fastpm_file_get_content(const char * filename);
 
-char **
-fastpm_strsplit(const char * str, const char * split);
-
 char *
 fastpm_strdup(const char * str);
 

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -591,10 +591,12 @@ MPIU_write_pids(char * filename)
     /* Smaller buffer than in cluster_get_num_hosts because
      * here an overflow is harmless but running out of memory isn't*/
     int bufsz = 64;
-    char * hosts = ta_malloc("hosts", char, NTask * bufsz);
-    gethostname(&hosts[bufsz*ThisTask], bufsz);
-    hosts[bufsz * ThisTask + bufsz - 1] = '\0';
-    MPI_Gather(MPI_IN_PLACE, bufsz, MPI_CHAR, hosts, bufsz, MPI_CHAR, 0, comm);
+    char * hosts = ta_malloc("hosts", char, (NTask+1) * bufsz);
+    char * thishost = hosts + NTask * bufsz;
+    gethostname(thishost, bufsz);
+    thishost[bufsz - 1] = '\0';
+    /* MPI_IN_PLACE is not used here because the MPI on travis doesn't like it*/
+    MPI_Gather(thishost, bufsz, MPI_CHAR, hosts, bufsz, MPI_CHAR, 0, comm);
     MPI_Gather(&my_pid, 1, MPI_INT, pids, 1, MPI_INT, 0, comm);
 
     if(ThisTask == 0)

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -478,9 +478,8 @@ cluster_get_hostid()
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Allreduce(&l, &ml, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
 
-    /* Avoid ta_malloc since this can be called very early. */
-    buffer = malloc(ml * NTask);
-    nid = malloc(sizeof(int) * NTask);
+    buffer = ta_malloc("buffer", char, ml * NTask);
+    nid = ta_malloc("nid", int, NTask);
     MPI_Allgather(hostname, ml, MPI_BYTE, buffer, ml, MPI_BYTE, MPI_COMM_WORLD);
 
     typedef int(*compar_fn)(const void *, const void *);
@@ -500,8 +499,8 @@ cluster_get_hostid()
         }
     }
     int rt = nid[i];
-    free(buffer);
-    free(nid);
+    ta_free(nid);
+    ta_free(buffer);
     MPI_Barrier(MPI_COMM_WORLD);
     return rt;
 }

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -468,7 +468,8 @@ cluster_get_num_hosts(void)
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
 
-    /* Size is set by the minimal size of the temp heap*/
+    /* Size is set by the size of the temp heap:
+     * this fills it and should be changed if needed.*/
     const int bufsz = 256;
     char * buffer = ta_malloc("buffer", char, bufsz * NTask);
 

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -23,9 +23,8 @@ void catch_fatal(int sig);
 void enable_core_dumps_and_fpu_exceptions(void);
 #endif
 
-int cluster_get_num_hosts();
-int cluster_get_hostid();
-double get_physmem_bytes();
+int cluster_get_num_hosts(void);
+double get_physmem_bytes(void);
 
 /* Gets a random number in the range [0, 1). Only the low bits of the id are used,
  * and random deviates are drawn from a pre-seeded table so that they are independent of processor.*/

--- a/libgadget/walltime.c
+++ b/libgadget/walltime.c
@@ -27,7 +27,7 @@ void walltime_init(struct ClockTable * ct) {
 }
 
 static void walltime_summary_clocks(struct Clock * C, int N, int root, MPI_Comm comm) {
-    double * t = ta_malloc("clocks",double, 4 * N);
+    double * t = ta_malloc("clocks", double, 4 * N);
     double * min = t + N;
     double * max = t + 2 * N;
     double * sum = t + 3 * N;
@@ -83,7 +83,7 @@ static int clockcmp(const void * c1, const void * c2) {
 static void walltime_clock_insert(char * name) {
     if(name[0] != '/') abort();
     if(strlen(name) > 1) {
-        char tmp[80] ={0};
+        char tmp[80] = {0};
         strncpy(tmp, name, 79);
         char * p;
         walltime_clock("/");

--- a/libgadget/walltime.c
+++ b/libgadget/walltime.c
@@ -27,10 +27,10 @@ void walltime_init(struct ClockTable * ct) {
 }
 
 static void walltime_summary_clocks(struct Clock * C, int N, int root, MPI_Comm comm) {
-    double t[N];
-    double min[N];
-    double max[N];
-    double sum[N];
+    double * t = ta_malloc("clocks",double, 4 * N);
+    double * min = t + N;
+    double * max = t + 2 * N;
+    double * sum = t + 3 * N;
     int i;
     for(i = 0; i < CT->N; i ++) {
         t[i] = C[i].time;
@@ -47,6 +47,7 @@ static void walltime_summary_clocks(struct Clock * C, int N, int root, MPI_Comm 
         C[i].max = max[i];
         C[i].mean = sum[i] / NTask;
     }
+    ta_free(t);
 }
 
 /* put min max mean of MPI ranks to rank 0*/

--- a/libgadget/walltime.c
+++ b/libgadget/walltime.c
@@ -83,8 +83,8 @@ static int clockcmp(const void * c1, const void * c2) {
 static void walltime_clock_insert(char * name) {
     if(name[0] != '/') abort();
     if(strlen(name) > 1) {
-        char tmp[80];
-        strcpy(tmp, name);
+        char tmp[80] ={0};
+        strncpy(tmp, name, 79);
         char * p;
         walltime_clock("/");
         for(p = tmp + 1; *p; p ++) {
@@ -99,8 +99,11 @@ static void walltime_clock_insert(char * name) {
         /* too many counters */
         abort();
     }
-    strcpy(CT->C[CT->N].name, name);
-    strcpy(CT->AC[CT->N].name, CT->C[CT->N].name);
+    const int nmsz = sizeof(CT->C[CT->N].name);
+    strncpy(CT->C[CT->N].name, name, nmsz);
+    CT->C[CT->N].name[nmsz-1] = '\0';
+    strncpy(CT->AC[CT->N].name, CT->C[CT->N].name, nmsz);
+    CT->AC[CT->N].name[nmsz-1] = '\0';
     CT->N ++;
     qsort_openmp(CT->C, CT->N, sizeof(struct Clock), clockcmp);
     qsort_openmp(CT->AC, CT->N, sizeof(struct Clock), clockcmp);
@@ -108,7 +111,9 @@ static void walltime_clock_insert(char * name) {
 
 int walltime_clock(char * name) {
     struct Clock dummy;
-    strcpy(dummy.name, name);
+    strncpy(dummy.name, name, sizeof(dummy.name));
+    dummy.name[sizeof(dummy.name)-1]='\0';
+
     struct Clock * rt = bsearch(&dummy, CT->C, CT->N, sizeof(struct Clock), clockcmp);
     if(rt == NULL) {
         walltime_clock_insert(name);

--- a/libgenic/glass.c
+++ b/libgenic/glass.c
@@ -71,7 +71,7 @@ setup_glass(double shift, int Ngrid, int seed, double mass, int NumPart, struct 
 
     char * fn = fastpm_strdup_printf("powerspectrum-glass-%08X", seed);
     glass_evolve(14, fn, ICP, NumPart);
-    free(fn);
+    myfree(fn);
 
     return NumPart;
 }

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -425,7 +425,8 @@ pmic_fill_gaussian_gadget(PM * pm, double * delta_k, int seed, int setUnitaryAmp
     unsigned int * seedtable[2][2];
     for(i = 0; i < 2; i ++)
     for(j = 0; j < 2; j ++) {
-            seedtable[i][j] = calloc(pm->ORegion.size[0] * pm->ORegion.size[1], sizeof(int));
+            seedtable[i][j] = mymalloc("seedtable", pm->ORegion.size[0] * pm->ORegion.size[1] * sizeof(int));
+            memset(seedtable[i][j], 0, pm->ORegion.size[0] * pm->ORegion.size[1] * sizeof(int));
     }
 
     for(i = 0; i < pm->Nmesh[0] / 2; i++) {
@@ -537,9 +538,9 @@ pmic_fill_gaussian_gadget(PM * pm, double * delta_k, int seed, int setUnitaryAmp
         gsl_rng_free(lower_rng);
         gsl_rng_free(this_rng);
     }
-    for(i = 0; i < 2; i ++)
-    for(j = 0; j < 2; j ++) {
-        free(seedtable[i][j]);
+    for(i = 1; i >= 0; i --)
+    for(j = 1; j >= 0; j --) {
+        myfree(seedtable[i][j]);
     }
 /*
     char * fn[1000];


### PR DESCRIPTION
This is a series of tiny memory changes done in an attempt to improve stability on frontera by changing the remaining mallocs to be on our own heap. They help somewhat. The main change is fastpm_strdup_printf which is now done on the temp heap, which is allocated first, before parsing the parameter file. Several static buffers were changed to use fastpm_strdup_printf. The pidfile printing was fixed to not open an arbitrary file and print to it!

I was also nazi about string copies in case the compiler was over-optimizing, but I don't think that did anything.