### PR TITLE
Drift BH to halo center more aggressively.

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -434,34 +434,21 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
      /* BH does not accrete wind */
     if(P[other].Type == 0 && SPHP(other).DelayTime > 0) return;
 
-    /* Drifting the blackhole towards minimum. This shall be refactored to some sink.c etc */
-    if(r2 < iter->accretion_kernel.HH) // && r < All.FOFHaloComovingLinkingLength)
+    /* Find the black hole potential minimum. */
+    if(r2 < iter->accretion_kernel.HH)
     {
         if(P[other].Potential < O->BH_MinPot)
         {
-            if(P[other].Type == 0 || P[other].Type == 1 || P[other].Type == 4 || P[other].Type == 5)
-            {
-                /* FIXME: compute peculiar velocities between two objects; this shall be a function */
-                int d;
-                double vrel[3];
-                for(d = 0; d < 3; d++)
-                    vrel[d] = (P[other].Vel[d] - I->Vel[d]);
-
-                /* disable the sound speed check as we suspect this is causing the BH to drift away from center.*/
-/*                double vpec = sqrt(dotproduct(vrel, vrel)) / All.cf.a;
-                  if(vpec <= 0.25 * I->Csnd)*/
-                {
-                    O->BH_MinPot = P[other].Potential;
-                    for(d = 0; d < 3; d++) {
-                        O->BH_MinPotPos[d] = P[other].Pos[d];
-                        O->BH_MinPotVel[d] = P[other].Vel[d];
-                    }
-                }
+            int d;
+            O->BH_MinPot = P[other].Potential;
+            for(d = 0; d < 3; d++) {
+                O->BH_MinPotPos[d] = P[other].Pos[d];
+                O->BH_MinPotVel[d] = P[other].Vel[d];
             }
         }
     }
 
-    /* Accretion / merger doesn't do self iteraction */
+    /* Accretion / merger doesn't do self interaction */
     if(P[other].ID == I->ID) return;
 
     struct SpinLocks * spin = BH_GET_PRIV(lv->tw)->spin;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -312,10 +312,9 @@ static void
 blackhole_accretion_postprocess(int i, TreeWalk * tw)
 {
     int k;
-
-    /* disable jumping in predict.c*/
-    BHP(i).JumpToMinPot = 0;
-    /* jumping here. may break consistency of tree. */
+    /* Move black hole here. WARNING! This breaks the tree consistency.
+     * It is fine because the only tree walk after this is for winds,
+     * which black holes do not participate in. */
     if(BHP(i).MinPot < 0.5 * BHPOTVALUEINIT) {
         for(k = 0; k < 3; k++)
            P[i].Pos[k] = BHP(i).MinPotPos[k];
@@ -700,7 +699,7 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
     {
         BHP(place).MinPot = remote->BH_MinPot;
         for(k = 0; k < 3; k++) {
-            /* Movement occurs in predict.c if we set JumpToPotMin to 1. Currently we set it to 0.*/
+            /* Movement occurs in postprocessing*/
             BHP(place).MinPotPos[k] = remote->BH_MinPotPos[k];
             BHP(place).MinPotVel[k] = remote->BH_MinPotVel[k];
         }

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -782,17 +782,6 @@ void blackhole_make_one(int index) {
     BHP(child).Mass = blackhole_params.SeedBlackHoleMass;
     BHP(child).Mdot = 0;
     BHP(child).FormationTime = All.Time;
-
-    /* It is important to initialize MinPotPos to the current position of
-     * a BH to avoid drifting to unknown locations (0,0,0) immediately
-     * after the BH is created. */
-    int j;
-    for(j = 0; j < 3; j++) {
-        BHP(child).MinPotPos[j] = P[child].Pos[j];
-        BHP(child).MinPotVel[j] = P[child].Vel[j];
-    }
-
-    BHP(child).MinPot = P[child].Potential;
     BHP(child).CountProgs = 1;
 }
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -425,15 +425,15 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         {
             if(P[other].Type == 0 || P[other].Type == 1 || P[other].Type == 4 || P[other].Type == 5)
             {
-                /* FIXME: compute peculier velocities between two objects; this shall be a function */
+                /* FIXME: compute peculiar velocities between two objects; this shall be a function */
                 int d;
                 double vrel[3];
                 for(d = 0; d < 3; d++)
                     vrel[d] = (P[other].Vel[d] - I->Vel[d]);
 
-                double vpec = sqrt(dotproduct(vrel, vrel)) / All.cf.a;
-
-                if(vpec <= 0.25 * I->Csnd)
+                /* disable the sound speed check as we suspect this is causing the BH to drift away from center.*/
+/*                double vpec = sqrt(dotproduct(vrel, vrel)) / All.cf.a;
+                  if(vpec <= 0.25 * I->Csnd)*/
                 {
                     O->BH_MinPot = P[other].Potential;
                     for(d = 0; d < 3; d++) {

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -50,6 +50,12 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
     /* Jumping of BH */
     if(P[i].Type == 5) {
         int k;
+        /* this is currently disabled due to blackhole.c setting it always to zero;
+         * for unclear reason blackholes are randomly not catching up with the potmin in bt-ii
+         * branch so I am reverting it to the bt-i logic, where only Pos tracks potmin (and not drifted
+         * in predict.c may crash PM randomly), and velocity
+         * tracks the accretion feedback (which made not much sense). */
+
         if (BHP(i).JumpToMinPot) {
             for(k = 0; k < 3; k++) {
                 double dx = NEAREST(P[i].Pos[k] - BHP(i).MinPotPos[k]);

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -39,41 +39,12 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
         endrun(12, "i=%d ti0=%d ti1=%d\n", i, ti0, ti1);
     }
 
-
 #ifdef LIGHTCONE
     double oldpos[3];
     for(j = 0; j < 3; j++) {
         oldpos[j] = P[i].Pos[j];
     }
 #endif
-
-    /* Jumping of BH */
-    if(P[i].Type == 5) {
-        int k;
-        /* this is currently disabled due to blackhole.c setting it always to zero;
-         * for unclear reason blackholes are randomly not catching up with the potmin in bt-ii
-         * branch so I am reverting it to the bt-i logic, where only Pos tracks potmin (and not drifted
-         * in predict.c may crash PM randomly), and velocity
-         * tracks the accretion feedback (which made not much sense). */
-
-        if (BHP(i).JumpToMinPot) {
-            for(k = 0; k < 3; k++) {
-                double dx = NEAREST(P[i].Pos[k] - BHP(i).MinPotPos[k]);
-                if(dx > 0.1 * All.BoxSize) {
-                    endrun(1, "Drifting blackhole very far, from %g %g %g to %g %g %g id = %ld. Likely due to the time step is too sparse.\n",
-                        P[i].Pos[0],
-                        P[i].Pos[1],
-                        P[i].Pos[2],
-                        BHP(i).MinPotPos[0],
-                        BHP(i).MinPotPos[1],
-                        BHP(i).MinPotPos[2], P[i].ID);
-                }
-                P[i].Pos[k] = BHP(i).MinPotPos[k];
-                P[i].Vel[k] = BHP(i).MinPotVel[k];
-            }
-        }
-        BHP(i).JumpToMinPot = 0;
-    }
 
     for(j = 0; j < 3; j++) {
         P[i].Pos[j] += P[i].Vel[j] * ddrift;

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -259,8 +259,6 @@ void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
             if (ptype == 5) {
                 keep |= (0 == strcmp(IOTable.ent[i].name, "Mass"));
                 keep |= (0 == strcmp(IOTable.ent[i].name, "BlackholeMass"));
-                keep |= (0 == strcmp(IOTable.ent[i].name, "MinPotPos"));
-                keep |= (0 == strcmp(IOTable.ent[i].name, "MinPotVel"));
             }
             if(!keep) continue;
         }
@@ -756,8 +754,6 @@ SIMPLE_PROPERTY_TYPE(StarFormationTime, 5, BHP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BlackholeMass, BHP(i).Mass, float, 1)
 SIMPLE_PROPERTY(BlackholeAccretionRate, BHP(i).Mdot, float, 1)
 SIMPLE_PROPERTY(BlackholeProgenitors, BHP(i).CountProgs, float, 1)
-SIMPLE_PROPERTY(BlackholeMinPotPos, BHP(i).MinPotPos[0], double, 3)
-SIMPLE_PROPERTY(BlackholeMinPotVel, BHP(i).MinPotVel[0], float, 3)
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, P[i].GrNr, uint32_t, 1)
 static void GTNeutralHydrogenFraction(int i, float * out) {
@@ -841,8 +837,6 @@ static void register_io_blocks() {
     IO_REG(BlackholeMass,          "f4", 1, 5);
     IO_REG(BlackholeAccretionRate, "f4", 1, 5);
     IO_REG(BlackholeProgenitors,   "i4", 1, 5);
-    IO_REG(BlackholeMinPotPos, "f8", 3, 5);
-    IO_REG(BlackholeMinPotVel,   "f4", 3, 5);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -758,7 +758,6 @@ SIMPLE_PROPERTY(BlackholeAccretionRate, BHP(i).Mdot, float, 1)
 SIMPLE_PROPERTY(BlackholeProgenitors, BHP(i).CountProgs, float, 1)
 SIMPLE_PROPERTY(BlackholeMinPotPos, BHP(i).MinPotPos[0], double, 3)
 SIMPLE_PROPERTY(BlackholeMinPotVel, BHP(i).MinPotVel[0], float, 3)
-SIMPLE_PROPERTY(BlackholeJumpToMinPot, BHP(i).JumpToMinPot, int, 1)
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, P[i].GrNr, uint32_t, 1)
 static void GTNeutralHydrogenFraction(int i, float * out) {
@@ -844,7 +843,6 @@ static void register_io_blocks() {
     IO_REG(BlackholeProgenitors,   "i4", 1, 5);
     IO_REG(BlackholeMinPotPos, "f8", 3, 5);
     IO_REG(BlackholeMinPotVel,   "f4", 3, 5);
-    IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5);

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -52,7 +52,6 @@ struct bh_particle_data {
     MyFloat accreted_BHMass;
     MyFloat accreted_momentum[3];
 
-    int JumpToMinPot;
     double  MinPotPos[3];
     MyFloat MinPotVel[3];
     MyFloat MinPot;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -52,10 +52,6 @@ struct bh_particle_data {
     MyFloat accreted_BHMass;
     MyFloat accreted_momentum[3];
 
-    double  MinPotPos[3];
-    MyFloat MinPotVel[3];
-    MyFloat MinPot;
-
     MyIDType SwallowID; /* Allows marking of a merging particle. Used only in blackhole.c.
                            Set to -1 in init.c and only reinitialised if a merger takes place.*/
 


### PR DESCRIPTION
Disable the sound speed check for black hole drift, as is done in bluetides-ii. We suspect it is causing the BH to drift away from the halo center.