### PR TITLE
Minimalfixbhdrift

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -130,6 +130,10 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
 static void
 blackhole_accretion_copy(int place, TreeWalkQueryBHAccretion * I, TreeWalk * tw);
 
+/* Initializes the minimum potentials*/
+static void
+blackhole_accretion_preprocess(int n, TreeWalk * tw);
+
 static void
 blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         TreeWalkResultBHAccretion * O,
@@ -137,9 +141,6 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         LocalTreeWalk * lv);
 
 /* feedback routines */
-
-static void
-blackhole_feedback_preprocess(int n, TreeWalk * tw);
 
 static void
 blackhole_feedback_postprocess(int n, TreeWalk * tw);
@@ -202,6 +203,7 @@ blackhole(ForceTree * tree)
     tw_accretion->ngbiter = (TreeWalkNgbIterFunction) blackhole_accretion_ngbiter;
     tw_accretion->haswork = blackhole_accretion_haswork;
     tw_accretion->postprocess = (TreeWalkProcessFunction) blackhole_accretion_postprocess;
+    tw_accretion->preprocess = (TreeWalkProcessFunction) blackhole_accretion_preprocess;
     tw_accretion->fill = (TreeWalkFillQueryFunction) blackhole_accretion_copy;
     tw_accretion->reduce = (TreeWalkReduceResultFunction) blackhole_accretion_reduce;
     tw_accretion->UseNodeList = 1;
@@ -218,7 +220,6 @@ blackhole(ForceTree * tree)
     tw_feedback->haswork = blackhole_feedback_haswork;
     tw_feedback->fill = (TreeWalkFillQueryFunction) blackhole_feedback_copy;
     tw_feedback->postprocess = (TreeWalkProcessFunction) blackhole_feedback_postprocess;
-    tw_feedback->preprocess = (TreeWalkProcessFunction) blackhole_feedback_preprocess;
     tw_feedback->reduce = (TreeWalkReduceResultFunction) blackhole_feedback_reduce;
     tw_feedback->UseNodeList = 1;
     tw_feedback->query_type_elsize = sizeof(TreeWalkQueryBHFeedback);
@@ -355,7 +356,7 @@ blackhole_accretion_postprocess(int i, TreeWalk * tw)
 }
 
 static void
-blackhole_feedback_preprocess(int n, TreeWalk * tw)
+blackhole_accretion_preprocess(int n, TreeWalk * tw)
 {
     int j;
     for(j = 0; j < 3; j++) {

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -237,7 +237,8 @@ blackhole(ForceTree * tree)
         #pragma omp parallel for
         for(i = 0; i < NumActiveParticle; i ++) {
             int p_i = ActiveParticle[i];
-            priv->SPH_SwallowID[P[p_i].PI] = -1;
+            if(P[p_i].Type == 0)
+                priv->SPH_SwallowID[P[p_i].PI] = -1;
         }
     }
     else {

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -695,10 +695,12 @@ void io_register_io_block(char * name,
         IOTable.allocated *= 2;
     }
     IOTableEntry * ent = &IOTable.ent[IOTable.used];
-    strncpy(ent->name, name, 64);
+    strncpy(ent->name, name, 63);
+    ent->name[63] = '\0';
     ent->zorder = IOTable.used;
     ent->ptype = ptype;
-    strncpy(ent->dtype, dtype, 8);
+    strncpy(ent->dtype, dtype, 7);
+    ent->dtype[7] = '\0';
     ent->getter = getter;
     ent->setter = setter;
     ent->items = items;

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -265,7 +265,7 @@ static int slot_cmp_reverse_link(const void * b1in, const void * b2in) {
 static int
 slots_gc_mark(const struct slots_manager_type * SlotsManager)
 {
-    int i, ptype;
+    int i;
     if(!(SlotsManager->info[0].enabled ||
        SlotsManager->info[1].enabled ||
        SlotsManager->info[2].enabled ||
@@ -275,6 +275,7 @@ slots_gc_mark(const struct slots_manager_type * SlotsManager)
         return 0;
 
 #ifdef DEBUG
+    int ptype;
     /*Initially set all reverse links to an obviously invalid value*/
     for(ptype = 0; ptype < 6; ptype++)
     {

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -296,7 +296,7 @@ slots_gc_mark(const struct slots_manager_type * SlotsManager)
             continue;
 
         int sind = P[i].PI;
-        if(sind > info.size)
+        if(sind >= info.size || sind < 0)
             endrun(1, "Particle %d, type %d has PI index %d beyond max slot size %d.\n", i, P[i].Type, sind, info.size);
         struct particle_data_ext * sdata = (struct particle_data_ext * )(info.ptr + info.elsize * sind);
         sdata->ReverseLink = i;
@@ -655,7 +655,7 @@ slots_setup_id(const struct slots_manager_type * SlotsManager)
             continue;
 
         int sind = P[i].PI;
-        if(sind > info.size)
+        if(sind >= info.size || sind < 0)
             endrun(1, "Particle %d, type %d has PI index %d beyond max slot size %d.\n", i, P[i].Type, sind, info.size);
         struct particle_data_ext * sdata = (struct particle_data_ext * )(info.ptr + info.elsize * sind);
         sdata->ReverseLink = i;

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -36,8 +36,7 @@ setup_sync_points(double TimeIC, double no_snapshot_until_time)
 
     if(NSyncPoints > 0)
         myfree(SyncPoints);
-    SyncPoints = mymalloc("SyncPoints", sizeof(SyncPoints) * (All.OutputListLength+2));
-    memset(&SyncPoints[0], -1, sizeof(SyncPoints[0]) * All.OutputListLength);
+    SyncPoints = mymalloc("SyncPoints", sizeof(SyncPoint) * (All.OutputListLength+2));
 
     /* Set up first and last entry to SyncPoints; TODO we can insert many more! */
 


### PR DESCRIPTION
This is a minimal fix for the black hole drifting (and a couple of other memory bugs!). The drifting was broken because MinPotPos was being over-written with the current position after being set to the potential minimum. This PR should definitely be merged.