### PR TITLE
Black hole cleanups

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -51,7 +51,6 @@ typedef struct {
 
     MyFloat Rho;
     MyFloat SmoothedEntropy;
-    MyFloat SmoothedPressure;
     MyFloat GasVel[3];
 } TreeWalkResultBHAccretion;
 
@@ -314,8 +313,6 @@ blackhole_accretion_postprocess(int i, TreeWalk * tw)
     if(BHP(i).Density > 0)
     {
         BHP(i).Entropy /= BHP(i).Density;
-        BHP(i).Pressure /= BHP(i).Density;
-
         for(k = 0; k < 3; k++)
             BH_GET_PRIV(tw)->BH_SurroundingGasVel[PI][k] /= BHP(i).Density;
     }
@@ -475,7 +472,6 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
-            O->SmoothedPressure += (mass_j * wk * PressurePred(P[other].PI));
             O->SmoothedEntropy += (mass_j * wk * SphP_scratch->EntVarPred[P[other].PI]);
             O->GasVel[0] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI]);
             O->GasVel[1] += (mass_j * wk * SphP_scratch->VelPred[3 * P[other].PI+1]);
@@ -683,7 +679,6 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
     TREEWALK_REDUCE(BHP(place).Density, remote->Rho);
     TREEWALK_REDUCE(BHP(place).FeedbackWeightSum, remote->FeedbackWeightSum);
     TREEWALK_REDUCE(BHP(place).Entropy, remote->SmoothedEntropy);
-    TREEWALK_REDUCE(BHP(place).Pressure, remote->SmoothedPressure);
 
     TREEWALK_REDUCE(BH_GET_PRIV(tw)->BH_SurroundingGasVel[PI][0], remote->GasVel[0]);
     TREEWALK_REDUCE(BH_GET_PRIV(tw)->BH_SurroundingGasVel[PI][1], remote->GasVel[1]);

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -736,13 +736,8 @@ blackhole_feedback_copy(int i, TreeWalkQueryBHFeedback * I, TreeWalk * tw)
 static void
 blackhole_feedback_reduce(int place, TreeWalkResultBHFeedback * remote, enum TreeWalkReduceMode mode, TreeWalk * tw)
 {
-    int k;
-
     TREEWALK_REDUCE(BHP(place).accreted_Mass, remote->Mass);
     TREEWALK_REDUCE(BHP(place).accreted_BHMass, remote->BH_Mass);
-    for(k = 0; k < 3; k++) {
-        TREEWALK_REDUCE(BHP(place).accreted_momentum[k], remote->AccretedMomentum[k]);
-    }
     TREEWALK_REDUCE(BHP(place).CountProgs, remote->BH_CountProgs);
 }
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -47,7 +47,7 @@ typedef struct {
     MyFloat BH_MinPotPos[3];
     MyFloat BH_MinPot;
 
-    int BH_TimeBinLimit;
+    short int BH_minTimeBin;
     MyFloat FeedbackWeightSum;
 
     MyFloat Rho;
@@ -387,7 +387,8 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
 {
 
     if(iter->base.other == -1) {
-        O->BH_TimeBinLimit = -1;
+        O->BH_minTimeBin = TIMEBINS;
+
         O->BH_MinPot = BHPOTVALUEINIT;
         int d;
         for(d = 0; d < 3; d++) {
@@ -412,8 +413,8 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     if(P[other].Mass < 0) return;
 
     if(P[other].Type != 5) {
-        if (O->BH_TimeBinLimit <= 0 || O->BH_TimeBinLimit >= P[other].TimeBin)
-            O->BH_TimeBinLimit = P[other].TimeBin;
+        if (O->BH_minTimeBin > P[other].TimeBin)
+            O->BH_minTimeBin = P[other].TimeBin;
     }
 
      /* BH does not accrete wind */
@@ -677,10 +678,8 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
             BHP(place).MinPotPos[k] = remote->BH_MinPotPos[k];
         }
     }
-    if (mode == 0 ||
-            BHP(place).TimeBinLimit < 0 ||
-            BHP(place).TimeBinLimit > remote->BH_TimeBinLimit) {
-        BHP(place).TimeBinLimit = remote->BH_TimeBinLimit;
+    if (mode == 0 || BHP(place).minTimeBin > remote->BH_minTimeBin) {
+        BHP(place).minTimeBin = remote->BH_minTimeBin;
     }
 
     TREEWALK_REDUCE(BHP(place).Density, remote->Rho);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -31,7 +31,7 @@ MyFloat SPH_EOMDensity(int i)
         return SPHP(i).Density;
 }
 
-double
+static double
 PressurePred(int PI)
 {
     MyFloat EOMDensity;

--- a/libgadget/hydra.h
+++ b/libgadget/hydra.h
@@ -4,9 +4,6 @@
 #include "forcetree.h"
 #include "types.h"
 
-/*Function to get the pressure from the entropy and the density*/
-double PressurePred(int i);
-
 /* Function to get the center of mass density and HSML correction factor for an SPH particle with index i.
  * Encodes the main difference between pressure-entropy SPH and regular SPH.*/
 MyFloat SPH_EOMDensity(int i);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -96,7 +96,6 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
         {
             /* Note: Gadget-3 sets this to the seed black hole mass.*/
             BHP(i).Mass = P[i].Mass;
-            BHP(i).TimeBinLimit = -1;
 
             /* Touch up potentially zero BH smoothing lengths, since they have historically not been saved in the snapshots.
              * Anything non-zero would work, but since BH tends to be in high density region,

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -58,7 +58,9 @@ struct bh_particle_data {
     MyIDType SwallowID; /* Allows marking of a merging particle. Used only in blackhole.c.
                            Set to -1 in init.c and only reinitialised if a merger takes place.*/
 
-    short int TimeBinLimit;
+    /* Stores the minimum timebins of all black hole neighbours.
+     * The black hole timebin is then set to this.*/
+    short int minTimeBin;
 };
 
 /*Data for each star particle*/

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -50,7 +50,6 @@ struct bh_particle_data {
 
     MyFloat accreted_Mass;
     MyFloat accreted_BHMass;
-    MyFloat accreted_momentum[3];
 
     int JumpToMinPot;
     double  MinPotPos[3];

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -41,13 +41,8 @@ struct bh_particle_data {
 
     MyFloat Mass;
     MyFloat Mdot;
-    MyFloat FeedbackWeightSum;
     MyFloat Density;
-    MyFloat Entropy;
     MyFloat FormationTime;  /*!< formation time of black hole. */
-
-    MyFloat accreted_Mass;
-    MyFloat accreted_BHMass;
 
     int JumpToMinPot;
     double  MinPotPos[3];

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -44,7 +44,6 @@ struct bh_particle_data {
     MyFloat FeedbackWeightSum;
     MyFloat Density;
     MyFloat Entropy;
-    MyFloat Pressure;
     MyFloat FormationTime;  /*!< formation time of black hole. */
 
     MyFloat accreted_Mass;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -45,8 +45,7 @@ struct bh_particle_data {
     MyFloat Density;
     MyFloat Entropy;
     MyFloat Pressure;
-    MyFloat SurroundingGasVel[3];
-    MyFloat FormationTime;		/*!< formation time of black hole. */
+    MyFloat FormationTime;  /*!< formation time of black hole. */
 
     MyFloat accreted_Mass;
     MyFloat accreted_BHMass;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -408,9 +408,12 @@ get_timestep_dloga(const int p)
             if(dt_accr < dt)
                 dt = dt_accr;
         }
-        if(BHP(p).TimeBinLimit > 0) {
-            double dt_limiter = get_dloga_for_bin(BHP(p).TimeBinLimit) / All.cf.hubble;
-            if (dt_limiter < dt) dt = dt_limiter;
+        if(BHP(p).minTimeBin > 0 && BHP(p).minTimeBin < TIMEBINS) {
+            double dt_limiter = get_dloga_for_bin(BHP(p).minTimeBin) / All.cf.hubble;
+            /* Set the black hole timestep to the minimum timesteps of neighbouring gas particles.
+             * It should be at least this for accretion accuracy, and it does not make sense to
+             * make it less than this.*/
+            dt = dt_limiter;
         }
     }
 


### PR DESCRIPTION
This removes some unloved parts of the black hole code. The major change is to the black hole timestepping: instead of the BH timestep being <= the smallest SPH timestep surrounding it, it is now = the smallest SPH timestep. This avoids situations where the smallest timesteps contain exclusively black holes. 