### PR TITLE
Fix black holes and the tree

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -37,7 +37,6 @@ typedef struct {
     MyFloat Mass;
     MyFloat BH_Mass;
     MyFloat Vel[3];
-    MyFloat Csnd;
     MyIDType ID;
 } TreeWalkQueryBHAccretion;
 
@@ -710,13 +709,10 @@ blackhole_accretion_copy(int place, TreeWalkQueryBHAccretion * I, TreeWalk * tw)
     {
         I->Vel[k] = P[place].Vel[k];
     }
-
-    int PI = P[place].PI;
     I->Hsml = P[place].Hsml;
     I->Mass = P[place].Mass;
     I->BH_Mass = BHP(place).Mass;
     I->Density = BHP(place).Density;
-    I->Csnd = blackhole_soundspeed(BH_GET_PRIV(tw)->BH_Entropy[PI], BHP(place).Density);
     I->ID = P[place].ID;
 }
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -72,7 +72,6 @@ typedef struct {
     TreeWalkResultBase base;
     MyFloat Mass;
     MyFloat BH_Mass;
-    MyFloat AccretedMomentum[3];
     int BH_CountProgs;
 } TreeWalkResultBHFeedback;
 
@@ -594,10 +593,6 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
         lock_spinlock(other, spin);
 
-        int d;
-        for(d = 0; d < 3; d++)
-            O->AccretedMomentum[d] += (P[other].Mass * P[other].Vel[d]);
-
         O->BH_CountProgs += BHP(other).CountProgs;
 
         /* We do not know how to notify the tree of mass changes. so
@@ -648,10 +643,6 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
         if(SPH_SwallowID[P[other].PI] != I->ID) return;
 
         lock_spinlock(other, spin);
-
-        int d;
-        for(d = 0; d < 3; d++)
-            O->AccretedMomentum[d] += (P[other].Mass * P[other].Vel[d]);
 
         /* We do not know how to notify the tree of mass changes. so
          * blindly enforce a mass conservation for now. */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -458,29 +458,22 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
 
     if(P[other].Type == 5 && r2 < iter->accretion_kernel.HH)	/* we have a black hole merger */
     {
-        /* compute relative velocity of BHs */
+        /* We do not depend on the BH relative velocity.
+         * Because the BHs are not dissipative, their relative velocities
+         * can be large, causing clumps of BHs to build up
+         * at the same position without merging. */
 
         lock_spinlock(other, spin);
-        int d;
-        double vrel[3];
-        for(d = 0; d < 3; d++)
-            vrel[d] = (P[other].Vel[d] - I->Vel[d]);
-
-        double vpec = sqrt(dotproduct(vrel, vrel)) / All.cf.a;
-
-        if(vpec <= 0.5 * I->Csnd)
-        {
-            if(P[other].Swallowed) {
-                /* Already marked, prefer to be swallowed by a bigger ID */
-                if(BHP(other).SwallowID < I->ID) {
-                    BHP(other).SwallowID = I->ID;
-                }
-            } else {
-                /* Unmarked, the BH with bigger ID swallows */
-                if(P[other].ID < I->ID) {
-                    P[other].Swallowed = 1;
-                    BHP(other).SwallowID = I->ID;
-                }
+        if(P[other].Swallowed) {
+            /* Already marked, prefer to be swallowed by a bigger ID */
+            if(BHP(other).SwallowID < I->ID) {
+                BHP(other).SwallowID = I->ID;
+            }
+        } else {
+            /* Unmarked, the BH with bigger ID swallows */
+            if(P[other].ID < I->ID) {
+                P[other].Swallowed = 1;
+                BHP(other).SwallowID = I->ID;
             }
         }
         unlock_spinlock(other, spin);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -285,8 +285,16 @@ create_new_node_layer(int parent, int p_toplace,
         /* Get memory for an extra node from our cache.*/
         nprnt->u.s.suns[i] = get_freenode(nnext, nc);
         /*If we already have too many nodes, exit loop.*/
-        if(nc->nnext_thread >= tb.lastnode)
+        if(nc->nnext_thread >= tb.lastnode) {
+            /* This means that we have > NMAXCHILD particles in the same place,
+             * which usually indicates a bug in the particle evolution. Print some helpful debug information.*/
+            message(1, "Failed placing %d at %g %g %g, type %d, ID %ld. Others were %d (%g %g %g, t %d ID %ld) and %d (%g %g %g, t %d ID %ld).\n",
+                p_toplace, P[p_toplace].Pos[0], P[p_toplace].Pos[1], P[p_toplace].Pos[2], P[p_toplace].Type, P[p_toplace].ID,
+                oldsuns[0], P[oldsuns[0]].Pos[0], P[oldsuns[0]].Pos[1], P[oldsuns[0]].Pos[2], P[oldsuns[0]].Type, P[oldsuns[0]].ID,
+                oldsuns[1], P[oldsuns[1]].Pos[0], P[oldsuns[1]].Pos[1], P[oldsuns[1]].Pos[2], P[oldsuns[1]].Type, P[oldsuns[1]].ID
+            );
             return 1;
+        }
         struct NODE *nfreep = &tb.Nodes[nprnt->u.s.suns[i]];
         /* We create a new leaf node.*/
         init_internal_node(nfreep, nprnt, i);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -791,6 +791,11 @@ force_update_particle_node(int no, int sib, const ForceTree * tree, const int Hy
 static int
 force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, const int HybridNuGrav)
 {
+#ifdef DEBUG
+    if(tree->Nodes[no].f.ChildType != NODE_NODE_TYPE)
+        endrun(3, "force_update_node_recursive called on node %d of type %d != %d!\n", no, tree->Nodes[no].f.ChildType, NODE_NODE_TYPE);
+#endif
+
     /*Last value of tails is the return value of this function*/
     int j, suns[8], tails[8];
 
@@ -1042,6 +1047,11 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
         /*This may not happen as we are an internal top level node*/
         if(p < tree->firstnode || p >= tree->lastnode)
             endrun(6767, "Updating pseudos: %d -> %d which is not an internal node between %d and %d.",no, p, tree->firstnode, tree->lastnode);
+#ifdef DEBUG
+        /* Check we don't move to another part of the tree*/
+        if(tree->Nodes[p].father != no)
+            endrun(6767, "Tried to update toplevel node %d with parent %d != expected %d\n", p, tree->Nodes[p].father, no);
+#endif
 
         if(tree->Nodes[p].f.InternalTopLevel)
             force_treeupdate_pseudos(p, tree);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -145,7 +145,7 @@ ForceTree force_tree_build(int npart, DomainDecomp * ddecomp, const double BoxSi
             force_tree_free(&tree);
             message(1, "TreeAllocFactor from %g to %g\n", ForceTreeParams.TreeAllocFactor, ForceTreeParams.TreeAllocFactor*1.15);
             ForceTreeParams.TreeAllocFactor *= 1.15;
-            if(ForceTreeParams.TreeAllocFactor > 5.0) {
+            if(ForceTreeParams.TreeAllocFactor > 3.0) {
                 TooManyNodes = 1;
                 break;
             }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -808,10 +808,18 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
      * This sharply reduces the size of the tree.
      * Also count the node children for thread balancing.*/
     for(j=0; j < 8; j++) {
-        /* Pseudo nodes may have zero occupation*/
-        if(tree->Nodes[suns[j]].f.ChildType == PARTICLE_NODE_TYPE &&
-            tree->Nodes[suns[j]].u.s.noccupied == 0)
+        /* Never remove empty top-level nodes so we don't
+         * mess up the pseudo-data exchange.
+         * This may happen for a pseudo particle host or, in very rare cases,
+         * when one of the local domains is empty. */
+        if(!tree->Nodes[suns[j]].f.TopLevel &&
+            tree->Nodes[suns[j]].f.ChildType == PARTICLE_NODE_TYPE &&
+            tree->Nodes[suns[j]].u.s.noccupied == 0) {
+                /* In principle the removed node will be
+                 * disconnected and never used, but zero it just in case.*/
+                force_zero_union(&tree->Nodes[suns[j]]);
                 suns[j] = -1;
+        }
         else if(tree->Nodes[suns[j]].f.ChildType == NODE_NODE_TYPE)
             childcnt++;
     }

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -320,7 +320,7 @@ do_the_short_range_kick(int i, inttime_t tistart, inttime_t tiend)
             vv += P[i].Vel[j] * P[i].Vel[j];
         vv = sqrt(vv);
 
-        if(vv/All.cf.a > All.MaxGasVel) {
+        if(vv > 0 && vv/All.cf.a > All.MaxGasVel) {
             message(1,"Gas Particle ID %ld exceeded the gas velocity limit: %g > %g\n",P[i].ID, vv / All.cf.a, All.MaxGasVel);
             for(j=0;j < 3; j++)
             {
@@ -356,7 +356,14 @@ do_the_short_range_kick(int i, inttime_t tistart, inttime_t tiend)
         if(SPHP(i).DtEntropy * dt_entr_next < - 0.5 * SPHP(i).Entropy)
             SPHP(i).DtEntropy = -0.5 * SPHP(i).Entropy / dt_entr_next;
     }
-
+#ifdef DEBUG
+    /* Check we have reasonable velocities. If we do not, try to explain why*/
+    if(isnan(P[i].Vel[0]) || isnan(P[i].Vel[1]) || isnan(P[i].Vel[2])) {
+        message(1, "Vel = %g %g %g Type = %d gk = %g a_g = %g %g %g\n",
+                P[i].Vel[0], P[i].Vel[1], P[i].Vel[2], P[i].Type,
+                Fgravkick, P[i].GravAccel[0], P[i].GravAccel[1], P[i].GravAccel[2]);
+    }
+#endif
 }
 
 double

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -605,10 +605,10 @@ treewalk_run(TreeWalk * tw, int * active_set, int size)
     }
 
 #ifdef DEBUG
-    int64_t totNodesinlist, totlist;
+    /*int64_t totNodesinlist, totlist;
     MPI_Reduce(&tw->Nnodesinlist,  &totNodesinlist, 1, MPI_INT64, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&tw->Nlist,  &totlist, 1, MPI_INT64, MPI_SUM, 0, MPI_COMM_WORLD);
-    message(0, "Nodes in nodelist: %g (avg). %ld nodes, %ld lists\n", ((double) totNodesinlist)/totlist, totlist, totNodesinlist);
+    message(0, "Nodes in nodelist: %g (avg). %ld nodes, %ld lists\n", ((double) totNodesinlist)/totlist, totlist, totNodesinlist);*/
 #endif
     double tstart, tend;
 


### PR DESCRIPTION
This PR: 
1) Makes it easier to debug a failure of the force tree to build
2) Makes the first stage of the force tree building non-recursive, so that we don't have a stack overflow if multiple particles are in the same spot.
3) Removes the sound speed check for the black hole mergers. This is actually a very bad idea, but we never noticed before because with repositioning broken there were no mergers anyway!
What happens goes like this:

1. BH moves to halo center
2. Merger happens
3. N+1 BHs move to halo
4. These BHs have different velocities so fail the sound speed check and do not merge. They are not dissipative so have no way for the velocities to reduce.
if N < 11:
    Goto 1.
if N > 11:
    Too many particles in one place for the tree to build!
    goto 5.

5. The function which creates new tree nodes recurses infinitely and overflows the stack / crashes with out of memory! Often the crash dump is never reached so you do not even know why.
    
This may also be affecting bt-ii, making it really really slow: it creates very deep trees with clumps of identically positioned black holes.

4) Fixes an extremely rare bug when building the force tree: pseudo-particle hosts could be removed which caused problems.

Please review! I would like to merge quickly, since the bugs are serious.