### PR TITLE
Add a random offset to particle positions, changing every PM step

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -136,6 +136,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeLimitCPU", REQUIRED, 0, "CPU time to run for in seconds. Code will stop if it notices that the time to end of the next PM step is longer than the remaining time.");
 
     param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 4, "Create on average this number of sub domains on a MPI rank. Load balancer will then move these subdomains around to equalize the work per rank. Higher numbers improve the load balancing but make domain more expensive.");
+    param_declare_double(ps, "RandomParticleOffset", OPTIONAL, 0., "Internally shift the particles within a periodic box by a random fraction of the box each domain decomposition, ensuring that tree openings are decorrelated between timesteps. The output does not get shifted.");
+
     param_declare_int   (ps, "DomainUseGlobalSorting", OPTIONAL, 1, "Determining the initial refinement of chunks globally. Enabling this produces better domains at costs of slowing down the domain decomposition.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "Controls the length of the short-range timestep. Smaller values are shorter timesteps.");
     param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
@@ -435,6 +437,7 @@ void read_parameter_file(char *fname)
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");
         All.AutoSnapshotTime = param_get_double(ps, "AutoSnapshotTime");
         All.TimeBetweenSeedingSearch = param_get_double(ps, "TimeBetweenSeedingSearch");
+        All.RandomParticleOffset = param_get_double(ps, "RandomParticleOffset");
 
         All.GravitySoftening = param_get_double(ps, "GravitySoftening");
         All.GravitySofteningGas = param_get_double(ps, "GravitySofteningGas");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -136,7 +136,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeLimitCPU", REQUIRED, 0, "CPU time to run for in seconds. Code will stop if it notices that the time to end of the next PM step is longer than the remaining time.");
 
     param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 4, "Create on average this number of sub domains on a MPI rank. Load balancer will then move these subdomains around to equalize the work per rank. Higher numbers improve the load balancing but make domain more expensive.");
-    param_declare_double(ps, "RandomParticleOffset", OPTIONAL, 0., "Internally shift the particles within a periodic box by a random fraction of the box each domain decomposition, ensuring that tree openings are decorrelated between timesteps. The output does not get shifted.");
+    param_declare_double(ps, "RandomParticleOffset", OPTIONAL, 0., "Internally shift the particles within a periodic box by a random fraction of a PM grid cell each domain decomposition, ensuring that tree openings are decorrelated between timesteps. This shift is subtracted before particles are saved.");
 
     param_declare_int   (ps, "DomainUseGlobalSorting", OPTIONAL, 1, "Determining the initial refinement of chunks globally. Enabling this produces better domains at costs of slowing down the domain decomposition.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "Controls the length of the short-range timestep. Smaller values are shorter timesteps.");

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -136,7 +136,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeLimitCPU", REQUIRED, 0, "CPU time to run for in seconds. Code will stop if it notices that the time to end of the next PM step is longer than the remaining time.");
 
     param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 4, "Create on average this number of sub domains on a MPI rank. Load balancer will then move these subdomains around to equalize the work per rank. Higher numbers improve the load balancing but make domain more expensive.");
-    param_declare_double(ps, "RandomParticleOffset", OPTIONAL, 0., "Internally shift the particles within a periodic box by a random fraction of a PM grid cell each domain decomposition, ensuring that tree openings are decorrelated between timesteps. This shift is subtracted before particles are saved.");
+    param_declare_double(ps, "RandomParticleOffset", OPTIONAL, 8., "Internally shift the particles within a periodic box by a random fraction of a PM grid cell each domain decomposition, ensuring that tree openings are decorrelated between timesteps. This shift is subtracted before particles are saved.");
 
     param_declare_int   (ps, "DomainUseGlobalSorting", OPTIONAL, 1, "Determining the initial refinement of chunks globally. Enabling this produces better domains at costs of slowing down the domain decomposition.");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "Controls the length of the short-range timestep. Smaller values are shorter timesteps.");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -130,6 +130,19 @@ extern struct global_data_all_processes
     double SlotsIncreaseFactor; /* !< What percentage to increase the slot allocation by when requested*/
     int OutputPotential;        /*!< Flag whether to include the potential in snapshots*/
 
+    double RandomParticleOffset; /* If > 0, a random shift of max RandomParticleOffset * BoxSize is applied to every particle
+                                  * every time a full domain decomposition is done. The box is periodic and the offset
+                                  * is subtracted on output, so this only affects the internal gravity solver.
+                                  * The purpose of this is to avoid correlated errors in the tree code, which occur when
+                                  * the tree opening conditions are similar in every timestep and accumulate over a
+                                  * long period of time. Upstream Arepo says this substantially improves momentum conservation,
+                                  * and it has the side-effect of guarding against periodicity bugs.
+                                  */
+    /* Random shift applied to the box. This is changed
+     * every domain decomposition to prevent correlated
+     * errors building up in the tree force. */
+    double CurrentParticleOffset[3];
+
     /* some SPH parameters */
 
     int DesNumNgb;		/*!< Desired number of SPH neighbours */

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -35,7 +35,9 @@ void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
 /* Drifts an individual particle to time ti1, by a drift factor ddrift.
  * The final argument is a random shift vector applied uniformly to all particles before periodic wrapping.
  * The box is periodic, so this does not affect real physics, but it avoids correlated errors
- * in the tree expansion.
+ * in the tree expansion. The shift is relative to the current position. On most timesteps this is zero,
+ * signifying no change in the coordinate frame. On PM steps a random offset is generated, and the routine
+ * receives a shift vector removing the previous random shift and adding a new one.
  * This function also updates the velocity and updates the density according to an adiabatic factor.
  */
 static void real_drift_particle(int i, inttime_t ti1, const double ddrift, const double random_shift[3])

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -14,24 +14,31 @@
 
 #define MAXHSML 30000.0
 
-
-static void real_drift_particle(int i, inttime_t ti1, const double ddrift);
+static void
+real_drift_particle(int i, inttime_t ti1, const double ddrift, const double random_shift[3]);
 
 /* Updates a single particle to the current drift time*/
 void drift_particle(int i, inttime_t ti1, struct SpinLocks * spin) {
     if(P[i].Ti_drift == ti1) return;
 
+    double random_shift[3] = {0};
     lock_spinlock(i, spin);
     inttime_t ti0 = P[i].Ti_drift;
     if(ti0 != ti1) {
         const double ddrift = get_drift_factor(ti0, ti1);
-        real_drift_particle(i, ti1, ddrift);
+        real_drift_particle(i, ti1, ddrift, random_shift);
 #pragma omp flush
     }
     unlock_spinlock(i, spin);
 }
 
-static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
+/* Drifts an individual particle to time ti1, by a drift factor ddrift.
+ * The final argument is a random shift vector applied uniformly to all particles before periodic wrapping.
+ * The box is periodic, so this does not affect real physics, but it avoids correlated errors
+ * in the tree expansion.
+ * This function also updates the velocity and updates the density according to an adiabatic factor.
+ */
+static void real_drift_particle(int i, inttime_t ti1, const double ddrift, const double random_shift[3])
 {
     int j;
     inttime_t ti0 = P[i].Ti_drift;
@@ -69,7 +76,7 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
     }
 
     for(j = 0; j < 3; j++) {
-        P[i].Pos[j] += P[i].Vel[j] * ddrift;
+        P[i].Pos[j] += P[i].Vel[j] * ddrift + random_shift[j];
     }
 
 #ifdef LIGHTCONE
@@ -112,7 +119,8 @@ static void real_drift_particle(int i, inttime_t ti1, const double ddrift)
     P[i].Ti_drift = ti1;
 }
 
-void drift_all_particles(inttime_t ti1)
+/* Update all particles to the current time, shifting them by a random vector.*/
+void drift_all_particles(inttime_t ti1, const double random_shift[3])
 {
     int i;
     walltime_measure("/Misc");
@@ -126,7 +134,7 @@ void drift_all_particles(inttime_t ti1)
         if(P[i].Ti_drift != ti0)
             endrun(10, "Drift time mismatch: (ids = %ld %ld) %d != %d\n",P[0].ID, P[i].ID, ti0,  P[i].Ti_drift);
 #endif
-        real_drift_particle(i, ti1, ddrift);
+        real_drift_particle(i, ti1, ddrift, random_shift);
     }
 
     walltime_measure("/Drift/All");

--- a/libgadget/drift.h
+++ b/libgadget/drift.h
@@ -2,6 +2,6 @@
 #define __DRIFT_H
 
 /* Updates all particles to the current drift time*/
-void drift_all_particles(inttime_t ti1);
+void drift_all_particles(inttime_t ti1, const double random_shift[3]);
 
 #endif

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -85,6 +85,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
 
     All.SnapshotFileCount = RestartSnapNum + 1;
     All.InitSnapshotCount = RestartSnapNum + 1;
+    All.CurrentParticleOffset[0] = All.CurrentParticleOffset[1] = All.CurrentParticleOffset[2] = 0;
 
     #pragma omp parallel for
     for(i = 0; i < PartManager->NumPart; i++)	/* initialize sph_properties */

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -704,7 +704,21 @@ void io_register_io_block(char * name,
     IOTable.used ++;
 }
 
-SIMPLE_PROPERTY(Position, P[i].Pos[0], double, 3)
+static void GTPosition(int i, double * out) {
+    /* Remove the particle offset before saving*/
+    int d;
+    for(d = 0; d < 3; d ++) {
+        out[d] = P[i].Pos[d] - All.CurrentParticleOffset[d];
+    }
+}
+
+static void STPosition(int i, double * out) {
+    int d;
+    for(d = 0; d < 3; d ++) {
+        P[i].Pos[d] = out[d];
+    }
+}
+
 static void GTVelocity(int i, float * out) {
     /* Convert to Peculiar Velocity if UsePeculiarVelocity is set */
     double fac;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -425,28 +425,28 @@ void write_cpu_log(int NumCurrentTiStep)
 static void
 update_random_offset(double * rel_random_shift)
 {
-            int i;
-            for (i = 0; i < 3; i++) {
-                /* Note random number table is duplicated across processors*/
-                double rr = get_random_number(i);
-                /* Upstream Gadget uses a random fraction of the box, but since all we need
-                 * is to adjust the tree openings, and the tree force is zero anyway on the
-                 * scale of a few PM grid cells, this seems enough.*/
-                rr *= All.RandomParticleOffset * All.BoxSize / All.Nmesh;
-                /* Subtract the old random shift first.*/
-                rel_random_shift[i] = rr - All.CurrentParticleOffset[i];
-                All.CurrentParticleOffset[i] = rr;
-            }
-            message(0, "Internal particle offset is now %g %g %g\n", All.CurrentParticleOffset[0], All.CurrentParticleOffset[1], All.CurrentParticleOffset[2]);
+    int i;
+    for (i = 0; i < 3; i++) {
+        /* Note random number table is duplicated across processors*/
+        double rr = get_random_number(i);
+        /* Upstream Gadget uses a random fraction of the box, but since all we need
+            * is to adjust the tree openings, and the tree force is zero anyway on the
+            * scale of a few PM grid cells, this seems enough.*/
+        rr *= All.RandomParticleOffset * All.BoxSize / All.Nmesh;
+        /* Subtract the old random shift first.*/
+        rel_random_shift[i] = rr - All.CurrentParticleOffset[i];
+        All.CurrentParticleOffset[i] = rr;
+    }
+    message(0, "Internal particle offset is now %g %g %g\n", All.CurrentParticleOffset[0], All.CurrentParticleOffset[1], All.CurrentParticleOffset[2]);
 #ifdef DEBUG
-            /* Check explicitly that the vector is the same on all processors*/
-            double test_random_shift[3] = {0};
-            for (i = 0; i < 3; i++)
-                test_random_shift[i] = All.CurrentParticleOffset[i];
-            MPI_Bcast(test_random_shift, 3, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-            for (i = 0; i < 3; i++)
-                if(test_random_shift[i] != All.CurrentParticleOffset[i])
-                    endrun(44, "Random shift %d is %g != %g on task 0!\n", i, test_random_shift[i], All.CurrentParticleOffset[i]);
+    /* Check explicitly that the vector is the same on all processors*/
+    double test_random_shift[3] = {0};
+    for (i = 0; i < 3; i++)
+        test_random_shift[i] = All.CurrentParticleOffset[i];
+    MPI_Bcast(test_random_shift, 3, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    for (i = 0; i < 3; i++)
+        if(test_random_shift[i] != All.CurrentParticleOffset[i])
+            endrun(44, "Random shift %d is %g != %g on task 0!\n", i, test_random_shift[i], All.CurrentParticleOffset[i]);
 #endif
 }
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -430,8 +430,8 @@ update_random_offset(double * rel_random_shift)
         /* Note random number table is duplicated across processors*/
         double rr = get_random_number(i);
         /* Upstream Gadget uses a random fraction of the box, but since all we need
-            * is to adjust the tree openings, and the tree force is zero anyway on the
-            * scale of a few PM grid cells, this seems enough.*/
+         * is to adjust the tree openings, and the tree force is zero anyway on the
+         * scale of a few PM grid cells, this seems enough.*/
         rr *= All.RandomParticleOffset * All.BoxSize / All.Nmesh;
         /* Subtract the old random shift first.*/
         rel_random_shift[i] = rr - All.CurrentParticleOffset[i];

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -183,6 +183,7 @@ void run(DomainDecomp * ddecomp)
                 new_random_shift[i] = rr - All.CurrentParticleOffset[i];
                 All.CurrentParticleOffset[i] = rr;
             }
+            message(0, "Internal particle offset is now %g %g %g\n", All.CurrentParticleOffset[0], All.CurrentParticleOffset[1], All.CurrentParticleOffset[2]);
 #ifdef DEBUG
             /* Check explicitly that the vector is the same on all processors*/
             double test_random_shift[3] = {0};

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -178,6 +178,16 @@ void run(DomainDecomp * ddecomp)
                 new_random_shift[i] = rr - All.CurrentParticleOffset[i];
                 All.CurrentParticleOffset[i] = rr;
             }
+#ifdef DEBUG
+            /* Check explicitly that the vector is the same on all processors*/
+            double test_random_shift[3] = {0};
+            for (i = 0; i < 3; i++)
+                test_random_shift[i] = All.CurrentParticleOffset[i];
+            MPI_Bcast(test_random_shift, 3, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+            for (i = 0; i < 3; i++)
+                if(test_random_shift[i] != All.CurrentParticleOffset[i])
+                    endrun(44, "Random shift %d is %g != %g on task 0!\n", i, test_random_shift[i], All.CurrentParticleOffset[i]);
+#endif
         }
         /* Sync positions of all particles */
         drift_all_particles(All.Ti_Current, new_random_shift);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -173,7 +173,12 @@ void run(DomainDecomp * ddecomp)
             int i;
             for (i = 0; i < 3; i++) {
                 /* Note random number table is duplicated across processors*/
-                double rr = get_random_number(i) * All.RandomParticleOffset * All.BoxSize;
+
+                double rr = get_random_number(i);
+                /* Upstream Gadget uses a random fraction of the box, but since all we need
+                 * is to adjust the tree openings, and the tree force is zero anyway on the
+                 * scale of a few PM grid cells, this seems enough.*/
+                rr *= All.RandomParticleOffset * All.BoxSize / All.Nmesh;
                 /* Subtract the old random shift first.*/
                 new_random_shift[i] = rr - All.CurrentParticleOffset[i];
                 All.CurrentParticleOffset[i] = rr;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -167,8 +167,20 @@ void run(DomainDecomp * ddecomp)
                 endrun(0, "Human triggered termination.\n");
             }
         }
+
+        double new_random_shift[3] = {0};
+        if(NumCurrentTiStep > 0 && is_PM  && All.RandomParticleOffset > 0) {
+            int i;
+            for (i = 0; i < 3; i++) {
+                /* Note random number table is duplicated across processors*/
+                double rr = get_random_number(i) * All.RandomParticleOffset * All.BoxSize;
+                /* Subtract the old random shift first.*/
+                new_random_shift[i] = rr - All.CurrentParticleOffset[i];
+                All.CurrentParticleOffset[i] = rr;
+            }
+        }
         /* Sync positions of all particles */
-        drift_all_particles(All.Ti_Current);
+        drift_all_particles(All.Ti_Current, new_random_shift);
 
         /* drift and ddecomp decomposition */
 
@@ -266,7 +278,7 @@ void run(DomainDecomp * ddecomp)
 
         write_checkpoint(WriteSnapshot, WriteFOF, &Tree);
 
-        write_cpu_log(NumCurrentTiStep);		/* produce some CPU usage info */
+        write_cpu_log(NumCurrentTiStep);    /* produce some CPU usage info */
 
         NumCurrentTiStep++;
 


### PR DESCRIPTION
This shifts the periodic box by a smallish random number to avoid inter-timestep correlations in the tree opening condition. The public Arepo release does something similar, but we use a much smaller shift so we don't move transfer all particles between processors every full domain decomp. This appears to actually increase speed slightly (!) by reducing the short range gravity time but I suspect this of being a coincidence in this specific box.