### PR TITLE
Don't do a small GC on large particle exchanges

### DIFF
--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -121,13 +121,10 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
 
         message(0, "iter=%d exchange of %013ld particles\n", iter, sumtogo);
 
-        /* Do a GC if we are asked to, if this isn't the last iteration,
-         * or if we are exchanging a peculiarly large number of particles,
-         * indicating large garbage. In practice, if memory is not tight,
-         * this means we will usually only gc on PM steps. The gc decision
-         * is made collective in domain_exchange_once*/
-        int really_do_gc = do_gc || (plan.last < plan.nexchange)
-            || (plan.nexchange > PartManager->NumPart / 1000);
+        /* Do a GC if we are asked to or if this isn't the last iteration.
+         * The gc decision is made collective in domain_exchange_once,
+         * and a gc will also be done if we have no space for particles.*/
+        int really_do_gc = do_gc || (plan.last < plan.nexchange);
 
         failure = domain_exchange_once(&plan, really_do_gc, Comm);
 


### PR DESCRIPTION
It was taking too much of the total time.

It is most often during a full domain decomp anyway, when the peano sort will remove the particles just afterwards. A particle table full of garbage does slow down the tree a little (~1%), but this is small compared to the cost of garbage collection, which was > 30% on the same run.