### PR TITLE
Debugoutput

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -129,6 +129,7 @@ create_gadget_parameter_set()
     /*End cosmology parameters*/
 
     param_declare_int(ps,    "OutputPotential", OPTIONAL, 1, "Save the potential in snapshots.");
+    param_declare_int(ps,    "OutputDebugFields", OPTIONAL, 0, "Save a large number of debug fields in snapshots.");
     param_declare_double(ps,    "MaxMemSizePerNode", OPTIONAL, 0.6, "Pre-allocate this much memory per computing node/ host, in MB. Defaults to 60\% of total available memory per node. Passing < 1 allocates a fraction of total available memory per node.");
     param_declare_double(ps, "AutoSnapshotTime", OPTIONAL, 0, "Seconds after which to automatically generate a snapshot if nothing is output.");
 
@@ -389,6 +390,7 @@ void read_parameter_file(char *fname)
         All.CP.HubbleParam = param_get_double(ps, "HubbleParam");
 
         All.OutputPotential = param_get_int(ps, "OutputPotential");
+        All.OutputDebugFields = param_get_int(ps, "OutputDebugFields");
         double MaxMemSizePerNode = param_get_double(ps, "MaxMemSizePerNode");
         if(MaxMemSizePerNode <= 1) {
             MaxMemSizePerNode *= get_physmem_bytes() / (1024. * 1024.);

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -129,6 +129,7 @@ extern struct global_data_all_processes
 
     double SlotsIncreaseFactor; /* !< What percentage to increase the slot allocation by when requested*/
     int OutputPotential;        /*!< Flag whether to include the potential in snapshots*/
+    int OutputDebugFields;      /* Flag whether to include a lot of debug output in snapshots*/
 
     double RandomParticleOffset; /* If > 0, a random shift of max RandomParticleOffset * BoxSize is applied to every particle
                                   * every time a full domain decomposition is done. The box is periodic and the offset

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -66,6 +66,8 @@ write_snapshot(int num)
     walltime_measure("/Misc");
     struct IOTable IOTable = {0};
     register_io_blocks(&IOTable);
+    if(All.OutputDebugFields)
+        register_debug_io_blocks(&IOTable);
     petaio_save_snapshot(&IOTable, "%s/%s_%03d", All.OutputDir, All.SnapshotFileBase, num);
 
     free_io_blocks(&IOTable);

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -57,7 +57,7 @@ dump_snapshot()
     register_io_blocks(&IOTable);
     register_debug_io_blocks(&IOTable);
     petaio_save_snapshot(&IOTable, "%s/CRASH-DUMP", All.OutputDir);
-    free_io_blocks(&IOTable);
+    destroy_io_blocks(&IOTable);
 }
 
 static void
@@ -70,7 +70,7 @@ write_snapshot(int num)
         register_debug_io_blocks(&IOTable);
     petaio_save_snapshot(&IOTable, "%s/%s_%03d", All.OutputDir, All.SnapshotFileBase, num);
 
-    free_io_blocks(&IOTable);
+    destroy_io_blocks(&IOTable);
     walltime_measure("/Snapshot/Write");
 
     if(ThisTask == 0) {

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -55,6 +55,7 @@ dump_snapshot()
 {
     struct IOTable IOTable = {0};
     register_io_blocks(&IOTable);
+    register_debug_io_blocks(&IOTable);
     petaio_save_snapshot(&IOTable, "%s/CRASH-DUMP", All.OutputDir);
     free_io_blocks(&IOTable);
 }

--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -53,16 +53,21 @@ write_checkpoint(int WriteSnapshot, int WriteFOF, ForceTree * tree)
 void
 dump_snapshot()
 {
-    petaio_save_snapshot("%s/CRASH-DUMP", All.OutputDir);
+    struct IOTable IOTable = {0};
+    register_io_blocks(&IOTable);
+    petaio_save_snapshot(&IOTable, "%s/CRASH-DUMP", All.OutputDir);
+    free_io_blocks(&IOTable);
 }
 
 static void
 write_snapshot(int num)
 {
     walltime_measure("/Misc");
+    struct IOTable IOTable = {0};
+    register_io_blocks(&IOTable);
+    petaio_save_snapshot(&IOTable, "%s/%s_%03d", All.OutputDir, All.SnapshotFileBase, num);
 
-    petaio_save_snapshot("%s/%s_%03d", All.OutputDir, All.SnapshotFileBase, num);
-
+    free_io_blocks(&IOTable);
     walltime_measure("/Snapshot/Write");
 
     if(ThisTask == 0) {

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -78,7 +78,7 @@ void fof_save_particles(int num, int SaveParticles, MPI_Comm Comm)
             petaio_destroy_buffer(&array);
         }
     }
-    free_io_blocks(&FOFIOTable);
+    destroy_io_blocks(&FOFIOTable);
     walltime_measure("/FOF/IO/WriteFOF");
 
     if(SaveParticles) {
@@ -115,7 +115,7 @@ void fof_save_particles(int num, int SaveParticles, MPI_Comm Comm)
 
         fof_return_particles(Comm);
         walltime_measure("/FOF/IO/Return");
-        free_io_blocks(&IOTable);
+        destroy_io_blocks(&IOTable);
     }
 
     big_file_mpi_close(&bf, Comm);

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -324,6 +324,10 @@ SIMPLE_PROPERTY(BlackholeMass, Group[i].BH_Mass, float, 1)
 SIMPLE_PROPERTY(BlackholeAccretionRate, Group[i].BH_Mdot, float, 1)
 
 static void fof_register_io_blocks(struct IOTable * IOTable) {
+    IOTable->used = 0;
+    IOTable->allocated = 100;
+    IOTable->ent = mymalloc("IOTable", IOTable->allocated* sizeof(IOTableEntry));
+
     IO_REG(GroupID, "u4", 1, PTYPE_FOF_GROUP);
     IO_REG(Mass, "f4", 1, PTYPE_FOF_GROUP);
     IO_REG(MassCenterPosition, "f8", 3, PTYPE_FOF_GROUP);

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -328,20 +328,20 @@ static void fof_register_io_blocks(struct IOTable * IOTable) {
     IOTable->allocated = 100;
     IOTable->ent = mymalloc("IOTable", IOTable->allocated* sizeof(IOTableEntry));
 
-    IO_REG(GroupID, "u4", 1, PTYPE_FOF_GROUP);
-    IO_REG(Mass, "f4", 1, PTYPE_FOF_GROUP);
-    IO_REG(MassCenterPosition, "f8", 3, PTYPE_FOF_GROUP);
-    IO_REG(FirstPos, "f4", 3, PTYPE_FOF_GROUP);
-    IO_REG(MinID, "u8", 1, PTYPE_FOF_GROUP);
-    IO_REG(Imom, "f4", 9, PTYPE_FOF_GROUP);
-    IO_REG(Jmom, "f4", 3, PTYPE_FOF_GROUP);
-    IO_REG_WRONLY(MassCenterVelocity, "f4", 3, PTYPE_FOF_GROUP);
-    IO_REG(LengthByType, "u4", 6, PTYPE_FOF_GROUP);
-    IO_REG(MassByType, "f4", 6, PTYPE_FOF_GROUP);
+    IO_REG(GroupID, "u4", 1, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(Mass, "f4", 1, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(MassCenterPosition, "f8", 3, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(FirstPos, "f4", 3, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(MinID, "u8", 1, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(Imom, "f4", 9, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(Jmom, "f4", 3, PTYPE_FOF_GROUP, IOTable);
+    IO_REG_WRONLY(MassCenterVelocity, "f4", 3, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(LengthByType, "u4", 6, PTYPE_FOF_GROUP, IOTable);
+    IO_REG(MassByType, "f4", 6, PTYPE_FOF_GROUP, IOTable);
     if(All.StarformationOn)
-        IO_REG(StarFormationRate, "f4", 1, PTYPE_FOF_GROUP);
+        IO_REG(StarFormationRate, "f4", 1, PTYPE_FOF_GROUP, IOTable);
     if(All.BlackHoleOn) {
-        IO_REG(BlackholeMass, "f4", 1, PTYPE_FOF_GROUP);
-        IO_REG(BlackholeAccretionRate, "f4", 1, PTYPE_FOF_GROUP);
+        IO_REG(BlackholeMass, "f4", 1, PTYPE_FOF_GROUP, IOTable);
+        IO_REG(BlackholeAccretionRate, "f4", 1, PTYPE_FOF_GROUP, IOTable);
     }
 }

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -122,8 +122,8 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
             SPHP(i).Entropy = -1;
             SPHP(i).Ne = 1.0;
             SPHP(i).DivVel = 0;
+            SPHP(i).DelayTime = 0;
         }
-        SPHP(i).DelayTime = 0;
     }
 
     walltime_measure("/Init");

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -809,55 +809,55 @@ void register_io_blocks(struct IOTable * IOTable) {
     IOTable->ent = mymalloc("IOTable", IOTable->allocated* sizeof(IOTableEntry));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
-        IO_REG(Position, "f8", 3, i);
-        IO_REG(Velocity, "f4", 3, i);
-        IO_REG(Mass,     "f4", 1, i);
-        IO_REG(ID,       "u8", 1, i);
+        IO_REG(Position, "f8", 3, i, IOTable);
+        IO_REG(Velocity, "f4", 3, i, IOTable);
+        IO_REG(Mass,     "f4", 1, i, IOTable);
+        IO_REG(ID,       "u8", 1, i, IOTable);
         if(All.OutputPotential)
-            IO_REG_WRONLY(Potential, "f4", 1, i);
+            IO_REG_WRONLY(Potential, "f4", 1, i, IOTable);
         if(All.SnapshotWithFOF)
-            IO_REG_WRONLY(GroupID, "u4", 1, i);
+            IO_REG_WRONLY(GroupID, "u4", 1, i, IOTable);
     }
 
-    IO_REG(Generation,       "u1", 1, 0);
-    IO_REG(Generation,       "u1", 1, 4);
-    IO_REG(Generation,       "u1", 1, 5);
+    IO_REG(Generation,       "u1", 1, 0, IOTable);
+    IO_REG(Generation,       "u1", 1, 4, IOTable);
+    IO_REG(Generation,       "u1", 1, 5, IOTable);
     /* Bare Bone SPH*/
-    IO_REG(SmoothingLength,  "f4", 1, 0);
-    IO_REG(Density,          "f4", 1, 0);
+    IO_REG(SmoothingLength,  "f4", 1, 0, IOTable);
+    IO_REG(Density,          "f4", 1, 0, IOTable);
 
     if(All.DensityIndependentSphOn)
-        IO_REG(EgyWtDensity,          "f4", 1, 0);
+        IO_REG(EgyWtDensity,          "f4", 1, 0, IOTable);
 
     /* On reload this sets the Entropy variable, need the densities.
      * Register this after Density and EgyWtDensity will ensure density is read
      * before this. */
-    IO_REG(InternalEnergy,   "f4", 1, 0);
+    IO_REG(InternalEnergy,   "f4", 1, 0, IOTable);
 
     /* Cooling */
-    IO_REG(ElectronAbundance,       "f4", 1, 0);
-    IO_REG_WRONLY(NeutralHydrogenFraction, "f4", 1, 0);
+    IO_REG(ElectronAbundance,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(NeutralHydrogenFraction, "f4", 1, 0, IOTable);
 
     /* SF */
-    IO_REG_WRONLY(StarFormationRate, "f4", 1, 0);
-    IO_REG_NONFATAL(BirthDensity, "f4", 1, 4);
-    IO_REG_TYPE(StarFormationTime, "f4", 1, 4);
-    IO_REG_TYPE(Metallicity,       "f4", 1, 0);
-    IO_REG_TYPE(Metallicity,       "f4", 1, 4);
+    IO_REG_WRONLY(StarFormationRate, "f4", 1, 0, IOTable);
+    IO_REG_NONFATAL(BirthDensity, "f4", 1, 4, IOTable);
+    IO_REG_TYPE(StarFormationTime, "f4", 1, 4, IOTable);
+    IO_REG_TYPE(Metallicity,       "f4", 1, 0, IOTable);
+    IO_REG_TYPE(Metallicity,       "f4", 1, 4, IOTable);
     /* Another new addition: save the DelayTime for wind particles*/
-    IO_REG_NONFATAL(DelayTime,  "f4", 1, 0);
+    IO_REG_NONFATAL(DelayTime,  "f4", 1, 0, IOTable);
     /* end SF */
 
     /* Black hole */
-    IO_REG_TYPE(StarFormationTime, "f4", 1, 5);
-    IO_REG(BlackholeMass,          "f4", 1, 5);
-    IO_REG(BlackholeAccretionRate, "f4", 1, 5);
-    IO_REG(BlackholeProgenitors,   "i4", 1, 5);
-    IO_REG(BlackholeMinPotPos, "f8", 3, 5);
-    IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5);
+    IO_REG_TYPE(StarFormationTime, "f4", 1, 5, IOTable);
+    IO_REG(BlackholeMass,          "f4", 1, 5, IOTable);
+    IO_REG(BlackholeAccretionRate, "f4", 1, 5, IOTable);
+    IO_REG(BlackholeProgenitors,   "i4", 1, 5, IOTable);
+    IO_REG(BlackholeMinPotPos, "f8", 3, 5, IOTable);
+    IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5, IOTable);
 
     /* Smoothing lengths for black hole: this is a new addition*/
-    IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5);
+    IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);
 
     /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
@@ -882,18 +882,18 @@ void register_debug_io_blocks(struct IOTable * IOTable)
 {
     int ptype;
     for(ptype = 0; ptype < 6; ptype++) {
-        IO_REG_WRONLY(GravAccel,       "f4", 3, ptype);
-        IO_REG_WRONLY(GravPM,       "f4", 3, ptype);
-        IO_REG_WRONLY(TimeBin,       "u4", 1, ptype);
-        IO_REG_WRONLY(GravCost,       "f4", 1, ptype);
+        IO_REG_WRONLY(GravAccel,       "f4", 3, ptype, IOTable);
+        IO_REG_WRONLY(GravPM,       "f4", 3, ptype, IOTable);
+        IO_REG_WRONLY(TimeBin,       "u4", 1, ptype, IOTable);
+        IO_REG_WRONLY(GravCost,       "f4", 1, ptype, IOTable);
     }
-    IO_REG_WRONLY(HydroAccel,       "f4", 3, 0);
-    IO_REG_WRONLY(MaxSignalVel,       "f4", 1, 0);
-    IO_REG_WRONLY(Entropy,       "f4", 1, 0);
-    IO_REG_WRONLY(DtEntropy,       "f4", 1, 0);
-    IO_REG_WRONLY(DhsmlEgyDensityFactor,       "f4", 1, 0);
-    IO_REG_WRONLY(DivVel,       "f4", 1, 0);
-    IO_REG_WRONLY(CurlVel,       "f4", 1, 0);
+    IO_REG_WRONLY(HydroAccel,       "f4", 3, 0, IOTable);
+    IO_REG_WRONLY(MaxSignalVel,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(Entropy,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(DtEntropy,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(DhsmlEgyDensityFactor,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(DivVel,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(CurlVel,       "f4", 1, 0, IOTable);
     /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
 }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -21,10 +21,6 @@
 #include "neutrinos_lra.h"
 
 #include "utils.h"
-
-/*Defined in fofpetaio.c and only used here*/
-void fof_register_io_blocks();
-
 /************
  *
  * The IO api , intented to replace io.c and read_ic.c
@@ -32,16 +28,12 @@ void fof_register_io_blocks();
  *
  */
 
-struct IOTable IOTable;
-
 static void petaio_write_header(BigFile * bf, const int64_t * NTotal);
 static void petaio_read_header_internal(BigFile * bf);
 
-static void register_io_blocks();
-
 /* these are only used in reading in */
-void petaio_init() {
-    /* Smaller files will do aggregareted IO.*/
+void petaio_init(void) {
+    /* Smaller files will do aggregated IO.*/
     if(All.IO.EnableAggregatedIO) {
         message(0, "Aggregated IO is enabled\n");
         big_file_mpi_set_aggregated_threshold(All.IO.AggregatedIOThreshold);
@@ -49,14 +41,13 @@ void petaio_init() {
         message(0, "Aggregated IO is disabled.\n");
         big_file_mpi_set_aggregated_threshold(0);
     }
-    register_io_blocks();
 }
 
 /* save a snapshot file */
-static void petaio_save_internal(char * fname);
+static void petaio_save_internal(char * fname, struct IOTable * IOTable);
 
 void
-petaio_save_snapshot(const char *fmt, ...)
+petaio_save_snapshot(struct IOTable * IOTable, const char *fmt, ...)
 {
     va_list va;
     va_start(va, fmt);
@@ -65,7 +56,7 @@ petaio_save_snapshot(const char *fmt, ...)
     va_end(va);
     message(0, "saving snapshot into %s\n", fname);
 
-    petaio_save_internal(fname);
+    petaio_save_internal(fname, IOTable);
     myfree(fname);
 }
 
@@ -117,7 +108,7 @@ petaio_build_selection(int * selection,
     }
 }
 
-static void petaio_save_internal(char * fname) {
+static void petaio_save_internal(char * fname, struct IOTable * IOTable) {
     BigFile bf = {0};
     if(0 != big_file_mpi_create(&bf, fname, MPI_COMM_WORLD)) {
         endrun(0, "Failed to create snapshot at %s:%s\n", fname,
@@ -137,17 +128,17 @@ static void petaio_save_internal(char * fname) {
     petaio_write_header(&bf, NTotal);
 
     int i;
-    for(i = 0; i < IOTable.used; i ++) {
+    for(i = 0; i < IOTable->used; i ++) {
         /* only process the particle blocks */
         char blockname[128];
-        int ptype = IOTable.ent[i].ptype;
+        int ptype = IOTable->ent[i].ptype;
         BigArray array = {0};
         /*This exclude FOF blocks*/
         if(!(ptype < 6 && ptype >= 0)) {
             continue;
         }
-        sprintf(blockname, "%d/%s", ptype, IOTable.ent[i].name);
-        petaio_build_buffer(&array, &IOTable.ent[i], selection + ptype_offset[ptype], ptype_count[ptype]);
+        sprintf(blockname, "%d/%s", ptype, IOTable->ent[i].name);
+        petaio_build_buffer(&array, &IOTable->ent[i], selection + ptype_offset[ptype], ptype_count[ptype]);
         petaio_save_block(&bf, blockname, &array);
         petaio_destroy_buffer(&array);
     }
@@ -165,7 +156,7 @@ static void petaio_save_internal(char * fname) {
     myfree(selection);
 }
 
-void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
+void petaio_read_internal(char * fname, int ic, struct IOTable * IOTable, MPI_Comm Comm) {
     int ptype;
     int i;
     BigFile bf = {0};
@@ -242,10 +233,10 @@ void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
     /* so we can set up the memory topology of secondary slots */
     slots_setup_topology(SlotsManager);
 
-    for(i = 0; i < IOTable.used; i ++) {
+    for(i = 0; i < IOTable->used; i ++) {
         /* only process the particle blocks */
         char blockname[128];
-        int ptype = IOTable.ent[i].ptype;
+        int ptype = IOTable->ent[i].ptype;
         BigArray array = {0};
         if(!(ptype < 6 && ptype >= 0)) {
             continue;
@@ -254,25 +245,25 @@ void petaio_read_internal(char * fname, int ic, MPI_Comm Comm) {
         if(ic) {
             /* for IC read in only three blocks */
             int keep = 0;
-            keep |= (0 == strcmp(IOTable.ent[i].name, "Position"));
-            keep |= (0 == strcmp(IOTable.ent[i].name, "Velocity"));
-            keep |= (0 == strcmp(IOTable.ent[i].name, "ID"));
+            keep |= (0 == strcmp(IOTable->ent[i].name, "Position"));
+            keep |= (0 == strcmp(IOTable->ent[i].name, "Velocity"));
+            keep |= (0 == strcmp(IOTable->ent[i].name, "ID"));
             if (ptype == 5) {
-                keep |= (0 == strcmp(IOTable.ent[i].name, "Mass"));
-                keep |= (0 == strcmp(IOTable.ent[i].name, "BlackholeMass"));
-                keep |= (0 == strcmp(IOTable.ent[i].name, "MinPotPos"));
+                keep |= (0 == strcmp(IOTable->ent[i].name, "Mass"));
+                keep |= (0 == strcmp(IOTable->ent[i].name, "BlackholeMass"));
+                keep |= (0 == strcmp(IOTable->ent[i].name, "MinPotPos"));
             }
             if(!keep) continue;
         }
-        if(IOTable.ent[i].setter == NULL) {
+        if(IOTable->ent[i].setter == NULL) {
             /* FIXME: do not know how to read this block; assume the fucker is
              * internally intialized; */
             continue;
         }
-        sprintf(blockname, "%d/%s", ptype, IOTable.ent[i].name);
-        petaio_alloc_buffer(&array, &IOTable.ent[i], NLocal[ptype]);
-        if(0 == petaio_read_block(&bf, blockname, &array, IOTable.ent[i].required))
-            petaio_readout_buffer(&array, &IOTable.ent[i]);
+        sprintf(blockname, "%d/%s", ptype, IOTable->ent[i].name);
+        petaio_alloc_buffer(&array, &IOTable->ent[i], NLocal[ptype]);
+        if(0 == petaio_read_block(&bf, blockname, &array, IOTable->ent[i].required))
+            petaio_readout_buffer(&array, &IOTable->ent[i]);
         petaio_destroy_buffer(&array);
     }
 
@@ -324,6 +315,10 @@ void
 petaio_read_snapshot(int num, MPI_Comm Comm)
 {
     char * fname;
+    struct IOTable IOTable = {0};
+
+    register_io_blocks(&IOTable);
+
     if(num == -1) {
         fname = fastpm_strdup_printf("%s", All.InitCondFile);
         /*
@@ -331,7 +326,7 @@ petaio_read_snapshot(int num, MPI_Comm Comm)
          *  InitTemp in paramfile, then use init.c to convert to
          *  entropy.
          * */
-        petaio_read_internal(fname, 1, Comm);
+        petaio_read_internal(fname, 1, &IOTable, Comm);
 
         int i;
         /* touch up the mass -- IC files save mass in header */
@@ -357,7 +352,7 @@ petaio_read_snapshot(int num, MPI_Comm Comm)
         /*
          * we always save the Entropy, init.c will not mess with the entropy
          * */
-        petaio_read_internal(fname, 0, Comm);
+        petaio_read_internal(fname, 0, &IOTable, Comm);
     }
     myfree(fname);
 }
@@ -688,16 +683,17 @@ void io_register_io_block(char * name,
         int ptype,
         property_getter getter,
         property_setter setter,
-        int required
+        int required,
+        struct IOTable * IOTable
         ) {
-    if (IOTable.used == IOTable.allocated) {
-        IOTable.ent = myrealloc(IOTable.ent, 2*IOTable.allocated*sizeof(IOTableEntry));
-        IOTable.allocated *= 2;
+    if (IOTable->used == IOTable->allocated) {
+        IOTable->ent = myrealloc(IOTable->ent, 2*IOTable->allocated*sizeof(IOTableEntry));
+        IOTable->allocated *= 2;
     }
-    IOTableEntry * ent = &IOTable.ent[IOTable.used];
+    IOTableEntry * ent = &IOTable->ent[IOTable->used];
     strncpy(ent->name, name, 63);
     ent->name[63] = '\0';
-    ent->zorder = IOTable.used;
+    ent->zorder = IOTable->used;
     ent->ptype = ptype;
     strncpy(ent->dtype, dtype, 7);
     ent->dtype[7] = '\0';
@@ -705,7 +701,7 @@ void io_register_io_block(char * name,
     ent->setter = setter;
     ent->items = items;
     ent->required = required;
-    IOTable.used ++;
+    IOTable->used ++;
 }
 
 static void GTPosition(int i, double * out) {
@@ -805,11 +801,11 @@ static int order_by_type(const void *a, const void *b)
     return 0;
 }
 
-static void register_io_blocks() {
+void register_io_blocks(struct IOTable * IOTable) {
     int i;
-    IOTable.used = 0;
-    IOTable.allocated = 100;
-    IOTable.ent = mymalloc("IOTable", IOTable.allocated* sizeof(IOTableEntry));
+    IOTable->used = 0;
+    IOTable->allocated = 100;
+    IOTable->ent = mymalloc("IOTable", IOTable->allocated* sizeof(IOTableEntry));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
         IO_REG(Position, "f8", 3, i);
@@ -860,10 +856,12 @@ static void register_io_blocks() {
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5);
 
-    if(All.SnapshotWithFOF)
-        fof_register_io_blocks();
-
     /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
-    qsort_openmp(IOTable.ent, IOTable.used, sizeof(struct IOTableEntry), order_by_type);
+    qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
+}
+
+void free_io_blocks(struct IOTable * IOTable) {
+    myfree(IOTable->ent);
+    IOTable->allocated = 0;
 }
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -754,6 +754,7 @@ SIMPLE_PROPERTY(SmoothingLength, P[i].Hsml, float, 1)
 SIMPLE_PROPERTY(Density, SPHP(i).Density, float, 1)
 SIMPLE_PROPERTY(EgyWtDensity, SPHP(i).EgyWtDensity, float, 1)
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
+SIMPLE_PROPERTY(DelayTime, SPHP(i).DelayTime, float, 1)
 SIMPLE_PROPERTY_TYPE(StarFormationTime, 4, STARP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BirthDensity, STARP(i).BirthDensity, float, 1)
 SIMPLE_PROPERTY_TYPE(Metallicity, 4, STARP(i).Metallicity, float, 1)
@@ -843,6 +844,8 @@ void register_io_blocks(struct IOTable * IOTable) {
     IO_REG_TYPE(StarFormationTime, "f4", 1, 4);
     IO_REG_TYPE(Metallicity,       "f4", 1, 0);
     IO_REG_TYPE(Metallicity,       "f4", 1, 4);
+    /* Another new addition: save the DelayTime for wind particles*/
+    IO_REG_NONFATAL(DelayTime,  "f4", 1, 0);
     /* end SF */
 
     /* Black hole */

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -93,6 +93,8 @@ petaio_build_selection(int * selection,
     ptype_count[0] = 0;
 
     for(i = 0; i < NumPart; i ++) {
+        if(P[i].IsGarbage)
+            continue;
         if((select_func == NULL) || (select_func(i) != 0)) {
             int ptype = P[i].Type;
             ptype_count[ptype] ++;
@@ -106,6 +108,8 @@ petaio_build_selection(int * selection,
     ptype_count[5] = 0;
     for(i = 0; i < NumPart; i ++) {
         int ptype = P[i].Type;
+        if(P[i].IsGarbage)
+            continue;
         if((select_func == NULL) || (select_func(i) != 0)) {
             selection[ptype_offset[ptype] + ptype_count[ptype]] = i;
             ptype_count[ptype]++;

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -898,7 +898,7 @@ void register_debug_io_blocks(struct IOTable * IOTable)
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
 }
 
-void free_io_blocks(struct IOTable * IOTable) {
+void destroy_io_blocks(struct IOTable * IOTable) {
     myfree(IOTable->ent);
     IOTable->allocated = 0;
 }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -860,6 +860,41 @@ void register_io_blocks(struct IOTable * IOTable) {
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
 }
 
+/* Add extra debug blocks to the output*/
+/* Write (but don't read) them, only useful for debugging the particle structures.
+ * Warning: future code versions may change the units!*/
+SIMPLE_GETTER(GTGravAccel, P[i].GravAccel[0], float, 3)
+SIMPLE_GETTER(GTGravPM, P[i].GravPM[0], float, 3)
+SIMPLE_GETTER(GTTimeBin, P[i].TimeBin, int, 1)
+SIMPLE_GETTER(GTGravCost, P[i].GravCost, int, 1)
+SIMPLE_GETTER(GTHydroAccel, SPHP(i).HydroAccel[0], float, 3)
+SIMPLE_GETTER(GTMaxSignalVel, SPHP(i).MaxSignalVel, float, 1)
+SIMPLE_GETTER(GTEntropy, SPHP(i).Entropy, float, 1)
+SIMPLE_GETTER(GTDtEntropy, SPHP(i).DtEntropy, float, 1)
+SIMPLE_GETTER(GTDhsmlEgyDensityFactor, SPHP(i).DhsmlEgyDensityFactor, float, 1)
+SIMPLE_GETTER(GTDivVel, SPHP(i).DivVel, float, 1)
+SIMPLE_GETTER(GTCurlVel, SPHP(i).CurlVel, float, 1)
+
+void register_debug_io_blocks(struct IOTable * IOTable)
+{
+    int ptype;
+    for(ptype = 0; ptype < 6; ptype++) {
+        IO_REG_WRONLY(GravAccel,       "f4", 3, ptype);
+        IO_REG_WRONLY(GravPM,       "f4", 3, ptype);
+        IO_REG_WRONLY(TimeBin,       "u4", 1, ptype);
+        IO_REG_WRONLY(GravCost,       "f4", 1, ptype);
+    }
+    IO_REG_WRONLY(HydroAccel,       "f4", 3, 0);
+    IO_REG_WRONLY(MaxSignalVel,       "f4", 1, 0);
+    IO_REG_WRONLY(Entropy,       "f4", 1, 0);
+    IO_REG_WRONLY(DtEntropy,       "f4", 1, 0);
+    IO_REG_WRONLY(DhsmlEgyDensityFactor,       "f4", 1, 0);
+    IO_REG_WRONLY(DivVel,       "f4", 1, 0);
+    IO_REG_WRONLY(CurlVel,       "f4", 1, 0);
+    /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
+    qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
+}
+
 void free_io_blocks(struct IOTable * IOTable) {
     myfree(IOTable->ent);
     IOTable->allocated = 0;

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -31,8 +31,8 @@ struct IOTable {
 void register_io_blocks(struct IOTable * IOTable);
 /* Write (but don't read) some extra output blocks useful for debugging the particle structure*/
 void register_debug_io_blocks(struct IOTable * IOTable);
-/* Free the IOTable.*/
-void free_io_blocks(struct IOTable * IOTable);
+/* Free the entries in the IOTable.*/
+void destroy_io_blocks(struct IOTable * IOTable);
 
 void petaio_init();
 void petaio_alloc_buffer(BigArray * array, IOTableEntry * ent, int64_t npartLocal);

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -29,6 +29,8 @@ struct IOTable {
 
 /* Populate an IOTable with the default set of blocks to read or write.*/
 void register_io_blocks(struct IOTable * IOTable);
+/* Write (but don't read) some extra output blocks useful for debugging the particle structure*/
+void register_debug_io_blocks(struct IOTable * IOTable);
 /* Free the IOTable.*/
 void free_io_blocks(struct IOTable * IOTable);
 

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -66,13 +66,13 @@ petaio_build_selection(int * selection,
  * IO_REG_TYPE declares an io block which has a type-specific property setter.
  * IO_REG_WRONLY declares an io block which is written, but is not read on snapshot load.
  * */
-#define IO_REG(name, dtype, items, ptype) \
+#define IO_REG(name, dtype, items, ptype, IOTable) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name, 1, IOTable)
-#define IO_REG_TYPE(name, dtype, items, ptype) \
+#define IO_REG_TYPE(name, dtype, items, ptype, IOTable) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## ptype ## name , (property_setter) ST ## ptype ## name, 0, IOTable)
-#define IO_REG_WRONLY(name, dtype, items, ptype) \
+#define IO_REG_WRONLY(name, dtype, items, ptype, IOTable) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , NULL, 1, IOTable)
-#define IO_REG_NONFATAL(name, dtype, items, ptype) \
+#define IO_REG_NONFATAL(name, dtype, items, ptype, IOTable) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name, 0, IOTable)
 void io_register_io_block(char * name,
         char * dtype,

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -27,8 +27,8 @@ void register_extra_blocks(struct IOTable * IOTable)
 {
     int ptype;
     for(ptype = 0; ptype < 6; ptype++) {
-        IO_REG(GravAccel,       "f4", 3, ptype);
-        IO_REG(GravPM,       "f4", 3, ptype);
+        IO_REG(GravAccel,       "f4", 3, ptype, IOTable);
+        IO_REG(GravPM,       "f4", 3, ptype, IOTable);
     }
 }
 

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -23,14 +23,20 @@ char * GDB_format_particle(int i);
 SIMPLE_PROPERTY(GravAccel, P[i].GravAccel[0], float, 3)
 SIMPLE_PROPERTY(GravPM, P[i].GravPM[0], float, 3)
 
-void runtests(DomainDecomp * ddecomp)
+void register_extra_blocks(struct IOTable * IOTable)
 {
-
     int ptype;
     for(ptype = 0; ptype < 6; ptype++) {
         IO_REG(GravAccel,       "f4", 3, ptype);
         IO_REG(GravPM,       "f4", 3, ptype);
     }
+}
+
+void runtests(DomainDecomp * ddecomp)
+{
+    struct IOTable IOTable = {0};
+    register_io_blocks(&IOTable);
+    register_extra_blocks(&IOTable);
 
     /* this produces a very imbalanced load to trigger Issue 86 */
     if(ThisTask == 0) {
@@ -49,7 +55,7 @@ void runtests(DomainDecomp * ddecomp)
 
     grav_short_pair(&Tree);
     message(0, "GravShort Pairs %s\n", GDB_format_particle(0));
-    petaio_save_snapshot("%s/PART-pairs-%03d-mpi", All.OutputDir, NTask);
+    petaio_save_snapshot(&IOTable, "%s/PART-pairs-%03d-mpi", All.OutputDir, NTask);
 
     grav_short_tree(&Tree);  /* computes gravity accel. */
     grav_short_tree(&Tree);  /* computes gravity accel. */
@@ -58,8 +64,9 @@ void runtests(DomainDecomp * ddecomp)
     message(0, "GravShort Tree %s\n", GDB_format_particle(0));
     force_tree_free(&Tree);
 
-    petaio_save_snapshot("%s/PART-tree-%03d-mpi", All.OutputDir, NTask);
+    petaio_save_snapshot(&IOTable, "%s/PART-tree-%03d-mpi", All.OutputDir, NTask);
 
+    free_io_blocks(&IOTable);
 }
 
 void runfof(int RestartSnapNum, DomainDecomp * ddecomp)

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -66,7 +66,7 @@ void runtests(DomainDecomp * ddecomp)
 
     petaio_save_snapshot(&IOTable, "%s/PART-tree-%03d-mpi", All.OutputDir, NTask);
 
-    free_io_blocks(&IOTable);
+    destroy_io_blocks(&IOTable);
 }
 
 void runfof(int RestartSnapNum, DomainDecomp * ddecomp)

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -201,8 +201,8 @@ dloga_from_dti(inttime_t dti)
 inttime_t
 dti_from_dloga(double loga)
 {
-    int ti = ti_from_loga(loga_from_ti(All.Ti_Current));
-    int tip = ti_from_loga(loga+loga_from_ti(All.Ti_Current));
+    inttime_t ti = ti_from_loga(loga_from_ti(All.Ti_Current));
+    inttime_t tip = ti_from_loga(loga+loga_from_ti(All.Ti_Current));
     return tip - ti;
 }
 

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -177,7 +177,7 @@ find_timesteps(inttime_t Ti_Current)
             endrun(1, "Inttimes out of sync: Particle %d (bin = %d, ID=%ld) Kick=%x != Drift=%x\n", i, P[i].TimeBin, P[i].ID, P[i].Ti_kick, P[i].Ti_drift);
         }
 
-        int dti;
+        inttime_t dti;
         if(All.ForceEqualTimesteps) {
             dti = dti_min;
         } else {
@@ -426,7 +426,7 @@ get_timestep_dloga(const int p)
 static inttime_t
 get_timestep_ti(const int p, const inttime_t dti_max)
 {
-    int dti;
+    inttime_t dti;
     /*Give a useful message if we are broken*/
     if(dti_max == 0)
         return 0;
@@ -448,7 +448,7 @@ get_timestep_ti(const int p, const inttime_t dti_max)
     /*
     sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / ac) * All.cf.hubble,
     */
-    if(dti <= 1 || (unsigned int) dti > TIMEBASE)
+    if(dti <= 1 || dti > (inttime_t) TIMEBASE)
     {
         message(1, "Bad timestep (%x) assigned! ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g)\n",
                 dti, P[p].ID, P[p].Type, dloga, dti_max,
@@ -563,7 +563,7 @@ get_PM_timestep_ti(inttime_t Ti_Current)
 {
     double dloga = get_long_range_timestep_dloga();
 
-    int dti = dti_from_dloga(dloga);
+    inttime_t dti = dti_from_dloga(dloga);
     dti = round_down_power_of_two(dti);
 
     SyncPoint * next = find_next_sync_point(Ti_Current);
@@ -582,13 +582,11 @@ int get_timestep_bin(inttime_t dti)
 {
    int bin = -1;
 
-   if(dti == 0)
+   if(dti <= 0)
        return 0;
 
    if(dti == 1)
-   {
        return -1;
-   }
 
    while(dti)
    {

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -159,8 +159,7 @@ find_timesteps(inttime_t Ti_Current)
             if(dti < dti_min)
                 dti_min = dti;
         }
-        /* FIXME : this assumes inttime_t is int*/
-        MPI_Allreduce(MPI_IN_PLACE, &dti_min, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(MPI_IN_PLACE, &dti_min, sizeof(inttime_t), MPI_BYTE, MPI_MIN, MPI_COMM_WORLD);
     }
 
     int badstepsizecount = 0;

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -31,7 +31,6 @@ void apply_half_kick(void);
 void apply_PM_half_kick(void);
 
 int is_timebin_active(int i, inttime_t current);
-void set_timebin_active(binmask_t mask);
 
 inttime_t find_next_kick(inttime_t Ti_Current, int minTimeBin);
 


### PR DESCRIPTION
This PR saves a variety of extra fields (all fields in P and SPHP) to the crash dump snapshot, and optionally to the main snapshot. It also saves and restores DelayTime, which we weren't doing before. This should be enough to debug future "bad timestep" crashes.