### PR TITLE
Ensure proper box wrapping for particle offset outputs

### DIFF
--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -808,7 +808,7 @@ void register_io_blocks(struct IOTable * IOTable) {
     int i;
     IOTable->used = 0;
     IOTable->allocated = 100;
-    IOTable->ent = mymalloc("IOTable", IOTable->allocated* sizeof(IOTableEntry));
+    IOTable->ent = mymalloc2("IOTable", IOTable->allocated * sizeof(IOTableEntry));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
         IO_REG(Position, "f8", 3, i, IOTable);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -709,6 +709,8 @@ static void GTPosition(int i, double * out) {
     int d;
     for(d = 0; d < 3; d ++) {
         out[d] = P[i].Pos[d] - All.CurrentParticleOffset[d];
+        while(out[d] > All.BoxSize) out[d] -= All.BoxSize;
+        while(out[d] <= 0) out[d] += All.BoxSize;
     }
 }
 


### PR DESCRIPTION
I forgot to do this before. Fix the box wrapping on the particle offsets so the output lies within the box.