### PR TITLE
Option to disable stack trace

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -42,8 +42,6 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
 
-    init_endrun();
-
     if(argc < 2)
     {
         message(0, "Parameters are missing.\n");
@@ -89,12 +87,12 @@ int main(int argc, char **argv)
         RestartSnapNum = -1;
 
     if(RestartFlag == 0) {
-        message(1, "Restart flag of 0 is deprecated. Use 2.\n");
+        message(0, "Restart flag of 0 is deprecated. Use 2.\n");
         RestartFlag = 2;
         RestartSnapNum = -1;
     }
     if(RestartFlag == 3 && RestartSnapNum < 0) {
-        endrun(1, "Need to give the snapshot number if FOF is selected for output\n");
+        endrun(0, "Need to give the snapshot number if FOF is selected for output\n");
     }
 
     if(RestartFlag == 1) {
@@ -111,6 +109,8 @@ int main(int argc, char **argv)
     /* Make sure memory has finished initialising on all ranks before doing more.
      * This may improve stability */
     MPI_Barrier(MPI_COMM_WORLD);
+
+    init_endrun(All.ShowBacktrace);
 
     begrun(RestartSnapNum);
 

--- a/gadget/params.c
+++ b/gadget/params.c
@@ -132,6 +132,7 @@ create_gadget_parameter_set()
 
     param_declare_int(ps,    "OutputPotential", OPTIONAL, 1, "Save the potential in snapshots.");
     param_declare_int(ps,    "OutputDebugFields", OPTIONAL, 0, "Save a large number of debug fields in snapshots.");
+    param_declare_int(ps,    "ShowBacktrace", OPTIONAL, 1, "Print a backtrace on crash. Hangs on stampede.");
     param_declare_double(ps,    "MaxMemSizePerNode", OPTIONAL, 0.6, "Pre-allocate this much memory per computing node/ host, in MB. Defaults to 60\% of total available memory per node. Passing < 1 allocates a fraction of total available memory per node.");
     param_declare_double(ps, "AutoSnapshotTime", OPTIONAL, 0, "Seconds after which to automatically generate a snapshot if nothing is output.");
 
@@ -394,6 +395,7 @@ void read_parameter_file(char *fname)
 
         All.OutputPotential = param_get_int(ps, "OutputPotential");
         All.OutputDebugFields = param_get_int(ps, "OutputDebugFields");
+        All.ShowBacktrace = param_get_int(ps, "ShowBacktrace");
         double MaxMemSizePerNode = param_get_double(ps, "MaxMemSizePerNode");
         if(MaxMemSizePerNode <= 1) {
             MaxMemSizePerNode *= get_physmem_bytes() / (1024. * 1024.);

--- a/genic/main.c
+++ b/genic/main.c
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
 {
   MPI_Init(&argc, &argv);
   MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
-  init_endrun();
-
   if(argc < 2)
     endrun(0,"Please pass a parameter file.\n");
 
@@ -32,6 +30,8 @@ int main(int argc, char **argv)
   read_parameterfile(argv[1]);
 
   mymalloc_init(All.MaxMemSizePerNode);
+
+  init_endrun(All.ShowBacktrace);
 
   walltime_init(&All.CT);
 
@@ -130,13 +130,13 @@ int main(int argc, char **argv)
     if(All2.MakeGlassGas || All2.MakeGlassCDM)
         glass_evolve(pm, 14, "powerspectrum-glass-tot", ICP, NumPartCDM+NumPartGas);
   }
-  
+
   /*Write initial positions into ICP struct (for CDM and gas)*/
   int j,k;
   for(j=0; j<NumPartCDM+NumPartGas; j++)
       for(k=0; k<3; k++)
           ICP[j].PrePos[k] = ICP[j].Pos[k];
-  
+
   if(NumPartCDM > 0) {
     displacement_fields(pm, DMType, ICP, NumPartCDM);
 

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -99,6 +99,7 @@ extern struct global_data_all_processes
     double SlotsIncreaseFactor; /* !< What percentage to increase the slot allocation by when requested*/
     int OutputPotential;        /*!< Flag whether to include the potential in snapshots*/
     int OutputDebugFields;      /* Flag whether to include a lot of debug output in snapshots*/
+    int ShowBacktrace;          /* Flag to enable or disable the backtrace printing code*/
 
     double RandomParticleOffset; /* If > 0, a random shift of max RandomParticleOffset * BoxSize is applied to every particle
                                   * every time a full domain decomposition is done. The box is periodic and the offset

--- a/libgadget/utils/endrun.c
+++ b/libgadget/utils/endrun.c
@@ -111,7 +111,7 @@ OsSigHandler(int no)
 }
 
 static void
-init_stacktrace()
+init_stacktrace(void)
 {
     struct sigaction act, oact;
 
@@ -127,17 +127,21 @@ init_stacktrace()
     }
 }
 
+static int ShowBacktrace;
+
 void
-init_endrun()
+init_endrun(int backtrace)
 {
-    init_stacktrace();
+    ShowBacktrace = backtrace;
+    if(backtrace)
+        init_stacktrace();
 }
 
 /*  This function aborts the simulation.
  *
  *  if where > 0, a stacktrace is printed per rank calling endrun.
  *  if where <= 0, the function shall be called by all ranks collectively.
- *    and only the root rank prints the error. 
+ *    and only the root rank prints the error.
  *
  *  No barrier is applied.
  */
@@ -152,7 +156,8 @@ endrun(int where, const char * fmt, ...)
     int ThisTask;
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     if(ThisTask == 0 || where > 0) {
-        show_backtrace();
+        if(ShowBacktrace)
+            show_backtrace();
         MPI_Abort(MPI_COMM_WORLD, where);
     }
     /* This is here so the compiler knows this

--- a/libgadget/utils/endrun.h
+++ b/libgadget/utils/endrun.h
@@ -1,5 +1,5 @@
 
-void init_endrun();
+void init_endrun(int backtrace);
 
 void endrun(int where, const char * fmt, ...) __attribute__ ((noreturn)) ;
 void message(int where, const char * fmt, ...);

--- a/tests/stub.c
+++ b/tests/stub.c
@@ -26,7 +26,7 @@ _cmocka_run_group_tests_mpi(const char * name, const struct CMUnitTest tests[], 
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
 
-    init_endrun();
+    init_endrun(1);
 
     if(NTask != 1) {
         setenv("CMOCKA_TEST_ABORT", "1", 1);


### PR DESCRIPTION
Printing the backtrace hangs on stampede (in the fork() call). I can't see that we can do anything about this, so add an option to disable backtrace printing