### PR TITLE
Use MPI_Init_thread instead of MPI_Init

### DIFF
--- a/gadget/main.c
+++ b/gadget/main.c
@@ -38,9 +38,12 @@ void gsl_handler (const char * reason, const char * file, int line, int gsl_errn
 int main(int argc, char **argv)
 {
     int NTask;
-    MPI_Init(&argc, &argv);
+    int thread_provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
+    if(thread_provided != MPI_THREAD_FUNNELED)
+        message(1, "MPI_Init_thread returned %d != MPI_THREAD_FUNNELED\n", thread_provided);
 
     if(argc < 2)
     {

--- a/genic/main.c
+++ b/genic/main.c
@@ -20,7 +20,8 @@ void print_spec(void);
 
 int main(int argc, char **argv)
 {
-  MPI_Init(&argc, &argv);
+  int thread_provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_provided);
   MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
   if(argc < 2)
     endrun(0,"Please pass a parameter file.\n");

--- a/genic/main.c
+++ b/genic/main.c
@@ -22,6 +22,9 @@ int main(int argc, char **argv)
 {
   int thread_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_provided);
+  if(thread_provided != MPI_THREAD_FUNNELED)
+  	message(1, "MPI_Init_thread returned %d != MPI_THREAD_FUNNELED\n", thread_provided);
+
   MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
   if(argc < 2)
     endrun(0,"Please pass a parameter file.\n");


### PR DESCRIPTION
On the recommendation of one of the Stampede admins

I think this will have little effect, because it seems most implementations are only affected if you use  MPI_THREAD_MULTIPLE, and their support is flaky at best, but it can't hurt.