### PR TITLE
Avoid FOF double exchange

### DIFF
--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -19,16 +19,8 @@
 #include <mpi.h>
 #include <stdio.h>
 
-#ifdef _OPENMP
 #include <omp.h>
 #include <pthread.h>
-#else
-#ifndef __clang_analyzer__
-#error no OMP
-#endif
-#define omp_get_max_threads()  (1)
-#define omp_get_thread_num()  (0)
-#endif
 
 #include "cosmology.h"
 #include "gravity.h"

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -529,7 +529,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             double mass_j;
             if(HAS(blackhole_params.BlackHoleFeedbackMethod, BH_FEEDBACK_OPTTHIN)) {
                 double redshift = 1./All.Time - 1;
-                double nh0 = get_neutral_fraction_sfreff(other, redshift);
+                double nh0 = get_neutral_fraction_sfreff(redshift, &P[other], &SPHP(other));
                 if(r2 > 0)
                     O->FeedbackWeightSum += (P[other].Mass * nh0) / r2;
             } else {

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -210,7 +210,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
     myfree(OldTopLeaves);
     myfree(OldTopNodes);
 
-    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, ddecomp->DomainComm))
+    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, ddecomp->DomainComm))
         endrun(1929,"Could not exchange particles\n");
 
     /*Do a garbage collection so that the slots are ordered
@@ -237,7 +237,7 @@ void domain_maintain(DomainDecomp * ddecomp)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, ddecomp->DomainComm)) {
+    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, ddecomp->DomainComm)) {
         domain_decompose_full(ddecomp);
         return;
     }

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -171,7 +171,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
         domain_free(ddecomp);
 
 #ifdef DEBUG
-        domain_test_id_uniqueness();
+        domain_test_id_uniqueness(PartManager);
 #endif
         int MaxTopNodes = domain_allocate(ddecomp, &policies[i]);
 
@@ -210,7 +210,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
     myfree(OldTopLeaves);
     myfree(OldTopNodes);
 
-    if(domain_exchange(domain_layoutfunc, ddecomp, 0, ddecomp->DomainComm))
+    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, ddecomp->DomainComm))
         endrun(1929,"Could not exchange particles\n");
 
     /*Do a garbage collection so that the slots are ordered
@@ -237,7 +237,7 @@ void domain_maintain(DomainDecomp * ddecomp)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, ddecomp->DomainComm)) {
+    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, ddecomp->DomainComm)) {
         domain_decompose_full(ddecomp);
         return;
     }

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -452,6 +452,8 @@ domain_build_plan(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, E
         const int target = layoutfunc(i, layout_userdata);
         plan->layouts[n].ptype = PartManager->Base[i].Type;
         plan->layouts[n].target = target;
+        if(target >= plan->NTask || target < 0)
+            endrun(4, "layoutfunc for %d returned unreasonable %d for %d tasks\n", i, target, plan->NTask);
     }
 
     /*Do the sum*/

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -6,7 +6,7 @@
 
 typedef int (*ExchangeLayoutFunc) (int p, const void * userdata);
 
-int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * PartManager, struct slots_manager_type * SlotsManager, MPI_Comm Comm);
-void domain_test_id_uniqueness(struct part_manager_type * PartManager);
+int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, MPI_Comm Comm);
+void domain_test_id_uniqueness(struct part_manager_type * pman);
 
 #endif

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -2,10 +2,11 @@
 #define __EXCHANGE_H
 
 #include "partmanager.h"
+#include "slotsmanager.h"
 
 typedef int (*ExchangeLayoutFunc) (int p, const void * userdata);
 
-int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * PartManager, MPI_Comm Comm);
+int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * PartManager, struct slots_manager_type * SlotsManager, MPI_Comm Comm);
 void domain_test_id_uniqueness(struct part_manager_type * PartManager);
 
 #endif

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -1,9 +1,11 @@
 #ifndef __EXCHANGE_H
 #define __EXCHANGE_H
 
+#include "partmanager.h"
+
 typedef int (*ExchangeLayoutFunc) (int p, const void * userdata);
 
-int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, MPI_Comm Comm);
-void domain_test_id_uniqueness();
+int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * PartManager, MPI_Comm Comm);
+void domain_test_id_uniqueness(struct part_manager_type * PartManager);
 
 #endif

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -802,21 +802,26 @@ fof_compile_catalogue(struct FOFGroups * fof, const int NgroupsExt, double BoxSi
     MPI_Allreduce(&Nids, &TotNids, 1, MPI_INT64, MPI_SUM, Comm);
 
     /* report some statistics */
-    int largestgroup = 0;
+    int largestloc_tot = 0;
+    double largestmass_tot= 0;
     if(fof->TotNgroups > 0)
     {
-        int largestloc = 0;
+        double largestmass = 0;
+        int largestlength = 0;
 
         for(i = 0; i < NgroupsExt; i++)
-            if(fof->Group[i].Length > largestloc)
-                largestloc = fof->Group[i].Length;
-        MPI_Allreduce(&largestloc, &largestgroup, 1, MPI_INT, MPI_MAX, Comm);
+            if(fof->Group[i].Length > largestlength) {
+                largestlength = fof->Group[i].Length;
+                largestmass = fof->Group[i].Mass;
+            }
+        MPI_Allreduce(&largestlength, &largestloc_tot, 1, MPI_INT, MPI_MAX, Comm);
+        MPI_Allreduce(&largestmass, &largestmass_tot, 1, MPI_DOUBLE, MPI_MAX, Comm);
     }
 
     message(0, "Total number of groups with at least %d particles: %ld\n", fof_params.FOFHaloMinLength, fof->TotNgroups);
     if(fof->TotNgroups > 0)
     {
-        message(0, "Largest group has %d particles, mass %g.\n", largestgroup, fof->Group[largestgroup].Mass);
+        message(0, "Largest group has %d particles, mass %g.\n", largestloc_tot, largestmass_tot);
         message(0, "Total number of particles in groups: %012ld\n", TotNids);
     }
 }

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -232,7 +232,7 @@ static void fof_distribute_particles(MPI_Comm Comm) {
     }
     myfree(pi);
 
-    if(domain_exchange(fof_sorted_layout, targettask, 1, Comm))
+    if(domain_exchange(fof_sorted_layout, targettask, 1, PartManager, Comm))
         endrun(1930,"Could not exchange particles\n");
     /* sort SPH and Others independently */
 
@@ -247,7 +247,7 @@ static void fof_distribute_particles(MPI_Comm Comm) {
 
 }
 static void fof_return_particles(MPI_Comm Comm) {
-    if(domain_exchange(fof_origin_layout, NULL, 1, Comm))
+    if(domain_exchange(fof_origin_layout, NULL, 1, PartManager, Comm))
         endrun(1931,"Could not exchange particles\n");
 }
 

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -260,7 +260,7 @@ static void build_buffer_fof(FOFGroups * fof, BigArray * array, IOTableEntry * e
     char * p = array->data;
     int i;
     for(i = 0; i < fof->Ngroups; i ++) {
-        ent->getter(i, p, fof->Group);
+        ent->getter(i, p, fof->Group, NULL);
         p += array->strides[0];
     }
 }
@@ -317,7 +317,7 @@ SIMPLE_PROPERTY_FOF(MassCenterPosition, CM[0], double, 3)
 SIMPLE_PROPERTY_FOF(Imom, Imom[0][0], float, 9)
 /* FIXME: set Jmom to use peculiar velocity */
 SIMPLE_PROPERTY_FOF(Jmom, Jmom[0], float, 3)
-static void GTMassCenterVelocity(int i, float * out, void * baseptr) {
+static void GTMassCenterVelocity(int i, float * out, void * baseptr, void * slotptr) {
     double fac;
     struct Group * Group = (struct Group *) baseptr;
     if (All.IO.UsePeculiarVelocity) {

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -37,9 +37,9 @@ static void fof_radix_Group_GrNr(const void * a, void * radix, void * arg) {
 }
 
 static int
-fof_petaio_select_func(int i)
+fof_petaio_select_func(int i, const struct particle_data * Parts)
 {
-    if(P[i].GrNr < 0) return 0;
+    if(Parts[i].GrNr < 0) return 0;
     return 1;
 }
 
@@ -96,7 +96,7 @@ void fof_save_particles(FOFGroups * fof, int num, int SaveParticles, MPI_Comm Co
 
         int ptype_offset[6]={0};
         int ptype_count[6]={0};
-        petaio_build_selection(selection, ptype_offset, ptype_count, PartManager->NumPart, fof_petaio_select_func);
+        petaio_build_selection(selection, ptype_offset, ptype_count, P, PartManager->NumPart, fof_petaio_select_func);
 
         /*Sort each type individually*/
         for(i = 0; i < 6; i++)

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -109,11 +109,15 @@ void fof_save_particles(FOFGroups * fof, int num, int SaveParticles, MPI_Comm Co
             char blockname[128];
             int ptype = IOTable.ent[i].ptype;
             BigArray array = {0};
-            sprintf(blockname, "%d/%s", ptype, IOTable.ent[i].name);
-            petaio_build_buffer(&array, &IOTable.ent[i], selection + ptype_offset[ptype], ptype_count[ptype]);
-            message(0, "Writing Block %s\n", blockname);
-            petaio_save_block(&bf, blockname, &array, 1);
-            petaio_destroy_buffer(&array);
+            if(ptype < 6 && ptype >= 0) {
+                sprintf(blockname, "%d/%s", ptype, IOTable.ent[i].name);
+                petaio_build_buffer(&array, &IOTable.ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P);
+
+                message(0, "Writing Block %s\n", blockname);
+
+                petaio_save_block(&bf, blockname, &array, 1);
+                petaio_destroy_buffer(&array);
+            }
         }
         myfree(selection);
         walltime_measure("/FOF/IO/WriteParticles");

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -232,7 +232,7 @@ static void fof_distribute_particles(MPI_Comm Comm) {
     }
     myfree(pi);
 
-    if(domain_exchange(fof_sorted_layout, targettask, 1, PartManager, Comm))
+    if(domain_exchange(fof_sorted_layout, targettask, 1, PartManager, SlotsManager, Comm))
         endrun(1930,"Could not exchange particles\n");
     /* sort SPH and Others independently */
 
@@ -247,7 +247,7 @@ static void fof_distribute_particles(MPI_Comm Comm) {
 
 }
 static void fof_return_particles(MPI_Comm Comm) {
-    if(domain_exchange(fof_origin_layout, NULL, 1, PartManager, Comm))
+    if(domain_exchange(fof_origin_layout, NULL, 1, PartManager, SlotsManager, Comm))
         endrun(1931,"Could not exchange particles\n");
 }
 

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -111,7 +111,7 @@ void fof_save_particles(FOFGroups * fof, int num, int SaveParticles, MPI_Comm Co
             BigArray array = {0};
             if(ptype < 6 && ptype >= 0) {
                 sprintf(blockname, "%d/%s", ptype, IOTable.ent[i].name);
-                petaio_build_buffer(&array, &IOTable.ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P);
+                petaio_build_buffer(&array, &IOTable.ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P, SlotsManager);
 
                 message(0, "Writing Block %s\n", blockname);
 

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -69,7 +69,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
     /*Read the snapshot*/
     petaio_read_snapshot(RestartSnapNum, MPI_COMM_WORLD);
 
-    domain_test_id_uniqueness();
+    domain_test_id_uniqueness(PartManager);
 
     check_omega();
 

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -59,11 +59,7 @@ struct particle_data
 
         int RegionInd; /* which region the particle belongs to; only by petapm.c */
 
-        struct {
-            /* used by fof.c which calls domain_exchange that doesn't uses peano_t */
-            int64_t GrNr;
-            int origintask;
-        };
+        int64_t GrNr;
     };
 
 };

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -824,13 +824,16 @@ SIMPLE_PROPERTY_PI(BlackholeJumpToMinPot, JumpToMinPot, int, 1, struct bh_partic
 SIMPLE_GETTER(GTGroupID, GrNr, uint32_t, 1, struct particle_data)
 static void GTNeutralHydrogenFraction(int i, float * out, void * baseptr, void * slotptr) {
     double redshift = 1./All.Time - 1;
-    *out = get_neutral_fraction_sfreff(i, redshift);
+    struct particle_data * pl = ((struct particle_data *) baseptr)+i;
+    int PI = pl->PI;
+    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
+    struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
+    *out = get_neutral_fraction_sfreff(redshift, pl, sl+PI);
 }
 
 static void GTInternalEnergy(int i, float * out, void * baseptr, void * slotptr) {
     int PI = ((struct particle_data *) baseptr)[i].PI;
-    int ptype = ((struct particle_data *) baseptr)[i].Type;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[ptype]);
+    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     *out = sl[PI].Entropy / GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1);
 }
@@ -838,8 +841,7 @@ static void GTInternalEnergy(int i, float * out, void * baseptr, void * slotptr)
 static void STInternalEnergy(int i, float * out, void * baseptr, void * slotptr) {
     float u = *out;
     int PI = ((struct particle_data *) baseptr)[i].PI;
-    int ptype = ((struct particle_data *) baseptr)[i].Type;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[ptype]);
+    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     sl[PI].Entropy  = GAMMA_MINUS1 * u / pow(SPH_EOMDensity(i) * All.cf.a3inv , GAMMA_MINUS1);
 }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -705,7 +705,7 @@ void io_register_io_block(char * name,
     IOTable->used ++;
 }
 
-static void GTPosition(int i, double * out, void * baseptr, void * slotptr) {
+static void GTPosition(int i, double * out, void * baseptr, void * smanptr) {
     /* Remove the particle offset before saving*/
     struct particle_data * part = (struct particle_data *) baseptr;
     int d;
@@ -716,7 +716,7 @@ static void GTPosition(int i, double * out, void * baseptr, void * slotptr) {
     }
 }
 
-static void STPosition(int i, double * out, void * baseptr, void * slotptr) {
+static void STPosition(int i, double * out, void * baseptr, void * smanptr) {
     int d;
     struct particle_data * part = (struct particle_data *) baseptr;
     for(d = 0; d < 3; d ++) {
@@ -734,10 +734,10 @@ static void STPosition(int i, double * out, void * baseptr, void * slotptr) {
 
 /* A property that uses getters and setters via the PI of a particle data array.*/
 #define SIMPLE_GETTER_PI(name, field, dtype, items, slottype) \
-static void name(int i, dtype * out, void * baseptr, void * slotptr) { \
+static void name(int i, dtype * out, void * baseptr, void * smanptr) { \
     int PI = ((struct particle_data *) baseptr)[i].PI; \
     int ptype = ((struct particle_data *) baseptr)[i].Type; \
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[ptype]); \
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[ptype]); \
     slottype * sl = (slottype *) info->ptr; \
     int k; \
     for(k = 0; k < items; k ++) { \
@@ -746,10 +746,10 @@ static void name(int i, dtype * out, void * baseptr, void * slotptr) { \
 }
 
 #define SIMPLE_SETTER_PI(name, field, dtype, items, slottype) \
-static void name(int i, dtype * out, void * baseptr, void * slotptr) { \
+static void name(int i, dtype * out, void * baseptr, void * smanptr) { \
     int PI = ((struct particle_data *) baseptr)[i].PI; \
     int ptype = ((struct particle_data *) baseptr)[i].Type; \
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[ptype]); \
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[ptype]); \
     slottype * sl = (slottype *) info->ptr; \
     int k; \
     for(k = 0; k < items; k ++) { \
@@ -764,7 +764,7 @@ static void name(int i, dtype * out, void * baseptr, void * slotptr) { \
     SIMPLE_GETTER_PI(GT ## ptype ## name , field, type, items, slottype) \
     SIMPLE_SETTER_PI(ST ## ptype ## name , field, type, items, slottype)
 
-static void GTVelocity(int i, float * out, void * baseptr, void * slotptr) {
+static void GTVelocity(int i, float * out, void * baseptr, void * smanptr) {
     /* Convert to Peculiar Velocity if UsePeculiarVelocity is set */
     double fac;
     struct particle_data * part = (struct particle_data *) baseptr;
@@ -779,7 +779,7 @@ static void GTVelocity(int i, float * out, void * baseptr, void * slotptr) {
         out[d] = fac * part[i].Vel[d];
     }
 }
-static void STVelocity(int i, float * out, void * baseptr, void * slotptr) {
+static void STVelocity(int i, float * out, void * baseptr, void * smanptr) {
     double fac;
     struct particle_data * part = (struct particle_data *) baseptr;
     if (All.IO.UsePeculiarVelocity) {
@@ -806,11 +806,11 @@ SIMPLE_PROPERTY_TYPE_PI(StarFormationTime, 4, FormationTime, float, 1, struct st
 SIMPLE_PROPERTY_PI(BirthDensity, BirthDensity, float, 1, struct star_particle_data)
 SIMPLE_PROPERTY_TYPE_PI(Metallicity, 4, Metallicity, float, 1, struct star_particle_data)
 SIMPLE_PROPERTY_TYPE_PI(Metallicity, 0, Metallicity, float, 1, struct sph_particle_data)
-static void GTStarFormationRate(int i, float * out, void * baseptr, void * slotptr) {
+static void GTStarFormationRate(int i, float * out, void * baseptr, void * smanptr) {
     /* Convert to Solar/year */
     int PI = ((struct particle_data *) baseptr)[i].PI;
     int ptype = ((struct particle_data *) baseptr)[i].Type;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[ptype]);
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[ptype]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     *out = sl[PI].Sfr * ((All.UnitMass_in_g / SOLAR_MASS) / (All.UnitTime_in_s / SEC_PER_YEAR));
 }
@@ -822,26 +822,26 @@ SIMPLE_PROPERTY_PI(BlackholeMinPotPos, MinPotPos[0], double, 3, struct bh_partic
 SIMPLE_PROPERTY_PI(BlackholeJumpToMinPot, JumpToMinPot, int, 1, struct bh_particle_data)
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, GrNr, uint32_t, 1, struct particle_data)
-static void GTNeutralHydrogenFraction(int i, float * out, void * baseptr, void * slotptr) {
+static void GTNeutralHydrogenFraction(int i, float * out, void * baseptr, void * smanptr) {
     double redshift = 1./All.Time - 1;
     struct particle_data * pl = ((struct particle_data *) baseptr)+i;
     int PI = pl->PI;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     *out = get_neutral_fraction_sfreff(redshift, pl, sl+PI);
 }
 
-static void GTInternalEnergy(int i, float * out, void * baseptr, void * slotptr) {
+static void GTInternalEnergy(int i, float * out, void * baseptr, void * smanptr) {
     int PI = ((struct particle_data *) baseptr)[i].PI;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     *out = sl[PI].Entropy / GAMMA_MINUS1 * pow(SPH_EOMDensity(i) * All.cf.a3inv, GAMMA_MINUS1);
 }
 
-static void STInternalEnergy(int i, float * out, void * baseptr, void * slotptr) {
+static void STInternalEnergy(int i, float * out, void * baseptr, void * smanptr) {
     float u = *out;
     int PI = ((struct particle_data *) baseptr)[i].PI;
-    struct slot_info * info = &(((struct slots_manager_type *) slotptr)->info[0]);
+    struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
     sl[PI].Entropy  = GAMMA_MINUS1 * u / pow(SPH_EOMDensity(i) * All.cf.a3inv , GAMMA_MINUS1);
 }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -139,7 +139,7 @@ static void petaio_save_internal(char * fname, struct IOTable * IOTable, int ver
             continue;
         }
         sprintf(blockname, "%d/%s", ptype, IOTable->ent[i].name);
-        petaio_build_buffer(&array, &IOTable->ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P);
+        petaio_build_buffer(&array, &IOTable->ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P, SlotsManager);
         petaio_save_block(&bf, blockname, &array, verbose);
         petaio_destroy_buffer(&array);
     }
@@ -541,7 +541,7 @@ void petaio_readout_buffer(BigArray * array, IOTableEntry * ent) {
  * NOTE: selected range should contain only one particle type!
 */
 void
-petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection, struct particle_data * Parts)
+petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection, struct particle_data * Parts, struct slots_manager_type * SlotsManager)
 {
     if(selection == NULL) {
         endrun(-1, "NULL selection is not supported\n");

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -75,8 +75,9 @@ void
 petaio_build_selection(int * selection,
     int * ptype_offset,
     int * ptype_count,
+    const struct particle_data * Parts,
     const int NumPart,
-    int (*select_func)(int i)
+    int (*select_func)(int i, const struct particle_data * Parts)
     )
 {
     int i;
@@ -86,8 +87,8 @@ petaio_build_selection(int * selection,
     for(i = 0; i < NumPart; i ++) {
         if(P[i].IsGarbage)
             continue;
-        if((select_func == NULL) || (select_func(i) != 0)) {
-            int ptype = P[i].Type;
+        if((select_func == NULL) || (select_func(i, Parts) != 0)) {
+            int ptype = Parts[i].Type;
             ptype_count[ptype] ++;
         }
     }
@@ -98,10 +99,10 @@ petaio_build_selection(int * selection,
 
     ptype_count[5] = 0;
     for(i = 0; i < NumPart; i ++) {
-        int ptype = P[i].Type;
+        int ptype = Parts[i].Type;
         if(P[i].IsGarbage)
             continue;
-        if((select_func == NULL) || (select_func(i) != 0)) {
+        if((select_func == NULL) || (select_func(i, Parts) != 0)) {
             selection[ptype_offset[ptype] + ptype_count[ptype]] = i;
             ptype_count[ptype]++;
         }
@@ -121,7 +122,7 @@ static void petaio_save_internal(char * fname, struct IOTable * IOTable, int ver
 
     int * selection = mymalloc("Selection", sizeof(int) * PartManager->NumPart);
 
-    petaio_build_selection(selection, ptype_offset, ptype_count, PartManager->NumPart, NULL);
+    petaio_build_selection(selection, ptype_offset, ptype_count, P, PartManager->NumPart, NULL);
 
     sumup_large_ints(6, ptype_count, NTotal);
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -139,7 +139,7 @@ static void petaio_save_internal(char * fname, struct IOTable * IOTable, int ver
             continue;
         }
         sprintf(blockname, "%d/%s", ptype, IOTable->ent[i].name);
-        petaio_build_buffer(&array, &IOTable->ent[i], selection + ptype_offset[ptype], ptype_count[ptype]);
+        petaio_build_buffer(&array, &IOTable->ent[i], selection + ptype_offset[ptype], ptype_count[ptype], P);
         petaio_save_block(&bf, blockname, &array, verbose);
         petaio_destroy_buffer(&array);
     }
@@ -541,7 +541,7 @@ void petaio_readout_buffer(BigArray * array, IOTableEntry * ent) {
  * NOTE: selected range should contain only one particle type!
 */
 void
-petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection)
+petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection, struct particle_data * Parts)
 {
     if(selection == NULL) {
         endrun(-1, "NULL selection is not supported\n");
@@ -567,10 +567,10 @@ petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection,
         p += array->strides[0] * start;
         for(i = start; i < end; i ++) {
             const int j = selection[i];
-            if(P[j].Type != ent->ptype) {
-                endrun(2, "Selection %d has type = %d != %d\n", j, P[j].Type, ent->ptype);
+            if(Parts[j].Type != ent->ptype) {
+                endrun(2, "Selection %d has type = %d != %d\n", j, Parts[j].Type, ent->ptype);
             }
-            ent->getter(j, p, P);
+            ent->getter(j, p, Parts);
             p += array->strides[0];
         }
     }

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -575,7 +575,7 @@ petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection,
     }
 }
 
-/* destropy a buffer, freeing its memory */
+/* destroy a buffer, freeing its memory */
 void petaio_destroy_buffer(BigArray * array) {
     myfree(array->data);
 }

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include "bigfile.h"
 #include "partmanager.h"
+#include "slotsmanager.h"
 
 typedef void (*property_getter) (int i, void * result, void * baseptr, void * slotptr);
 typedef void (*property_setter) (int i, void * target, void * baseptr, void * slotptr);
@@ -37,7 +38,7 @@ void destroy_io_blocks(struct IOTable * IOTable);
 
 void petaio_init();
 void petaio_alloc_buffer(BigArray * array, IOTableEntry * ent, int64_t npartLocal);
-void petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int size, struct particle_data * Parts);
+void petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection, struct particle_data * Parts, struct slots_manager_type * SlotsManager);
 void petaio_readout_buffer(BigArray * array, IOTableEntry * ent);
 void petaio_destroy_buffer(BigArray * array);
 

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -5,8 +5,8 @@
 #include "bigfile.h"
 #include "partmanager.h"
 
-typedef void (*property_getter) (int i, void * result, void * baseptr);
-typedef void (*property_setter) (int i, void * target, void * baseptr);
+typedef void (*property_getter) (int i, void * result, void * baseptr, void * slotptr);
+typedef void (*property_setter) (int i, void * target, void * baseptr, void * slotptr);
 typedef int (*petaio_selection) (int i);
 
 typedef struct IOTableEntry {
@@ -101,14 +101,14 @@ void io_register_io_block(char * name,
  * stype: type of the base pointer to use
  * */
 #define SIMPLE_GETTER(name, field, type, items, stype) \
-static void name(int i, type * out, void * baseptr) { \
+static void name(int i, type * out, void * baseptr, void * slotptr) { \
     int k; \
     for(k = 0; k < items; k ++) { \
         out[k] = *(&(((stype *)baseptr)[i].field) + k); \
     } \
 }
 #define SIMPLE_SETTER(name, field, type, items, stype) \
-static void name(int i, type * out, void * baseptr) { \
+static void name(int i, type * out, void * baseptr, void * slotptr) { \
     int k; \
     for(k = 0; k < items; k ++) { \
         *(&(((stype *)baseptr)[i].field) + k) = out[k]; \

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -5,8 +5,8 @@
 #include "bigfile.h"
 #include "partmanager.h"
 
-typedef void (*property_getter) (int i, void * result);
-typedef void (*property_setter) (int i, void * target);
+typedef void (*property_getter) (int i, void * result, void * baseptr);
+typedef void (*property_setter) (int i, void * target, void * baseptr);
 typedef int (*petaio_selection) (int i);
 
 typedef struct IOTableEntry {
@@ -93,32 +93,26 @@ void io_register_io_block(char * name,
  * field: for example, P[i].Pos[0].
  *     i can be used to refer to the index of the particle being read.
  *
- * type:  a C type descr, float / double / int, it descirbes the
+ * type:  a C type descr, float / double / int, it describes the
  *     expected format of the output buffer; (compiler knows the format of field)
  *
  * items: number of items in one property. 1 for scalars.  (3 for pos, eg)
  *
+ * stype: type of the base pointer to use
  * */
-#define SIMPLE_GETTER(name, field, type, items) \
-static void name(int i, type * out) { \
+#define SIMPLE_GETTER(name, field, type, items, stype) \
+static void name(int i, type * out, void * baseptr) { \
     int k; \
     for(k = 0; k < items; k ++) { \
-        out[k] = *(&(field) + k); \
+        out[k] = *(&(((stype *)baseptr)[i].field) + k); \
     } \
 }
-#define SIMPLE_SETTER(name, field, type, items) \
-static void name(int i, type * out) { \
+#define SIMPLE_SETTER(name, field, type, items, stype) \
+static void name(int i, type * out, void * baseptr) { \
     int k; \
     for(k = 0; k < items; k ++) { \
-        *(&(field) + k) = out[k]; \
+        *(&(((stype *)baseptr)[i].field) + k) = out[k]; \
     } \
 }
-#define SIMPLE_PROPERTY(name, field, type, items) \
-    SIMPLE_GETTER(GT ## name , field, type, items) \
-    SIMPLE_SETTER(ST ## name , field, type, items) \
-/*A property with getters and setters that are type specific*/
-#define SIMPLE_PROPERTY_TYPE(name, ptype, field, type, items) \
-    SIMPLE_GETTER(GT ## ptype ## name , field, type, items) \
-    SIMPLE_SETTER(ST ## ptype ## name , field, type, items) \
 
 #endif

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -3,6 +3,7 @@
 
 #include <mpi.h>
 #include "bigfile.h"
+#include "partmanager.h"
 
 typedef void (*property_getter) (int i, void * result);
 typedef void (*property_setter) (int i, void * target);
@@ -51,8 +52,9 @@ void
 petaio_build_selection(int * selection,
     int * ptype_offset,
     int * ptype_count,
+    const struct particle_data * Parts,
     const int NumPart,
-    int (*select_func)(int i)
+    int (*select_func)(int i, const struct particle_data * Parts)
     );
 /*
  * Declares a io block with name (literal, not a string)

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -37,7 +37,7 @@ void destroy_io_blocks(struct IOTable * IOTable);
 
 void petaio_init();
 void petaio_alloc_buffer(BigArray * array, IOTableEntry * ent, int64_t npartLocal);
-void petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int size);
+void petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int size, struct particle_data * Parts);
 void petaio_readout_buffer(BigArray * array, IOTableEntry * ent);
 void petaio_destroy_buffer(BigArray * array);
 

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -84,11 +84,7 @@ petapm_module_init(int Nthreads)
 {
     pfft_init();
 
-#ifdef _OPENMP
     pfft_plan_with_nthreads(Nthreads);
-#else
-    #warning without OpenMP the FFTs will be single threaded!
-#endif
 
     /* initialize the MPI Datatype of pencil */
     MPI_Type_contiguous(sizeof(struct Pencil), MPI_BYTE, &MPI_PENCIL);

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -21,15 +21,15 @@
 
 char * GDB_format_particle(int i);
 
-SIMPLE_PROPERTY(GravAccel, P[i].GravAccel[0], float, 3)
-SIMPLE_PROPERTY(GravPM, P[i].GravPM[0], float, 3)
+SIMPLE_GETTER(GTGravAccel, GravAccel[0], float, 3, struct particle_data)
+SIMPLE_GETTER(GTGravPM, GravPM[0], float, 3, struct particle_data)
 
 void register_extra_blocks(struct IOTable * IOTable)
 {
     int ptype;
     for(ptype = 0; ptype < 6; ptype++) {
-        IO_REG(GravAccel,       "f4", 3, ptype, IOTable);
-        IO_REG(GravPM,       "f4", 3, ptype, IOTable);
+        IO_REG_WRONLY(GravAccel,       "f4", 3, ptype, IOTable);
+        IO_REG_WRONLY(GravPM,       "f4", 3, ptype, IOTable);
     }
 }
 

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -4,6 +4,8 @@
 #include "forcetree.h"
 #include "utils/paramset.h"
 #include "timestep.h"
+#include "partmanager.h"
+#include "slotsmanager.h"
 
 #define  METAL_YIELD       0.02	/*!< effective metal yield for star formation */
 
@@ -29,7 +31,7 @@ void cooling_and_starformation(ActiveParticles * act, ForceTree * tree);
 /*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
  * This calls the cooling routines for the current internal energy when off the equation of state, but
  * when on the equation of state calls them separately for the cold and hot gas.*/
-double get_neutral_fraction_sfreff(int i, double redshift);
+double get_neutral_fraction_sfreff(double redshift, struct particle_data * partdata, struct sph_particle_data * sphdata);
 
 /* Return whether we are using a star formation model that needs grad rho computed for the gas particles*/
 int sfr_need_to_compute_sph_grad_rho(void);

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -105,12 +105,12 @@ test_exchange(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
     slots_check_id_consistency(SlotsManager);
-    domain_test_id_uniqueness();
+    domain_test_id_uniqueness(PartManager);
 
     for(i = 0; i < PartManager->NumPart; i ++) {
         assert_true(P[i].ID % NTask == ThisTask);
@@ -129,12 +129,12 @@ test_exchange_zero_slots(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
     slots_check_id_consistency(SlotsManager);
-    domain_test_id_uniqueness();
+    domain_test_id_uniqueness(PartManager);
 
     for(i = 0; i < PartManager->NumPart; i ++) {
         assert_true (P[i].ID % NTask == ThisTask);
@@ -155,11 +155,11 @@ test_exchange_with_garbage(void **state)
     slots_mark_garbage(0); /* watch out! this propogates the garbage flag to children */
     TotNumPart -= NTask;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
-    domain_test_id_uniqueness();
+    domain_test_id_uniqueness(PartManager);
     slots_check_id_consistency(SlotsManager);
 
     for(i = 0; i < PartManager->NumPart; i ++) {
@@ -191,7 +191,7 @@ test_exchange_uneven(void **state)
     int i;
 
     /* this will trigger a slot growth on slot type 0 due to the inbalance */
-    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -201,7 +201,7 @@ test_exchange_uneven(void **state)
     }
 
     slots_check_id_consistency(SlotsManager);
-    domain_test_id_uniqueness();
+    domain_test_id_uniqueness(PartManager);
 
     for(i = 0; i < PartManager->NumPart; i ++) {
         if(P[i].Type == 0) {

--- a/libgadget/utils/mpsort.c
+++ b/libgadget/utils/mpsort.c
@@ -97,12 +97,16 @@ static void _bisect_radix(void * r, const void * r1, const void * r2, size_t rsi
     const unsigned char * u2 = r2;
     unsigned char * u = r;
     unsigned int carry = 0;
-    /* from most least significant */
+    if(dir > 0) {
+        u1 += rsize - 1;
+        u2 += rsize - 1;
+    }
+    /* from most significant */
     for(i = 0; i < rsize; i ++) {
         unsigned int tmp = (unsigned int) *u2 + *u1 + carry;
         if(tmp >= 256) carry = 1;
         else carry = 0;
-        *u = tmp;
+        *u = tmp % (UINT8_MAX+1);
         u -= dir;
         u1 -= dir;
         u2 -= dir;
@@ -195,6 +199,7 @@ static void radix_sort(void * base, size_t nmemb, size_t size,
         size_t rsize,
         void * arg) {
 
+    memset(&_cacr_d, 0, sizeof(struct crstruct));
     _setup_radix_sort(&_cacr_d, base, nmemb, size, radix, rsize, arg);
 
     qsort_openmp(_cacr_d.base, _cacr_d.nmemb, _cacr_d.size, _compute_and_compar_radix);

--- a/libgadget/utils/mpsort.c
+++ b/libgadget/utils/mpsort.c
@@ -344,11 +344,15 @@ struct piter {
 static void piter_init(struct piter * pi,
         char * Pmin, char * Pmax, int Plength,
         struct crstruct * d) {
-    pi->stable = calloc(Plength, sizeof(int));
-    pi->narrow = calloc(Plength, sizeof(int));
+    pi->stable = ta_malloc("stable", int, Plength);
+    memset(pi->stable, 0, Plength * sizeof(int));
+    pi->narrow = ta_malloc("narrow", int, Plength);
+    memset(pi->narrow, 0, Plength * sizeof(int));
     pi->d = d;
-    pi->Pleft = calloc(Plength, d->rsize);
-    pi->Pright = calloc(Plength, d->rsize);
+    pi->Pleft = ta_malloc("left", char, Plength * d->rsize);
+    memset(pi->Pleft, 0, Plength * d->rsize * sizeof(char));
+    pi->Pright = ta_malloc("right", char, Plength * d->rsize);
+    memset(pi->Pright, 0, Plength * d->rsize * sizeof(char));
     pi->Plength = Plength;
 
     int i;
@@ -358,10 +362,10 @@ static void piter_init(struct piter * pi,
     }
 }
 static void piter_destroy(struct piter * pi) {
-    free(pi->stable);
-    free(pi->narrow);
-    free(pi->Pleft);
-    free(pi->Pright);
+    myfree(pi->Pright);
+    myfree(pi->Pleft);
+    myfree(pi->narrow);
+    myfree(pi->stable);
 }
 
 /*

--- a/libgadget/utils/openmpsort.c
+++ b/libgadget/utils/openmpsort.c
@@ -1,6 +1,4 @@
-#ifdef _OPENMP
 #include <omp.h>
-#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -10,11 +10,9 @@
 #define MPI_INT64 MPI_LONG
 
 /* check the version of OPENMP */
-#if defined(_OPENMP)
 #if _OPENMP < 201107
 #error MP-Gadget requires OpenMP >= 3.1 if openmp is enabled. \
        Try to compile without openmp or use a newer compiler (gcc >= 4.7) .
-#endif
 #endif
 
 #ifdef DEBUG


### PR DESCRIPTION
The point of this PR is to avoid the double particle exchange when saving a FOF table. Instead it makes a copy of the subset of the particles in the halos, exchanges them to the right processor, saves and discards them. This has the side-effect that a FOF table save does not affect the overall particle order. To do this I had to add a lot of infrastructure to make the particle and slot tables local to their functions in the IO and exchange routines. This was enough effort that I am probably not making these fully local variables any time soon. There was also a lot of messing about with the semi-generic IO routines, which is a little ugly.

What do you think? The IO routine stuff badly needs cleaning up, but I am unsure how to do that without going full C++.