### PR TITLE
Noglobalsort

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "bigfile"]
 	path = depends/bigfile
 	url = https://github.com/rainwoodman/bigfile
-[submodule "radixsort"]
-	path = depends/mpsort
-	url = https://github.com/rainwoodman/MP-sort

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -1202,9 +1202,9 @@ int domain_determine_global_toptree(DomainDecompositionPolicy * policy,
 
     walltime_measure("/Domain/DetermineTopTree/LocalRefine/truncate");
 
-    if(*topTreeSize > 4 * policy->NTopLeaves) {
+    if(*topTreeSize > 10 * policy->NTopLeaves) {
         message(1, "local TopTree Size =%d >> expected = %d; Usually this indicates very bad imbalance, due to a giant density peak.\n",
-            *topTreeSize, 4 * policy->NTopLeaves);
+            *topTreeSize, policy->NTopLeaves);
     }
 
 #if 0

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -195,7 +195,7 @@ slots_find_next_nongarbage(int start, int used, int ptype, struct part_manager_t
 
 /*Compaction algorithm*/
 static int
-slots_gc_compact(int used, int ptype, struct part_manager_type * pman, struct slots_manager_type * sman)
+slots_gc_compact(const int used, int ptype, struct part_manager_type * pman, struct slots_manager_type * sman)
 {
     /*Find first garbage particle: can't use bisection here as not sorted.*/
     int nextgc = slots_find_next_garbage(0, used, ptype, pman, sman);
@@ -414,6 +414,9 @@ order_by_type_and_key(const void *a, const void *b)
 int
 slots_get_last_garbage(int nfirst, int nlast, int ptype, const struct part_manager_type * pman, const struct slots_manager_type * sman)
 {
+    /* Enforce that we don't get a negative number for an empty array*/
+    if(nlast < 0)
+        return 0;
     /* nfirst is always not garbage, nlast is always garbage*/
     if(GARBAGE(nfirst, ptype, pman, sman))
         return nfirst;


### PR DESCRIPTION
This PR force-disables gather sort in MP-Sort, which has problems with icc, and by default doesn't use MP-Sort during the domain decomposition. It also modifies domain so it handles uneven particle distributions with garbage better.