### PR TITLE
Issue 67 

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -603,8 +603,6 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
         O->BH_Mass += (BHP(other).Mass);
         P[other].Mass = 0;
         BHP(other).Mass = 0;
-
-        slots_mark_garbage(other, PartManager, SlotsManager);
         BHP(other).Mdot = 0;
         unlock_spinlock(other, spin);
 
@@ -792,4 +790,3 @@ decide_hsearch(double h)
         return h;
     }
 }
-

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -140,6 +140,8 @@ void drift_all_particles(inttime_t ti1, const double random_shift[3])
         if(P[i].Ti_drift != ti0)
             endrun(10, "Drift time mismatch: (ids = %ld %ld) %d != %d\n",P[0].ID, P[i].ID, ti0,  P[i].Ti_drift);
 #endif
+        if(P[i].Swallowed)
+            continue;
         real_drift_particle(i, ti1, ddrift, random_shift);
     }
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -403,11 +403,11 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         if(nc.nnext_thread >= tb.lastnode-1)
             continue;
 
-        /* Do not add garbage particles to the tree*/
-        if(P[i].IsGarbage)
+        /* Do not add garbage/swallowed particles to the tree*/
+        if(P[i].IsGarbage || P[i].Swallowed)
             continue;
-        /*First find the Node for the TopLeaf */
 
+        /*First find the Node for the TopLeaf */
         int this;
         if(inside_node(&tb.Nodes[this_acc], i)) {
             this = this_acc;

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -149,8 +149,14 @@ static PetaPMRegion * _prepare(PetaPM * pm, void * userdata, int * Nregions) {
     message(0, "max number of regions is %d\n", maxNregions);
 
     int i;
+    int numswallowed = 0;
     for(i =0; i < PartManager->NumPart; i ++) {
-        P[i].RegionInd = -1;
+        if(P[i].Swallowed==1 && P[i].Type==5){
+            P[i].RegionInd = -2;
+            numswallowed++;
+        }
+        else
+            P[i].RegionInd = -1;
     }
 
     /* now lets mark particles to their hosting region */
@@ -166,7 +172,7 @@ static PetaPMRegion * _prepare(PetaPM * pm, void * userdata, int * Nregions) {
         }
     }
     /* All particles shall have been processed just once. Otherwise we die */
-    if(numpart != PartManager->NumPart) {
+    if((numpart+numswallowed) != PartManager->NumPart) {
         endrun(1, "Processed only %d particles out of %d\n", numpart, PartManager->NumPart);
     }
     for(r =0; r < *Nregions; r++) {
@@ -474,4 +480,3 @@ static void readout_force_y(PetaPM * pm, int i, double * mesh, double weight) {
 static void readout_force_z(PetaPM * pm, int i, double * mesh, double weight) {
     P[i].GravPM[2] += weight * mesh[0];
 }
-

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -16,7 +16,6 @@ struct particle_data
 
     double Pos[3];   /*!< particle position at its current time */
     float Mass;     /*!< particle mass */
-    int Swallowed; /* True if the particle is being swallowed; used in BH to determine swallower and swallowee;*/
 
     struct {
         /* particle type.  0=gas, 1=halo, 2=disk, 3=bulge, 4=stars, 5=bndry */
@@ -24,6 +23,7 @@ struct particle_data
 
         unsigned int IsGarbage            :1; /* True for a garbage particle. readonly: Use slots_mark_garbage to mark this.*/
         unsigned int DensityIterationDone :1; /* True if the density-like iterations already finished; */
+        unsigned int Swallowed            :1; /* True if the particle is being swallowed; used in BH to determine swallower and swallowee;*/
         unsigned int HeIIIionized         :1; /*True if the particle has undergone helium reionization*/
         unsigned char Generation; /* How many particles it has spawned; used to generate unique particle ID.
                                      may wrap around with too many SFR/BH if a feedback model goes rogue */

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -16,6 +16,7 @@ struct particle_data
 
     double Pos[3];   /*!< particle position at its current time */
     float Mass;     /*!< particle mass */
+    int Swallowed; /* True if the particle is being swallowed; used in BH to determine swallower and swallowee;*/
 
     struct {
         /* particle type.  0=gas, 1=halo, 2=disk, 3=bulge, 4=stars, 5=bndry */
@@ -23,7 +24,6 @@ struct particle_data
 
         unsigned int IsGarbage            :1; /* True for a garbage particle. readonly: Use slots_mark_garbage to mark this.*/
         unsigned int DensityIterationDone :1; /* True if the density-like iterations already finished; */
-        unsigned int Swallowed            :1; /* True if the particle is being swallowed; used in BH to determine swallower and swallowee;*/
         unsigned int HeIIIionized         :1; /*True if the particle has undergone helium reionization*/
         unsigned char Generation; /* How many particles it has spawned; used to generate unique particle ID.
                                      may wrap around with too many SFR/BH if a feedback model goes rogue */

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -921,8 +921,6 @@ void register_io_blocks(struct IOTable * IOTable) {
     IO_REG_WRONLY(NeutralHydrogenFraction, "f4", 1, 0, IOTable);
     /* Marks whether a particle has been HeIII ionized yet*/
     IO_REG_NONFATAL(HeIIIIonized, "u1", 1, 0, IOTable);
-    /* Marks whether a BH particle has been swallowed*/
-    IO_REG_NONFATAL(Swallowed, "u1", 1, 0, IOTable);
 
     /* SF */
     IO_REG_WRONLY(StarFormationRate, "f4", 1, 0, IOTable);
@@ -944,6 +942,8 @@ void register_io_blocks(struct IOTable * IOTable) {
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);
+    /* Marks whether a BH particle has been swallowed*/
+    IO_REG_NONFATAL(Swallowed, "u1", 1, 5, IOTable);
 
     /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -820,6 +820,7 @@ SIMPLE_PROPERTY_PI(BlackholeAccretionRate, Mdot, float, 1, struct bh_particle_da
 SIMPLE_PROPERTY_PI(BlackholeProgenitors, CountProgs, float, 1, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeMinPotPos, MinPotPos[0], double, 3, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeJumpToMinPot, JumpToMinPot, int, 1, struct bh_particle_data)
+SIMPLE_PROPERTY(BlackholeSwallowed, Swallowed, int, 1)
 
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, GrNr, uint32_t, 1, struct particle_data)
@@ -930,6 +931,7 @@ void register_io_blocks(struct IOTable * IOTable) {
     IO_REG(BlackholeProgenitors,   "i4", 1, 5, IOTable);
     IO_REG(BlackholeMinPotPos, "f8", 3, 5, IOTable);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5, IOTable);
+    IO_REG(BlackholeSwallowed,   "i4", 1, 5, IOTable);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);
@@ -977,4 +979,3 @@ void destroy_io_blocks(struct IOTable * IOTable) {
     myfree(IOTable->ent);
     IOTable->allocated = 0;
 }
-

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -820,7 +820,6 @@ SIMPLE_PROPERTY_PI(BlackholeAccretionRate, Mdot, float, 1, struct bh_particle_da
 SIMPLE_PROPERTY_PI(BlackholeProgenitors, CountProgs, float, 1, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeMinPotPos, MinPotPos[0], double, 3, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeJumpToMinPot, JumpToMinPot, int, 1, struct bh_particle_data)
-SIMPLE_PROPERTY(BlackholeSwallowed, Swallowed, int, 1)
 
 /*This is only used if FoF is enabled*/
 SIMPLE_GETTER(GTGroupID, GrNr, uint32_t, 1, struct particle_data)
@@ -857,6 +856,15 @@ static void GTHeIIIIonized(int i, unsigned char * out, void * baseptr, void * sm
 static void STHeIIIIonized(int i, unsigned char * out, void * baseptr, void * smanptr) {
     struct particle_data * part = (struct particle_data *) baseptr;
     part[i].HeIIIionized = *out;
+}
+static void GTSwallowed(int i, unsigned char * out, void * baseptr, void * smanptr) {
+    struct particle_data * part = (struct particle_data *) baseptr;
+    *out = part[i].Swallowed;
+}
+
+static void STSwallowed(int i, unsigned char * out, void * baseptr, void * smanptr) {
+    struct particle_data * part = (struct particle_data *) baseptr;
+    part[i].Swallowed = *out;
 }
 
 static int order_by_type(const void *a, const void *b)
@@ -913,6 +921,8 @@ void register_io_blocks(struct IOTable * IOTable) {
     IO_REG_WRONLY(NeutralHydrogenFraction, "f4", 1, 0, IOTable);
     /* Marks whether a particle has been HeIII ionized yet*/
     IO_REG_NONFATAL(HeIIIIonized, "u1", 1, 0, IOTable);
+    /* Marks whether a BH particle has been swallowed*/
+    IO_REG_NONFATAL(Swallowed, "u1", 1, 0, IOTable);
 
     /* SF */
     IO_REG_WRONLY(StarFormationRate, "f4", 1, 0, IOTable);
@@ -931,7 +941,6 @@ void register_io_blocks(struct IOTable * IOTable) {
     IO_REG(BlackholeProgenitors,   "i4", 1, 5, IOTable);
     IO_REG(BlackholeMinPotPos, "f8", 3, 5, IOTable);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5, IOTable);
-    IO_REG(BlackholeSwallowed,   "i4", 1, 5, IOTable);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -756,7 +756,8 @@ pm_iterate_one(PetaPM * pm,
     double Res[3]; /* residual*/
     double * Pos = POS(i);
     int RegionInd = REGION(i)[0];
-
+    
+    /* Asserts that the swallowed particles are not considered (region -2) */
     if(RegionInd<0)
         return;
 

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -757,6 +757,9 @@ pm_iterate_one(PetaPM * pm,
     double * Pos = POS(i);
     int RegionInd = REGION(i)[0];
 
+    if(RegionInd<0)
+        return;
+
     PetaPMRegion * region = &regions[RegionInd];
     for(k = 0; k < 3; k++) {
         double tmp = Pos[k] / pm->CellSize;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -161,8 +161,8 @@ cooling_and_starformation(ActiveParticles * act, ForceTree * tree)
         {
             /*Use raw particle number if active_set is null, otherwise use active_set*/
             const int p_i = act->ActiveParticle ? act->ActiveParticle[i] : i;
-            /* Skip non-gas or garbage particles */
-            if(P[p_i].Type != 0 || P[p_i].IsGarbage || P[p_i].Mass <= 0)
+            /* Skip non-gas, swallowed, or garbage particles */
+            if(P[p_i].Type != 0 || P[p_i].IsGarbage || P[p_i].Swallowed || P[p_i].Mass <= 0)
                 continue;
 
             int shall_we_star_form = 0;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -153,7 +153,7 @@ find_timesteps(const ActiveParticles * act, inttime_t Ti_Current)
         {
             /* Because we don't GC on short timesteps, there can be garbage here.
              * Avoid making it active. */
-            if(P[i].IsGarbage)
+            if(P[i].IsGarbage || P[i].Swallowed)
                 continue;
             inttime_t dti = get_timestep_ti(i, dti_max);
             if(dti < dti_min)
@@ -169,7 +169,7 @@ find_timesteps(const ActiveParticles * act, inttime_t Ti_Current)
     {
         const int i = get_active_particle(act, pa);
 
-        if(P[i].IsGarbage)
+        if(P[i].IsGarbage || P[i].Swallowed)
             continue;
 
         if(P[i].Ti_kick != P[i].Ti_drift) {
@@ -645,7 +645,7 @@ int rebuild_activelist(ActiveParticles * act, inttime_t Ti_Current, int NumCurre
     {
         const int bin = P[i].TimeBin;
         const int tid = omp_get_thread_num();
-        if(P[i].IsGarbage)
+        if(P[i].IsGarbage || P[i].Swallowed)
             continue;
         if(act->ActiveParticle && is_timebin_active(bin, Ti_Current))
         {
@@ -766,4 +766,3 @@ static void print_timebin_statistics(int NumCurrentTiStep, int * TimeBinCountTyp
         tot_type[0], tot_type[1], tot_type[2], tot_type[3], tot_type[4], tot_type[5], tot);
 
 }
-


### PR DESCRIPTION
Changes to note:
1. Removed garbage collection from blackhole.c
2. Swallowed type 5's are not allowed to interact both by applying checks in drift, sfc, timestep and by removal from the force tree.
3. 'Swallowed' variable moved within partmanager.h to satisfy output generation. Petaio forced my hand here as it was not able to call the 'Swallowed' property otherwise. Would appreciate your opinion as to whether this is alright -- in checking, I did not find any adverse effects to such a change.
4. Added Swallowed to output snapshot
5. Set swallowed particles to a region of -2 and asserted that petapm ignore such regions. This was necessary to satisfy checks within gravpm