### PR TITLE
Windmodelfix

### DIFF
--- a/examples/heliumreion/paramfile.gadget
+++ b/examples/heliumreion/paramfile.gadget
@@ -25,7 +25,7 @@ DensityIndependentSphOn = 1
 RadiationOn = 1
 MassiveNuLinRespOn = 0
 WindOn = 1
-WindModel = ofjt10,decouple
+WindModel = ofjt10,isotropic
 MetalCoolFile = ../cooling_metal_UVB
 SnapshotWithFOF = 1
 #--------------------Helium Reionization----------------

--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -86,7 +86,7 @@ TempClouds = 1000.0   #  in Kelvin
 FactorSN = 0.1
 FactorEVP = 1000.0
 
-WindModel = ofjt10,decouple
+WindModel = ofjt10,isotropic
 WindEfficiency = 2.0
 WindEnergyFraction = 1.0
 WindSigma0 = 353.0 #km/s

--- a/examples/small/paramfile.gadget
+++ b/examples/small/paramfile.gadget
@@ -88,7 +88,7 @@ FactorSN = 0.1
 FactorEVP = 1000.0
 
 WindOn = 1
-WindModel = ofjt10,decouple
+WindModel = ofjt10,isotropic
 WindEfficiency = 2.0
 WindEnergyFraction = 1.0
 WindSigma0 = 353.0 #km/s

--- a/examples/travis/paramfile.gadget
+++ b/examples/travis/paramfile.gadget
@@ -50,4 +50,4 @@ CritOverDensity = 0   #  overdensity threshold value
 
 QuickLymanAlphaProbability = 0.001 # Set to 1.0 to turn dense gas directly into stars.
 WindOn = 1
-WindModel = ofjt10
+WindModel = ofjt10,isotropic

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -16,6 +16,7 @@
 #include "hydra.h"
 #include "density.h"
 #include "sfr_eff.h"
+#include "winds.h"
 #include "walltime.h"
 /*! \file blackhole.c
  *  \brief routines for gas accretion onto black holes, and black hole mergers
@@ -442,7 +443,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     }
 
      /* BH does not accrete wind */
-    if(P[other].Type == 0 && SPHP(other).DelayTime > 0) return;
+    if(winds_is_particle_decoupled(other)) return;
 
     /* Find the black hole potential minimum. */
     if(r2 < iter->accretion_kernel.HH)
@@ -594,7 +595,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
     if(P[other].ID == I->ID) return;
 
      /* BH does not accrete wind */
-    if(P[other].Type == 0 && SPHP(other).DelayTime > 0)
+    if(winds_is_particle_decoupled(other))
         return;
 
     struct SpinLocks * spin = BH_GET_PRIV(lv->tw)->spin;

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -14,7 +14,6 @@
 #include "timefac.h"
 #include "slotsmanager.h"
 #include "timestep.h"
-#include "winds.h"
 #include "utils.h"
 
 #define MAXITER 400
@@ -114,8 +113,6 @@ typedef struct
     TreeWalkQueryBase base;
     double Vel[3];
     MyFloat Hsml;
-    /*Wind model*/
-    MyFloat DelayTime;
     int Type;
 } TreeWalkQueryDensity;
 
@@ -387,14 +384,12 @@ density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw)
         I->Vel[0] = P[place].Vel[0];
         I->Vel[1] = P[place].Vel[1];
         I->Vel[2] = P[place].Vel[2];
-        I->DelayTime = 0;
     }
     else
     {
         I->Vel[0] = SphP_scratch->VelPred[3 * P[place].PI];
         I->Vel[1] = SphP_scratch->VelPred[3 * P[place].PI + 1];
         I->Vel[2] = SphP_scratch->VelPred[3 * P[place].PI + 2];
-        I->DelayTime = SPHP(place).DelayTime;
     }
 
 }

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -16,6 +16,7 @@
 #include "sfr_eff.h"
 #include "blackhole.h"
 #include "domain.h"
+#include "winds.h"
 
 #include "forcetree.h"
 #include "treewalk.h"
@@ -587,17 +588,14 @@ static void add_particle_to_group(struct Group * gdst, int i, double BoxSize, in
     }
     /*This used to depend on black holes being enabled, but I do not see why.
      * I think because it is only useful for seeding*/
-    if(P[index].Type == 0)
-    {
-        /* make bh in non wind gas on bh wind*/
-        if(SPHP(index).DelayTime <= 0)
-            if(SPHP(index).Density > gdst->MaxDens)
-            {
-                gdst->MaxDens = SPHP(index).Density;
-                gdst->seed_index = index;
-                gdst->seed_task = ThisTask;
-            }
-    }
+    /* Don't make bh in wind.*/
+    if(P[index].Type == 0 && !winds_is_particle_decoupled(index))
+        if(SPHP(index).Density > gdst->MaxDens)
+        {
+            gdst->MaxDens = SPHP(index).Density;
+            gdst->seed_index = index;
+            gdst->seed_task = ThisTask;
+        }
 
     int d1, d2;
     double xyz[3];

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -446,7 +446,7 @@ sfreff_on_eeqos(const struct sph_particle_data * sph)
         flag = 0;
 
     if(sph->DelayTime > 0)
-        flag = 0;		/* only normal cooling for particles in the wind */
+        flag = 0;   /* only normal cooling for particles in the wind */
 
     return flag;
 }

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -192,7 +192,7 @@ dloga_from_dti(inttime_t dti)
         sign = -1;
     }
     if((unsigned int) dti > TIMEBASE) {
-        endrun(1, "Requesting dti larger than TIMEBASE\n");
+        endrun(1, "Requesting dti %d larger than TIMEBASE %u\n", dti, TIMEBASE);
     }
     return Dloga * dti * sign;
 }

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -507,16 +507,22 @@ get_timestep_ti(const int p, const inttime_t dti_max)
     */
     if(dti <= 1 || dti > (inttime_t) TIMEBASE)
     {
-        message(1, "Bad timestep (%x) assigned! ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g)\n",
+        if(P[p].Type == 0)
+            message(1, "Bad timestep (%x) assigned! ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g) hydro-frc=(%g|%g|%g) dens=%g hsml=%g egyrho=%g Entropy=%g, dtEntropy=%g maxsignal=%g\n",
+                dti, P[p].ID, P[p].Type, dloga, dti_max,
+                P[p].Pos[0], P[p].Pos[1], P[p].Pos[2],
+                P[p].GravAccel[0], P[p].GravAccel[1], P[p].GravAccel[2],
+                P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2],
+                SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2],
+                SPHP(p).Density, P[p].Hsml, SPH_EOMDensity(p),
+                SPHP(p).Entropy, SPHP(p).DtEntropy, SPHP(p).MaxSignalVel);
+        else
+            message(1, "Bad timestep (%x) assigned! ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g)\n",
                 dti, P[p].ID, P[p].Type, dloga, dti_max,
                 P[p].Pos[0], P[p].Pos[1], P[p].Pos[2],
                 P[p].GravAccel[0], P[p].GravAccel[1], P[p].GravAccel[2],
                 P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2]
               );
-        if(P[p].Type == 0)
-            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n",
-                    SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, SPH_EOMDensity(p),
-                    SPHP(p).DhsmlEgyDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy);
     }
 
     return dti;

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -346,7 +346,7 @@ sfr_wind_weight_ngbiter(TreeWalkQueryWind * I,
 {
     /* this evaluator walks the tree and sums the total mass of surrounding gas
      * particles as described in VS08. */
-    /* it also calculates the DM dispersion of the nearest 40 DM paritlces */
+    /* it also calculates the DM dispersion of the nearest 40 DM particles */
     if(iter->base.other == -1) {
         double hsearch = DMAX(I->Hsml, I->DMRadius);
         iter->base.Hsml = hsearch;
@@ -470,15 +470,12 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
         endrun(1, "WindModel = 0x%X is strange. This shall not happen.\n", wind_params.WindModel);
     }
 
-    //double wk = density_kernel_wk(&kernel, r);
-
     /* in this case the particle is already locked by the tree walker */
     /* we may want to add another lock to avoid this. */
     if(P[other].ID != I->base.ID)
         lock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
 
-    double wk = 1.0;
-    double p = windeff * wk * I->Mass / I->TotalWeight;
+    double p = windeff * I->Mass / I->TotalWeight;
     double random = get_random_number(I->base.ID + P[other].ID);
     if (random < p) {
         adjust_wind_velocity(other, v, I->Vmean);

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -71,7 +71,10 @@ static struct winddata {
 
 #define WINDP(i) Winddata[P[i].PI]
 
-/*Set the parameters of the domain module*/
+/*Set the parameters of the wind module.
+ ofjt10 is Okamoto, Frenk, Jenkins and Theuns 2010 https://arxiv.org/abs/0909.0265
+ VS08 is Dalla Vecchia & Schaye 2008 https://arxiv.org/abs/0801.2770
+ SH03 is Springel & Hernquist 2003 https://arxiv.org/abs/astro-ph/0206395*/
 void set_winds_params(ParameterSet * ps)
 {
     int ThisTask;


### PR DESCRIPTION
The only really important commit is 2bb1165 which changes the wind model to be less timing dependent: this should help the code give more similar answers in threaded mode vs. non-threaded mode for the hydro run. It does this by allowing particles to be made wind twice. Also switch some of the examples to isotropic winds, which modern practice shows is simpler and somewhat cleaner.