### PR TITLE
Exchangefix

### DIFF
--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -210,7 +210,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
     myfree(OldTopLeaves);
     myfree(OldTopNodes);
 
-    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, ddecomp->DomainComm))
+    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, 10000, ddecomp->DomainComm))
         endrun(1929,"Could not exchange particles\n");
 
     /*Do a garbage collection so that the slots are ordered
@@ -237,7 +237,7 @@ void domain_maintain(DomainDecomp * ddecomp)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, ddecomp->DomainComm)) {
+    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, 10000, ddecomp->DomainComm)) {
         domain_decompose_full(ddecomp);
         return;
     }

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -34,12 +34,12 @@ typedef struct {
     /*List of particles to exchange*/
     int * ExchangeList;
     /*Total number of exchanged particles*/
-    int nexchange;
+    size_t nexchange;
     /*Number of garbage particles*/
     int ngarbage;
     /* last particle in current batch of the exchange.
      * Exchange stops when last == nexchange.*/
-    int last;
+    size_t last;
     ExchangePartCache * layouts;
 } ExchangePlan;
 /*
@@ -49,7 +49,7 @@ typedef struct {
 */
 static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, MPI_Comm Comm);
 static void domain_build_plan(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman);
-static int domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pman, const struct slots_manager_type * sman);
+static size_t domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pman, const struct slots_manager_type * sman);
 static void domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman, MPI_Comm Comm);
 
 /* This function builts the count/displ arrays from
@@ -390,11 +390,11 @@ domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_us
 }
 
 /*Find how many particles we can transfer in current exchange iteration*/
-static int
+static size_t
 domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pman, const struct slots_manager_type * sman)
 {
-    int n, ptype;
-    size_t nlimit = mymalloc_freebytes();
+    int ptype;
+    size_t n, nlimit = mymalloc_freebytes();
     /* Limit us to 4GB exchanges to help out MPI*/
     if (nlimit > 1024*1024*2030)
         nlimit = 1024*1024*2030;
@@ -446,7 +446,8 @@ domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pma
 static void
 domain_build_plan(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman)
 {
-    int ptype, n;
+    int ptype;
+    size_t n;
 
     memset(plan->toGo, 0, sizeof(plan->toGo[0]) * plan->NTask);
 

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -391,6 +391,9 @@ domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pma
 {
     int n, ptype;
     size_t nlimit = mymalloc_freebytes();
+    /* Limit us to 4GB exchanges to help out MPI*/
+    if (nlimit > 1024*1024*2030)
+        nlimit = 1024*1024*2030;
 
     if (nlimit <  4096 * 2 + plan->NTask * 2 * sizeof(MPI_Request))
         endrun(1, "Not enough memory free to store requests!\n");

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -135,7 +135,12 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
         iter++;
     }
     while(MPIU_Any(plan.last < plan.nexchange, Comm));
-
+#ifdef DEBUG
+    domain_build_exchange_list(layoutfunc, layout_userdata, &plan, pman, Comm);
+    if(plan.nexchange > 0)
+        endrun(5, "Still have %ld particles in exchange list\n", plan.nexchange);
+    myfree(plan.ExchangeList);
+#endif
     myfree(plan.toGetOffset);
     myfree(plan.toGet);
     myfree(plan.toGoOffset);

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -73,7 +73,7 @@ _transpose_plan_entries(ExchangePlanEntry * entries, int * count, int ptype, int
 }
 
 /*Plan and execute a domain exchange, also performing a garbage collection if requested*/
-int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, MPI_Comm Comm) {
+int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm) {
     int64_t sumtogo;
     int failure = 0;
 
@@ -101,6 +101,8 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
     int iter = 0;
 
     do {
+        if(iter >= maxiter)
+            endrun(5, "Too many exchange iterations\n");
         domain_build_exchange_list(layoutfunc, layout_userdata, &plan, pman, Comm);
 
         /*Exit early if nothing to do*/

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -85,8 +85,6 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
 
     /*Structure for building a list of particles that will be exchanged*/
     ExchangePlan plan;
-    plan.last = 0;
-    plan.nexchange = pman->NumPart;
 
     MPI_Comm_size(Comm, &plan.NTask);
     /*! toGo[0][task*NTask + partner] gives the number of particles in task 'task'
@@ -351,7 +349,8 @@ static void
 domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman, MPI_Comm Comm)
 {
     int i;
-    int numthreads = omp_get_max_threads();
+    size_t numthreads = omp_get_max_threads();
+    plan->nexchange = pman->NumPart;
     /*static schedule below so we only need this much memory*/
     int narr = plan->nexchange/numthreads+2;
     plan->ExchangeList = mymalloc2("exchangelist", sizeof(int) * narr * numthreads);

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -6,7 +6,7 @@
 
 typedef int (*ExchangeLayoutFunc) (int p, const void * userdata);
 
-int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, MPI_Comm Comm);
+int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm);
 void domain_test_id_uniqueness(struct part_manager_type * pman);
 
 #endif

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -281,7 +281,7 @@ static void fof_distribute_particles(struct part_manager_type * halo_pman, struc
 #endif
 
     /* sort SPH and Others independently */
-    if(domain_exchange(fof_sorted_layout, targettask, 1, halo_pman, halo_sman, Comm))
+    if(domain_exchange(fof_sorted_layout, targettask, 1, halo_pman, halo_sman, 1, Comm))
         endrun(1930,"Could not exchange particles\n");
 
     myfree(targettask);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -582,7 +582,7 @@ set_units(void)
 
     message(0, "Hubble (internal units) = %g\n", All.CP.Hubble);
     message(0, "G (internal units) = %g\n", All.G);
-    message(0, "UnitLengh_in_cm = %g \n", All.UnitLength_in_cm);
+    message(0, "UnitLength_in_cm = %g \n", All.UnitLength_in_cm);
     message(0, "UnitMass_in_g = %g \n", All.UnitMass_in_g);
     message(0, "UnitTime_in_s = %g \n", All.UnitTime_in_s);
     message(0, "UnitVelocity_in_cm_per_s = %g \n", All.UnitVelocity_in_cm_per_s);

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -390,8 +390,8 @@ add_injected_BH_energy(double unew, double injected_BH_energy, double mass)
 
     double temp = u_to_temp_fac * unew;
 
-    if(temp > 1.0e9)
-        unew = 1.0e9 / u_to_temp_fac;
+    if(temp > 1.0e8)
+        unew = 1.0e8 / u_to_temp_fac;
 
     return unew;
 }

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -105,7 +105,7 @@ test_exchange(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager,10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -129,7 +129,7 @@ test_exchange_zero_slots(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -155,7 +155,7 @@ test_exchange_with_garbage(void **state)
     slots_mark_garbage(0, PartManager, SlotsManager); /* watch out! this propogates the garbage flag to children */
     TotNumPart -= NTask;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -191,7 +191,7 @@ test_exchange_uneven(void **state)
     int i;
 
     /* this will trigger a slot growth on slot type 0 due to the inbalance */
-    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, PartManager, SlotsManager, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 


### PR DESCRIPTION
- Limits the exchange to 2GB, to make MPI on Frontera happy
- Limits the BH heating to 10^8 K to make the timestepping happier
- Fixes multiple exchange iterations
- Enforces that fof petaio cannot do multiple iterations (it is not implemented). 