### PR TITLE
Batchedtree

### DIFF
--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -1295,7 +1295,6 @@ void fof_seed(FOFGroups * fof, ForceTree * tree, ActiveParticles * act, MPI_Comm
     if(Nimport + SlotsManager->info[5].size > SlotsManager->info[5].maxsize)
     {
         struct NODE * nodes_base_tmp=NULL;
-        int *Nextnode_tmp=NULL;
         int *Father_tmp=NULL;
         int *ActiveParticle_tmp=NULL;
         if(force_tree_allocated(tree)) {
@@ -1305,9 +1304,6 @@ void fof_seed(FOFGroups * fof, ForceTree * tree, ActiveParticles * act, MPI_Comm
             Father_tmp = mymalloc2("Father_tmp", PartManager->MaxPart * sizeof(int));
             memmove(Father_tmp, tree->Father, PartManager->MaxPart * sizeof(int));
             myfree(tree->Father);
-            Nextnode_tmp = mymalloc2("Nextnode_tmp", tree->Nnextnode * sizeof(int));
-            memmove(Nextnode_tmp, tree->Nextnode, tree->Nnextnode * sizeof(int));
-            myfree(tree->Nextnode);
         }
         /* This is only called on a PM step, so the condition should never be true*/
         if(act->ActiveParticle) {
@@ -1331,9 +1327,6 @@ void fof_seed(FOFGroups * fof, ForceTree * tree, ActiveParticles * act, MPI_Comm
             myfree(ActiveParticle_tmp);
         }
         if(force_tree_allocated(tree)) {
-            tree->Nextnode = mymalloc("Nextnode", tree->Nnextnode * sizeof(int));
-            memmove(tree->Nextnode, Nextnode_tmp, tree->Nnextnode * sizeof(int));
-            myfree(Nextnode_tmp);
             tree->Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
             memmove(tree->Father, Father_tmp, PartManager->MaxPart * sizeof(int));
             myfree(Father_tmp);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -738,14 +738,10 @@ force_update_particle_node(int no, int sib, const ForceTree * tree, const int Hy
     if(tree->Nodes[no].f.ChildType != PARTICLE_NODE_TYPE)
         endrun(3, "force_update_particle_node called on node %d of wrong type!\n", no);
     /*Last value of tails is the return value of this function*/
-    int j, suns[NMAXCHILD];
+    int j;
 
-    /* this "backup" is necessary because the nextnode
-     * entry will overwrite one element (union!) */
-    int noccupied = tree->Nodes[no].u.s.noccupied;
-    for(j = 0; j < noccupied; j++) {
-        suns[j] = tree->Nodes[no].u.s.suns[j];
-    }
+    const int noccupied = tree->Nodes[no].u.s.noccupied;
+    int * suns = tree->Nodes[no].u.s.suns;
 
     /*After this point the suns array is invalid!*/
     force_zero_union(&tree->Nodes[no]);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1196,6 +1196,7 @@ ForceTree force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp)
     message(0, "Allocating memory for %d tree-nodes (MaxPart=%d).\n", maxnodes, maxpart);
     tb.Nnextnode = maxpart + ddecomp->NTopNodes;
     tb.Nextnode = (int *) mymalloc("Nextnode", bytes = tb.Nnextnode * sizeof(int));
+    allbytes += bytes;
     tb.Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));
     allbytes += bytes;
     tb.Nodes_base = (struct NODE *) mymalloc("Nodes_base", bytes = (maxnodes + 1) * sizeof(struct NODE));
@@ -1208,7 +1209,6 @@ ForceTree force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp)
     tb.NTopLeaves = ddecomp->NTopLeaves;
     tb.TopLeaves = ddecomp->TopLeaves;
 
-    allbytes += bytes;
     message(0, "Allocated %g MByte for BH-tree, (presently allocated %g MB)\n",
          allbytes / (1024.0 * 1024.0),
          mymalloc_usedbytes() / (1024.0 * 1024.0));

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -274,6 +274,8 @@ modify_internal_node(int parent, int subnode, int p_toplace, const ForceTree tb)
 {
     tb.Father[p_toplace] = parent;
     tb.Nodes[parent].u.s.suns[subnode] = p_toplace;
+    if(subnode == 0)
+        tb.Nodes[parent].u.d.nextnode = tb.Nodes[parent].u.s.suns[0];
     return 0;
 }
 
@@ -320,6 +322,16 @@ create_new_node_layer(int firstparent, int p_toplace,
             /*Set father of new node*/
             nfreep->father = parent;
         }
+        /* Set nextnode and sibling for the new rank. Since empty at this point, point both of them onwards.*/
+        nprnt->u.d.nextnode = nprnt->u.s.suns[0];
+        for(i=0; i<7; i++) {
+            int child = nprnt->u.s.suns[i];
+            struct NODE * nchild = &tb.Nodes[child];
+            nchild->u.d.nextnode = nchild->u.d.sibling = nprnt->u.s.suns[i+1];
+        }
+        /* Final child needs special handling: we don't use its nextnode, so set to -1.*/
+        tb.Nodes[nprnt->u.s.suns[7]].u.d.nextnode = -1;
+
         /*Initialize the remaining entries to empty*/
         for(i=8; i<NMAXCHILD;i++)
             nprnt->u.s.suns[i] = -1;
@@ -584,6 +596,7 @@ force_insert_pseudo_particles(const ForceTree * tree, const DomainDecomp * ddeco
             tree->Nodes[index].f.ChildType = PSEUDO_NODE_TYPE;
             /* This node points to the pseudo particle*/
             tree->Nodes[index].u.d.nextnode = firstpseudo + i;
+            tree->Nodes[index].u.s.suns[0] = firstpseudo + i;
         }
     }
 }
@@ -678,7 +691,6 @@ force_update_particle_node(int no, int sib, const ForceTree * tree, const int Hy
     int * suns = tree->Nodes[no].u.s.suns;
 
     tree->Nodes[no].u.d.sibling = sib;
-    tree->Nodes[no].u.d.nextnode = suns[0];
 
     /*Now we do the moments*/
     for(j = 0; j < noccupied; j++) {
@@ -745,14 +757,14 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
             childcnt++;
     }
 
-    /* Nextnode for this node is the first non-zero child*/
-    /*First do the children*/
-    for(j = 0; j < 8; j++) {
-        if(suns[j] >= 0) {
-            tree->Nodes[no].u.d.nextnode = suns[j];
-            break;
+    /* Reset nextnode to point to a new child if needed.*/
+    if(childcnt < 8)
+        for(j = 0; j < 8; j++) {
+            if(suns[j] >= 0) {
+                tree->Nodes[no].u.d.nextnode = suns[j];
+                break;
+            }
         }
-    }
 
     /*First do the children*/
     for(j = 0; j < 8; j++)
@@ -965,7 +977,7 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
     if(!tree->Nodes[no].f.InternalTopLevel)
         return;
 
-    p = tree->Nodes[no].u.d.nextnode;
+    p = tree->Nodes[no].u.s.suns[0];
 
     /* since we are dealing with top-level nodes, we know that there are 8 consecutive daughter nodes */
     for(j = 0; j < 8; j++)

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -78,13 +78,18 @@ force_tree_eh_slots_fork(EIBase * event, void * userdata)
     EISlotsFork * ev = (EISlotsFork*) event;
     int parent = ev->parent;
     int child = ev->child;
-    int no;
     ForceTree * tree = (ForceTree * ) userdata;
-    no = tree->Nextnode[parent];
-    tree->Nextnode[parent] = child;
-    tree->Nextnode[child] = no;
-    tree->Father[child] = tree->Father[parent];
-
+    int no = force_get_father(parent, tree);
+    struct NODE * nop = &tree->Nodes[no];
+    /* FIXME: We lose particles if the node is full.
+     * At the moment this does not matter, because
+     * the only new particles are stars, which do not
+     * participate in the SPH tree walk.*/
+    if(nop->u.s.noccupied < NMAXCHILD) {
+       nop->u.s.suns[nop->u.s.noccupied-1] = child;
+        nop->u.s.noccupied++;
+    }
+    tree->Father[child] = no;
     return 0;
 }
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -590,7 +590,6 @@ force_insert_pseudo_particles(const ForceTree * tree, const DomainDecomp * ddeco
             if(tree->Nodes[index].u.s.noccupied != 0)
                 endrun(5, "In node %d, overwriting %d child particles (i = %d etc) with pseudo particle %d\n",
                        index, tree->Nodes[index].u.s.noccupied, tree->Nodes[index].u.s.suns[0], i);
-            tree->Nodes[index].u.s.suns[0] = firstpseudo + i;
             force_zero_union(&tree->Nodes[index]);
             tree->Nodes[index].f.ChildType = PSEUDO_NODE_TYPE;
             /* This node points to the pseudo particle*/

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1142,9 +1142,6 @@ ForceTree force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp)
     ForceTree tb;
 
     message(0, "Allocating memory for %d tree-nodes (MaxPart=%d).\n", maxnodes, maxpart);
-    tb.Nnextnode = maxpart + ddecomp->NTopNodes;
-    tb.Nextnode = (int *) mymalloc("Nextnode", bytes = tb.Nnextnode * sizeof(int));
-    allbytes += bytes;
     tb.Father = (int *) mymalloc("Father", bytes = (maxpart) * sizeof(int));
     allbytes += bytes;
     tb.Nodes_base = (struct NODE *) mymalloc("Nodes_base", bytes = (maxnodes + 1) * sizeof(struct NODE));
@@ -1174,6 +1171,5 @@ void force_tree_free(ForceTree * tree)
         return;
     myfree(tree->Nodes_base);
     myfree(tree->Father);
-    myfree(tree->Nextnode);
     tree->tree_allocated_flag = 0;
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -743,11 +743,8 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
 #endif
 
     /*Last value of tails is the return value of this function*/
-    int j, suns[8], tails[8];
-
-    /* this "backup" is necessary because the nextnode
-     * entry will overwrite one element (union!) */
-    memcpy(suns, tree->Nodes[no].u.s.suns, 8 * sizeof(int));
+    int j, tails[8];
+    int * suns = tree->Nodes[no].u.s.suns;
 
     int childcnt = 0;
     /* Remove any empty children.
@@ -799,7 +796,6 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
             tails[j] = force_update_node_recursive(p, nextsib, level, tree, HybridNuGrav);
     }
 
-    /*After this point the suns array is invalid!*/
     force_zero_union(&tree->Nodes[no]);
     tree->Nodes[no].u.d.sibling = sib;
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -664,23 +664,8 @@ force_get_sibling(const int sib, const int j, const int * suns)
     return nextsib;
 }
 
-/* Very little to be done for a pseudo particle because the mass of the
-* pseudo-particle is still zero. The node attributes will be changed
-* later when we exchange the pseudo-particles.*/
 static int
-force_update_pseudo_node(int no, int sib, const ForceTree * tree)
-{
-    if(tree->Nodes[no].f.ChildType != PSEUDO_NODE_TYPE)
-        endrun(3, "force_update_pseudo_node called on node %d of wrong type!\n", no);
-
-    tree->Nodes[no].u.d.sibling = sib;
-
-    /*The pseudo-particle does not need a tail set.*/
-    return -1;
-}
-
-static int
-force_update_particle_node(int no, int sib, const ForceTree * tree, const int HybridNuGrav)
+force_update_particle_node(int no, const ForceTree * tree, const int HybridNuGrav)
 {
     if(tree->Nodes[no].f.ChildType != PARTICLE_NODE_TYPE)
         endrun(3, "force_update_particle_node called on node %d of wrong type!\n", no);
@@ -689,8 +674,6 @@ force_update_particle_node(int no, int sib, const ForceTree * tree, const int Hy
 
     const int noccupied = tree->Nodes[no].u.s.noccupied;
     int * suns = tree->Nodes[no].u.s.suns;
-
-    tree->Nodes[no].u.d.sibling = sib;
 
     /*Now we do the moments*/
     for(j = 0; j < noccupied; j++) {
@@ -773,30 +756,29 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         /*Empty slot*/
         if(p < 0)
             continue;
-
         const int nextsib = force_get_sibling(sib, j, suns);
+        /* This is set in create_nodes but needed because we may remove empty nodes above.*/
+        tree->Nodes[p].u.d.sibling = nextsib;
         /* Nodes containing particles or pseudo-particles*/
         if(tree->Nodes[p].f.ChildType == PARTICLE_NODE_TYPE)
-            force_update_particle_node(p, nextsib, tree, HybridNuGrav);
-        else if(tree->Nodes[p].f.ChildType == PSEUDO_NODE_TYPE)
-            force_update_pseudo_node(p, nextsib, tree);
-        /*Don't spawn a new task if we are deep enough that we already spawned a lot.
-        Note: final clause is much slower for some reason. */
-        else if(childcnt > 1 && level < 256) {
-            /* We cannot use default(none) here because we need a const (HybridNuGrav),
-            * which for gcc < 9 is default shared (and thus cannot be explicitly shared
-            * without error) and for gcc == 9 must be explicitly shared. The other solution
-            * is to make it firstprivate which I think will be excessively expensive for a
-            * recursive call like this. See:
-            * https://www.gnu.org/software/gcc/gcc-9/porting_to.html */
-            #pragma omp task shared(level, childcnt, tree) firstprivate(j, nextsib, p)
-            force_update_node_recursive(p, nextsib, level*childcnt, tree, HybridNuGrav);
+            force_update_particle_node(p, tree, HybridNuGrav);
+        if(tree->Nodes[p].f.ChildType == NODE_NODE_TYPE) {
+            /* Don't spawn a new task if we are deep enough that we already spawned a lot.
+             * Note: final clause is much slower for some reason. */
+            if(childcnt > 1 && level < 256) {
+                /* We cannot use default(none) here because we need a const (HybridNuGrav),
+                * which for gcc < 9 is default shared (and thus cannot be explicitly shared
+                * without error) and for gcc == 9 must be explicitly shared. The other solution
+                * is to make it firstprivate which I think will be excessively expensive for a
+                * recursive call like this. See:
+                * https://www.gnu.org/software/gcc/gcc-9/porting_to.html */
+                #pragma omp task shared(level, childcnt, tree) firstprivate(j, p)
+                force_update_node_recursive(p, nextsib, level*childcnt, tree, HybridNuGrav);
+            }
+            else
+                force_update_node_recursive(p, nextsib, level, tree, HybridNuGrav);
         }
-        else
-            force_update_node_recursive(p, nextsib, level, tree, HybridNuGrav);
     }
-
-    tree->Nodes[no].u.d.sibling = sib;
 
     /*Make sure all child nodes are done*/
     #pragma omp taskwait
@@ -853,9 +835,7 @@ force_update_node_parallel(const ForceTree * tree, const int HybridNuGrav)
         if(tree->Nodes[tree->firstnode].f.ChildType == NODE_NODE_TYPE)
             tail = force_update_node_recursive(tree->firstnode, -1, 1, tree, HybridNuGrav);
         else if(tree->Nodes[tree->firstnode].f.ChildType == PARTICLE_NODE_TYPE)
-            tail = force_update_particle_node(tree->firstnode, -1, tree, HybridNuGrav);
-        else
-            tail = force_update_pseudo_node(tree->firstnode, -1, tree);
+            tail = force_update_particle_node(tree->firstnode, tree, HybridNuGrav);
     }
     return tail;
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -238,8 +238,6 @@ static void init_internal_node(struct NODE *nfreep, struct NODE *parent, int sub
     nfreep->mom.hmax = 0;
     nfreep->mom.MaxSoftening = -1;
     nfreep->f.DependsOnLocalMass = 0;
-    nfreep->f.MixedSofteningsInNode = 0;
-
 }
 
 /* Size of the free Node thread cache.
@@ -630,20 +628,10 @@ force_get_father(int no, const ForceTree * tree)
  *
  * */
 static void
-force_adjust_node_softening(struct NODE * pnode, double MaxSoftening, int mixed)
+force_adjust_node_softening(struct NODE * pnode, double MaxSoftening)
 {
-
-    if(pnode->mom.MaxSoftening > 0) {
-        /* already set? mark MixedSoftenings */
-        if(MaxSoftening != pnode->mom.MaxSoftening) {
-            pnode->f.MixedSofteningsInNode = 1;
-        }
-    }
     if(MaxSoftening > pnode->mom.MaxSoftening) {
         pnode->mom.MaxSoftening = MaxSoftening;
-    }
-    if(mixed) {
-        pnode->f.MixedSofteningsInNode = 1;
     }
 }
 
@@ -661,7 +649,7 @@ add_particle_moment_to_node(struct NODE * pnode, int i)
             pnode->mom.hmax = P[i].Hsml;
     }
 
-    force_adjust_node_softening(pnode, FORCE_SOFTENING(i), 0);
+    force_adjust_node_softening(pnode, FORCE_SOFTENING(i));
 }
 
 /*Get the sibling of a node, using the suns array. Only to be used in the tree build, before update_node_recursive is called.*/
@@ -812,7 +800,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         if(tree->Nodes[p].mom.hmax > tree->Nodes[no].mom.hmax)
             tree->Nodes[no].mom.hmax = tree->Nodes[p].mom.hmax;
 
-        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
+        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening);
     }
 
     /*Set the center of mass moments*/
@@ -870,9 +858,6 @@ void force_exchange_pseudodata(ForceTree * tree, const DomainDecomp * ddecomp)
         MyFloat s[3];
         MyFloat mass;
         MyFloat hmax;
-        struct {
-            unsigned int MixedSofteningsInNode :1;
-        };
         MyFloat MaxSoftening;
     }
     *TopLeafMoments;
@@ -895,7 +880,6 @@ void force_exchange_pseudodata(ForceTree * tree, const DomainDecomp * ddecomp)
         TopLeafMoments[i].mass = tree->Nodes[no].mom.mass;
         TopLeafMoments[i].hmax = tree->Nodes[no].mom.hmax;
         TopLeafMoments[i].MaxSoftening = tree->Nodes[no].mom.MaxSoftening;
-        TopLeafMoments[i].MixedSofteningsInNode = tree->Nodes[no].f.MixedSofteningsInNode;
 
         /*Set the local base nodes dependence on local mass*/
         while(no >= 0)
@@ -944,7 +928,6 @@ void force_exchange_pseudodata(ForceTree * tree, const DomainDecomp * ddecomp)
             tree->Nodes[no].mom.mass = TopLeafMoments[i].mass;
             tree->Nodes[no].mom.hmax = TopLeafMoments[i].hmax;
             tree->Nodes[no].mom.MaxSoftening = TopLeafMoments[i].MaxSoftening;
-            tree->Nodes[no].f.MixedSofteningsInNode = TopLeafMoments[i].MixedSofteningsInNode;
          }
     }
     myfree(TopLeafMoments);
@@ -967,7 +950,6 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
     hmax = 0;
 
     tree->Nodes[no].mom.MaxSoftening = -1;
-    tree->Nodes[no].f.MixedSofteningsInNode = 0;
 
     /* This happens if we have a trivial domain with only one entry*/
     if(!tree->Nodes[no].f.InternalTopLevel)
@@ -998,7 +980,7 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
         if(tree->Nodes[p].mom.hmax > hmax)
             hmax = tree->Nodes[p].mom.hmax;
 
-        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
+        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening);
 
         p = tree->Nodes[p].sibling;
     }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -724,9 +724,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
     if(tree->Nodes[no].f.ChildType != NODE_NODE_TYPE)
         endrun(3, "force_update_node_recursive called on node %d of type %d != %d!\n", no, tree->Nodes[no].f.ChildType, NODE_NODE_TYPE);
 #endif
-
-    /*Last value of tails is the return value of this function*/
-    int j, tails[8];
+    int j;
     int * suns = tree->Nodes[no].u.s.suns;
 
     int childcnt = 0;
@@ -746,6 +744,16 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         else if(tree->Nodes[suns[j]].f.ChildType == NODE_NODE_TYPE)
             childcnt++;
     }
+
+    /* Nextnode for this node is the first non-zero child*/
+    /*First do the children*/
+    for(j = 0; j < 8; j++) {
+        if(suns[j] >= 0) {
+            tree->Nodes[no].u.d.nextnode = suns[j];
+            break;
+        }
+    }
+
     /*First do the children*/
     for(j = 0; j < 8; j++)
     {
@@ -757,9 +765,9 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         const int nextsib = force_get_sibling(sib, j, suns);
         /* Nodes containing particles or pseudo-particles*/
         if(tree->Nodes[p].f.ChildType == PARTICLE_NODE_TYPE)
-            tails[j] = force_update_particle_node(p, nextsib, tree, HybridNuGrav);
+            force_update_particle_node(p, nextsib, tree, HybridNuGrav);
         else if(tree->Nodes[p].f.ChildType == PSEUDO_NODE_TYPE)
-            tails[j] = force_update_pseudo_node(p, nextsib, tree);
+            force_update_pseudo_node(p, nextsib, tree);
         /*Don't spawn a new task if we are deep enough that we already spawned a lot.
         Note: final clause is much slower for some reason. */
         else if(childcnt > 1 && level < 256) {
@@ -769,11 +777,11 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
             * is to make it firstprivate which I think will be excessively expensive for a
             * recursive call like this. See:
             * https://www.gnu.org/software/gcc/gcc-9/porting_to.html */
-            #pragma omp task shared(tails, level, childcnt, tree) firstprivate(j, nextsib, p)
-            tails[j] = force_update_node_recursive(p, nextsib, level*childcnt, tree, HybridNuGrav);
+            #pragma omp task shared(level, childcnt, tree) firstprivate(j, nextsib, p)
+            force_update_node_recursive(p, nextsib, level*childcnt, tree, HybridNuGrav);
         }
         else
-            tails[j] = force_update_node_recursive(p, nextsib, level, tree, HybridNuGrav);
+            force_update_node_recursive(p, nextsib, level, tree, HybridNuGrav);
     }
 
     tree->Nodes[no].u.d.sibling = sib;
@@ -806,20 +814,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         tree->Nodes[no].u.d.s[2] /= mass;
     }
 
-    /*This loop sets the next node value for the row we just computed.
-      Note that tails[i] is the next node for suns[i-1].
-      The the last tail needs to be the return value of this function.*/
-    int tail = no;
-    for(j = 0; j < 8; j++)
-    {
-        if(suns[j] < 0)
-            continue;
-        /*Set NextNode for this node*/
-        if(tail >= tree->firstnode)
-            tree->Nodes[tail].u.d.nextnode = suns[j];
-        tail = tails[j];
-    }
-    return tail;
+    return -1;
 }
 
 /*! This routine determines the multipole moments for a given internal node
@@ -850,11 +845,6 @@ force_update_node_parallel(const ForceTree * tree, const int HybridNuGrav)
         else
             tail = force_update_pseudo_node(tree->firstnode, -1, tree);
     }
-
-    /* Round off the last entry*/
-    if(tail >= tree->firstnode)
-        tree->Nodes[tail].u.d.nextnode = -1;
-
     return tail;
 }
 

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -590,6 +590,7 @@ force_insert_pseudo_particles(const ForceTree * tree, const DomainDecomp * ddeco
             if(tree->Nodes[index].u.s.noccupied != 0)
                 endrun(5, "In node %d, overwriting %d child particles (i = %d etc) with pseudo particle %d\n",
                        index, tree->Nodes[index].u.s.noccupied, tree->Nodes[index].u.s.suns[0], i);
+            tree->Nodes[index].u.s.suns[0] = firstpseudo + i;
             force_zero_union(&tree->Nodes[index]);
             tree->Nodes[index].f.ChildType = PSEUDO_NODE_TYPE;
             force_set_next_node(index, firstpseudo + i, tree);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -85,9 +85,9 @@ force_tree_eh_slots_fork(EIBase * event, void * userdata)
      * At the moment this does not matter, because
      * the only new particles are stars, which do not
      * participate in the SPH tree walk.*/
-    if(nop->u.s.noccupied < NMAXCHILD) {
-       nop->u.s.suns[nop->u.s.noccupied-1] = child;
-        nop->u.s.noccupied++;
+    if(nop->s.noccupied < NMAXCHILD) {
+       nop->s.suns[nop->s.noccupied-1] = child;
+        nop->s.noccupied++;
     }
     tree->Father[child] = no;
     return 0;
@@ -231,12 +231,12 @@ static void init_internal_node(struct NODE *nfreep, struct NODE *parent, int sub
         nfreep->center[j] = parent->center[j] + sign*lenhalf;
     }
     for(j = 0; j < NMAXCHILD; j++)
-        nfreep->u.s.suns[j] = -1;
-    nfreep->u.s.noccupied = 0;
-    memset(&(nfreep->u.d.s),0,3*sizeof(MyFloat));
-    nfreep->u.d.mass = 0;
-    nfreep->u.d.hmax = 0;
-    nfreep->u.d.MaxSoftening = -1;
+        nfreep->s.suns[j] = -1;
+    nfreep->s.noccupied = 0;
+    memset(&(nfreep->mom.cofm),0,3*sizeof(MyFloat));
+    nfreep->mom.mass = 0;
+    nfreep->mom.hmax = 0;
+    nfreep->mom.MaxSoftening = -1;
     nfreep->f.DependsOnLocalMass = 0;
     nfreep->f.MixedSofteningsInNode = 0;
 
@@ -273,9 +273,9 @@ static int
 modify_internal_node(int parent, int subnode, int p_toplace, const ForceTree tb)
 {
     tb.Father[p_toplace] = parent;
-    tb.Nodes[parent].u.s.suns[subnode] = p_toplace;
+    tb.Nodes[parent].s.suns[subnode] = p_toplace;
     if(subnode == 0)
-        tb.Nodes[parent].u.d.nextnode = tb.Nodes[parent].u.s.suns[0];
+        tb.Nodes[parent].nextnode = tb.Nodes[parent].s.suns[0];
     return 0;
 }
 
@@ -297,14 +297,14 @@ create_new_node_layer(int firstparent, int p_toplace,
         struct NODE *nprnt = &tb.Nodes[parent];
 
         /* Copy the old particles and a new one into a temporary array*/
-        memcpy(oldsuns, nprnt->u.s.suns, NMAXCHILD * sizeof(int));
+        memcpy(oldsuns, nprnt->s.suns, NMAXCHILD * sizeof(int));
 
         /*We have two particles here, so create a new child node to store them both.*/
         /* if we are here the node must be large enough, thus contain exactly one child. */
         /* The parent is already a leaf, need to split */
         for(i=0; i<8; i++) {
             /* Get memory for an extra node from our cache.*/
-            nprnt->u.s.suns[i] = get_freenode(nnext, nc);
+            nprnt->s.suns[i] = get_freenode(nnext, nc);
             /*If we already have too many nodes, exit loop.*/
             if(nc->nnext_thread >= tb.lastnode) {
                 /* This means that we have > NMAXCHILD particles in the same place,
@@ -316,43 +316,43 @@ create_new_node_layer(int firstparent, int p_toplace,
                 );
                 return 1;
             }
-            struct NODE *nfreep = &tb.Nodes[nprnt->u.s.suns[i]];
+            struct NODE *nfreep = &tb.Nodes[nprnt->s.suns[i]];
             /* We create a new leaf node.*/
             init_internal_node(nfreep, nprnt, i);
             /*Set father of new node*/
             nfreep->father = parent;
         }
         /* Set nextnode and sibling for the new rank. Since empty at this point, point both of them onwards.*/
-        nprnt->u.d.nextnode = nprnt->u.s.suns[0];
+        nprnt->nextnode = nprnt->s.suns[0];
         for(i=0; i<7; i++) {
-            int child = nprnt->u.s.suns[i];
+            int child = nprnt->s.suns[i];
             struct NODE * nchild = &tb.Nodes[child];
-            nchild->u.d.nextnode = nchild->u.d.sibling = nprnt->u.s.suns[i+1];
+            nchild->nextnode = nchild->sibling = nprnt->s.suns[i+1];
         }
         /* Final child needs special handling: set to the parent's sibling/nextnode.*/
-        tb.Nodes[nprnt->u.s.suns[7]].u.d.nextnode = tb.Nodes[nprnt->u.s.suns[7]].u.d.sibling = nprnt->u.d.sibling;
+        tb.Nodes[nprnt->s.suns[7]].nextnode = tb.Nodes[nprnt->s.suns[7]].sibling = nprnt->sibling;
 
         /*Initialize the remaining entries to empty*/
         for(i=8; i<NMAXCHILD;i++)
-            nprnt->u.s.suns[i] = -1;
+            nprnt->s.suns[i] = -1;
 
         for(i=0; i < NMAXCHILD; i++) {
             /* Re-attach each particle to the appropriate new leaf.
             * Notice that since we have NMAXCHILD slots on each child and NMAXCHILD particles,
             * we will always have a free slot. */
             int subnode = get_subnode(nprnt, oldsuns[i]);
-            int child = nprnt->u.s.suns[subnode];
+            int child = nprnt->s.suns[subnode];
             struct NODE * nchild = &tb.Nodes[child];
-            modify_internal_node(child, nchild->u.s.noccupied, oldsuns[i], tb);
-            nchild->u.s.noccupied++;
+            modify_internal_node(child, nchild->s.noccupied, oldsuns[i], tb);
+            nchild->s.noccupied++;
         }
         /* Now try again to add the new particle*/
         int subnode = get_subnode(nprnt, p_toplace);
-        int child = nprnt->u.s.suns[subnode];
+        int child = nprnt->s.suns[subnode];
         struct NODE * nchild = &tb.Nodes[child];
-        if(nchild->u.s.noccupied < NMAXCHILD) {
-            modify_internal_node(child, nchild->u.s.noccupied, p_toplace, tb);
-            nchild->u.s.noccupied++;
+        if(nchild->s.noccupied < NMAXCHILD) {
+            modify_internal_node(child, nchild->s.noccupied, p_toplace, tb);
+            nchild->s.noccupied++;
             break;
         }
         /* The attached particles are already within one subnode of the new node.
@@ -362,7 +362,7 @@ create_new_node_layer(int firstparent, int p_toplace,
              * so mark it a Node-containing node. It cannot be accessed until
              * we mark the top-level parent, so no need for atomics.*/
             tb.Nodes[child].f.ChildType = NODE_NODE_TYPE;
-            tb.Nodes[child].u.s.noccupied = (1<<16);
+            tb.Nodes[child].s.noccupied = (1<<16);
             parent = child;
         }
     } while(1);
@@ -371,7 +371,7 @@ create_new_node_layer(int firstparent, int p_toplace,
      * This goes last so that we don't access the child before it is constructed.*/
     tb.Nodes[firstparent].f.ChildType = NODE_NODE_TYPE;
     #pragma omp atomic write
-    tb.Nodes[firstparent].u.s.noccupied = (1<<16);
+    tb.Nodes[firstparent].s.noccupied = (1<<16);
     return 0;
 }
 
@@ -390,11 +390,11 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         for(i = 0; i < 3; i++)
             nfreep->center[i] = BoxSize/2.;
         for(i = 0; i < NMAXCHILD; i++)
-            nfreep->u.s.suns[i] = -1;
-        nfreep->u.s.noccupied = 0;
+            nfreep->s.suns[i] = -1;
+        nfreep->s.noccupied = 0;
         nfreep->father = -1;
-        nfreep->u.d.sibling = -1;
-        nfreep->u.d.nextnode = -1;
+        nfreep->sibling = -1;
+        nfreep->nextnode = -1;
         nfreep->f.TopLevel = 1;
         nfreep->f.InternalTopLevel = 0;
         nfreep->f.ChildType = PARTICLE_NODE_TYPE;
@@ -449,7 +449,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         {
             /*No lock needed: if we have an internal node here it will be stable*/
             #pragma omp atomic read
-            nocc = tb.Nodes[this].u.s.noccupied;
+            nocc = tb.Nodes[this].s.noccupied;
 
             /* This node still has space for a particle (or needs conversion)*/
             if(nocc < (1 << 16))
@@ -458,7 +458,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
             /* This node has child subnodes: find them.*/
             int subnode = get_subnode(&tb.Nodes[this], i);
             /*No lock needed: if we have an internal node here it will be stable*/
-            child = tb.Nodes[this].u.s.suns[subnode];
+            child = tb.Nodes[this].s.suns[subnode];
 
             if(child > tb.lastnode || child < tb.firstnode)
                 endrun(1,"Corruption in tree build: N[%d].[%d] = %d > lastnode (%d)\n",this, subnode, child, tb.lastnode);
@@ -469,13 +469,13 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
         /*Now lock this node.*/
         lock_spinlock(this-tb.firstnode, spin);
         /* We have a guaranteed spot.*/
-        nocc = atomic_fetch_and_add(&tb.Nodes[this].u.s.noccupied, 1);
+        nocc = atomic_fetch_and_add(&tb.Nodes[this].s.noccupied, 1);
 
         /* Check whether there is now a new layer of nodes and if so walk down until there isn't.*/
         if(nocc >= (1<<16)) {
             /* This node has child subnodes: find them.*/
             int subnode = get_subnode(&tb.Nodes[this], i);
-            child = tb.Nodes[this].u.s.suns[subnode];
+            child = tb.Nodes[this].s.suns[subnode];
             while(child >= tb.firstnode)
             {
                 /*Move the lock to the child*/
@@ -485,7 +485,7 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
 
                 /*No lock needed: if we have an internal node here it will be stable*/
                 #pragma omp atomic read
-                nocc = tb.Nodes[this].u.s.noccupied;
+                nocc = tb.Nodes[this].s.noccupied;
                 /* This node still has space for a particle (or needs conversion)*/
                 if(nocc < (1 << 16))
                     break;
@@ -493,10 +493,10 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
                 /* This node has child subnodes: find them.*/
                 subnode = get_subnode(&tb.Nodes[this], i);
                 /*No lock needed: if we have an internal node here it will be stable*/
-                child = tb.Nodes[this].u.s.suns[subnode];
+                child = tb.Nodes[this].s.suns[subnode];
             }
             /* Get the free spot under the lock.*/
-            nocc = atomic_fetch_and_add(&tb.Nodes[this].u.s.noccupied, 1);
+            nocc = atomic_fetch_and_add(&tb.Nodes[this].s.noccupied, 1);
         }
 
         /*Update last-used cache*/
@@ -546,11 +546,11 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
 
                 int count = i + 2 * j + 4 * k;
 
-                Nodes[no].u.s.suns[count] = *nextfree;
+                Nodes[no].s.suns[count] = *nextfree;
                 /*We are an internal top level node as we now have a child top level.*/
                 Nodes[no].f.InternalTopLevel = 1;
                 Nodes[no].f.ChildType = NODE_NODE_TYPE;
-                Nodes[no].u.s.noccupied = (1<<16);
+                Nodes[no].s.noccupied = (1<<16);
 
                 /* We create a new leaf node.*/
                 init_internal_node(&Nodes[*nextfree], &Nodes[no], count);
@@ -570,19 +570,19 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
                     endrun(11, "Not enough force nodes to topnode grid: need %d\n",lastnode);
             }
     /* Set nextnode on the parent, sibling on the child*/
-    Nodes[no].u.d.nextnode = Nodes[no].u.s.suns[0];
+    Nodes[no].nextnode = Nodes[no].s.suns[0];
     for(j=0; j<7; j++) {
-        int chld = Nodes[no].u.s.suns[j];
-        Nodes[chld].u.d.nextnode = Nodes[chld].u.d.sibling = Nodes[no].u.s.suns[j+1];
+        int chld = Nodes[no].s.suns[j];
+        Nodes[chld].nextnode = Nodes[chld].sibling = Nodes[no].s.suns[j+1];
     }
-    Nodes[Nodes[no].u.s.suns[7]].u.d.nextnode = Nodes[Nodes[no].u.s.suns[7]].u.d.sibling = Nodes[no].u.d.sibling;
+    Nodes[Nodes[no].s.suns[7]].nextnode = Nodes[Nodes[no].s.suns[7]].sibling = Nodes[no].sibling;
     for(i = 0; i < 2; i++)
         for(j = 0; j < 2; j++)
             for(k = 0; k < 2; k++)
             {
                 int sub = 7 & peano_hilbert_key((x << 1) + i, (y << 1) + j, (z << 1) + k, bits);
                 int count = i + 2 * j + 4 * k;
-                force_create_node_for_topnode(Nodes[no].u.s.suns[count], ddecomp->TopNodes[topnode].Daughter + sub, Nodes, ddecomp,
+                force_create_node_for_topnode(Nodes[no].s.suns[count], ddecomp->TopNodes[topnode].Daughter + sub, Nodes, ddecomp,
                         bits + 1, 2 * x + i, 2 * y + j, 2 * z + k, nextfree, lastnode);
             }
 
@@ -606,13 +606,13 @@ force_insert_pseudo_particles(const ForceTree * tree, const DomainDecomp * ddeco
     {
         index = ddecomp->TopLeaves[i].treenode;
         if(ddecomp->TopLeaves[i].Task != ThisTask) {
-            if(tree->Nodes[index].u.s.noccupied != 0)
+            if(tree->Nodes[index].s.noccupied != 0)
                 endrun(5, "In node %d, overwriting %d child particles (i = %d etc) with pseudo particle %d\n",
-                       index, tree->Nodes[index].u.s.noccupied, tree->Nodes[index].u.s.suns[0], i);
+                       index, tree->Nodes[index].s.noccupied, tree->Nodes[index].s.suns[0], i);
             tree->Nodes[index].f.ChildType = PSEUDO_NODE_TYPE;
             /* This node points to the pseudo particle*/
-            tree->Nodes[index].u.d.nextnode = firstpseudo + i;
-            tree->Nodes[index].u.s.suns[0] = firstpseudo + i;
+            tree->Nodes[index].nextnode = firstpseudo + i;
+            tree->Nodes[index].s.suns[0] = firstpseudo + i;
         }
     }
 }
@@ -633,14 +633,14 @@ static void
 force_adjust_node_softening(struct NODE * pnode, double MaxSoftening, int mixed)
 {
 
-    if(pnode->u.d.MaxSoftening > 0) {
+    if(pnode->mom.MaxSoftening > 0) {
         /* already set? mark MixedSoftenings */
-        if(MaxSoftening != pnode->u.d.MaxSoftening) {
+        if(MaxSoftening != pnode->mom.MaxSoftening) {
             pnode->f.MixedSofteningsInNode = 1;
         }
     }
-    if(MaxSoftening > pnode->u.d.MaxSoftening) {
-        pnode->u.d.MaxSoftening = MaxSoftening;
+    if(MaxSoftening > pnode->mom.MaxSoftening) {
+        pnode->mom.MaxSoftening = MaxSoftening;
     }
     if(mixed) {
         pnode->f.MixedSofteningsInNode = 1;
@@ -651,14 +651,14 @@ static void
 add_particle_moment_to_node(struct NODE * pnode, int i)
 {
     int k;
-    pnode->u.d.mass += (P[i].Mass);
+    pnode->mom.mass += (P[i].Mass);
     for(k=0; k<3; k++)
-        pnode->u.d.s[k] += (P[i].Mass * P[i].Pos[k]);
+        pnode->mom.cofm[k] += (P[i].Mass * P[i].Pos[k]);
 
     if(P[i].Type == 0)
     {
-        if(P[i].Hsml > pnode->u.d.hmax)
-            pnode->u.d.hmax = P[i].Hsml;
+        if(P[i].Hsml > pnode->mom.hmax)
+            pnode->mom.hmax = P[i].Hsml;
     }
 
     force_adjust_node_softening(pnode, FORCE_SOFTENING(i), 0);
@@ -688,8 +688,8 @@ force_update_particle_node(int no, const ForceTree * tree, const int HybridNuGra
     /*Last value of tails is the return value of this function*/
     int j;
 
-    const int noccupied = tree->Nodes[no].u.s.noccupied;
-    int * suns = tree->Nodes[no].u.s.suns;
+    const int noccupied = tree->Nodes[no].s.noccupied;
+    int * suns = tree->Nodes[no].s.suns;
 
     /*Now we do the moments*/
     for(j = 0; j < noccupied; j++) {
@@ -701,15 +701,15 @@ force_update_particle_node(int no, const ForceTree * tree, const int HybridNuGra
     }
 
     /*Set the center of mass moments*/
-    const double mass = tree->Nodes[no].u.d.mass;
+    const double mass = tree->Nodes[no].mom.mass;
     /* Be careful about empty nodes*/
     if(mass > 0) {
         for(j = 0; j < 3; j++)
-            tree->Nodes[no].u.d.s[j] /= mass;
+            tree->Nodes[no].mom.cofm[j] /= mass;
     }
     else {
         for(j = 0; j < 3; j++)
-            tree->Nodes[no].u.d.s[j] = tree->Nodes[no].center[j];
+            tree->Nodes[no].mom.cofm[j] = tree->Nodes[no].center[j];
     }
 
     /* The tail of a particle node
@@ -736,7 +736,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         endrun(3, "force_update_node_recursive called on node %d of type %d != %d!\n", no, tree->Nodes[no].f.ChildType, NODE_NODE_TYPE);
 #endif
     int j;
-    int * suns = tree->Nodes[no].u.s.suns;
+    int * suns = tree->Nodes[no].s.suns;
 
     int childcnt = 0;
     /* Remove any empty children.
@@ -749,7 +749,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
          * when one of the local domains is empty. */
         if(!tree->Nodes[suns[j]].f.TopLevel &&
             tree->Nodes[suns[j]].f.ChildType == PARTICLE_NODE_TYPE &&
-            tree->Nodes[suns[j]].u.s.noccupied == 0) {
+            tree->Nodes[suns[j]].s.noccupied == 0) {
                 suns[j] = -1;
         }
         else if(tree->Nodes[suns[j]].f.ChildType == NODE_NODE_TYPE)
@@ -760,7 +760,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
     if(childcnt < 8)
         for(j = 0; j < 8; j++) {
             if(suns[j] >= 0) {
-                tree->Nodes[no].u.d.nextnode = suns[j];
+                tree->Nodes[no].nextnode = suns[j];
                 break;
             }
         }
@@ -774,7 +774,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
             continue;
         const int nextsib = force_get_sibling(sib, j, suns);
         /* This is set in create_nodes but needed because we may remove empty nodes above.*/
-        tree->Nodes[p].u.d.sibling = nextsib;
+        tree->Nodes[p].sibling = nextsib;
         /* Nodes containing particles or pseudo-particles*/
         if(tree->Nodes[p].f.ChildType == PARTICLE_NODE_TYPE)
             force_update_particle_node(p, tree, HybridNuGrav);
@@ -805,23 +805,23 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree, 
         const int p = suns[j];
         if(p < 0)
             continue;
-        tree->Nodes[no].u.d.mass += (tree->Nodes[p].u.d.mass);
-        tree->Nodes[no].u.d.s[0] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[0]);
-        tree->Nodes[no].u.d.s[1] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[1]);
-        tree->Nodes[no].u.d.s[2] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[2]);
-        if(tree->Nodes[p].u.d.hmax > tree->Nodes[no].u.d.hmax)
-            tree->Nodes[no].u.d.hmax = tree->Nodes[p].u.d.hmax;
+        tree->Nodes[no].mom.mass += (tree->Nodes[p].mom.mass);
+        tree->Nodes[no].mom.cofm[0] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[0]);
+        tree->Nodes[no].mom.cofm[1] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[1]);
+        tree->Nodes[no].mom.cofm[2] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[2]);
+        if(tree->Nodes[p].mom.hmax > tree->Nodes[no].mom.hmax)
+            tree->Nodes[no].mom.hmax = tree->Nodes[p].mom.hmax;
 
-        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].u.d.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
+        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
     }
 
     /*Set the center of mass moments*/
-    const double mass = tree->Nodes[no].u.d.mass;
+    const double mass = tree->Nodes[no].mom.mass;
     /* In principle all the children could be pseudo-particles*/
     if(mass > 0) {
-        tree->Nodes[no].u.d.s[0] /= mass;
-        tree->Nodes[no].u.d.s[1] /= mass;
-        tree->Nodes[no].u.d.s[2] /= mass;
+        tree->Nodes[no].mom.cofm[0] /= mass;
+        tree->Nodes[no].mom.cofm[1] /= mass;
+        tree->Nodes[no].mom.cofm[2] /= mass;
     }
 
     return -1;
@@ -889,12 +889,12 @@ void force_exchange_pseudodata(ForceTree * tree, const DomainDecomp * ddecomp)
             endrun(131231231, "TopLeaf %d Task table is corrupted: task is %d\n", i, ddecomp->TopLeaves[i].Task);
 
         /* read out the multipole moments from the local base cells */
-        TopLeafMoments[i].s[0] = tree->Nodes[no].u.d.s[0];
-        TopLeafMoments[i].s[1] = tree->Nodes[no].u.d.s[1];
-        TopLeafMoments[i].s[2] = tree->Nodes[no].u.d.s[2];
-        TopLeafMoments[i].mass = tree->Nodes[no].u.d.mass;
-        TopLeafMoments[i].hmax = tree->Nodes[no].u.d.hmax;
-        TopLeafMoments[i].MaxSoftening = tree->Nodes[no].u.d.MaxSoftening;
+        TopLeafMoments[i].s[0] = tree->Nodes[no].mom.cofm[0];
+        TopLeafMoments[i].s[1] = tree->Nodes[no].mom.cofm[1];
+        TopLeafMoments[i].s[2] = tree->Nodes[no].mom.cofm[2];
+        TopLeafMoments[i].mass = tree->Nodes[no].mom.mass;
+        TopLeafMoments[i].hmax = tree->Nodes[no].mom.hmax;
+        TopLeafMoments[i].MaxSoftening = tree->Nodes[no].mom.MaxSoftening;
         TopLeafMoments[i].MixedSofteningsInNode = tree->Nodes[no].f.MixedSofteningsInNode;
 
         /*Set the local base nodes dependence on local mass*/
@@ -938,12 +938,12 @@ void force_exchange_pseudodata(ForceTree * tree, const DomainDecomp * ddecomp)
         for(i = ddecomp->Tasks[ta].StartLeaf; i < ddecomp->Tasks[ta].EndLeaf; i ++) {
             no = ddecomp->TopLeaves[i].treenode;
 
-            tree->Nodes[no].u.d.s[0] = TopLeafMoments[i].s[0];
-            tree->Nodes[no].u.d.s[1] = TopLeafMoments[i].s[1];
-            tree->Nodes[no].u.d.s[2] = TopLeafMoments[i].s[2];
-            tree->Nodes[no].u.d.mass = TopLeafMoments[i].mass;
-            tree->Nodes[no].u.d.hmax = TopLeafMoments[i].hmax;
-            tree->Nodes[no].u.d.MaxSoftening = TopLeafMoments[i].MaxSoftening;
+            tree->Nodes[no].mom.cofm[0] = TopLeafMoments[i].s[0];
+            tree->Nodes[no].mom.cofm[1] = TopLeafMoments[i].s[1];
+            tree->Nodes[no].mom.cofm[2] = TopLeafMoments[i].s[2];
+            tree->Nodes[no].mom.mass = TopLeafMoments[i].mass;
+            tree->Nodes[no].mom.hmax = TopLeafMoments[i].hmax;
+            tree->Nodes[no].mom.MaxSoftening = TopLeafMoments[i].MaxSoftening;
             tree->Nodes[no].f.MixedSofteningsInNode = TopLeafMoments[i].MixedSofteningsInNode;
          }
     }
@@ -966,14 +966,14 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
     s[2] = 0;
     hmax = 0;
 
-    tree->Nodes[no].u.d.MaxSoftening = -1;
+    tree->Nodes[no].mom.MaxSoftening = -1;
     tree->Nodes[no].f.MixedSofteningsInNode = 0;
 
     /* This happens if we have a trivial domain with only one entry*/
     if(!tree->Nodes[no].f.InternalTopLevel)
         return;
 
-    p = tree->Nodes[no].u.s.suns[0];
+    p = tree->Nodes[no].s.suns[0];
 
     /* since we are dealing with top-level nodes, we know that there are 8 consecutive daughter nodes */
     for(j = 0; j < 8; j++)
@@ -990,17 +990,17 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
         if(tree->Nodes[p].f.InternalTopLevel)
             force_treeupdate_pseudos(p, tree);
 
-        mass += (tree->Nodes[p].u.d.mass);
-        s[0] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[0]);
-        s[1] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[1]);
-        s[2] += (tree->Nodes[p].u.d.mass * tree->Nodes[p].u.d.s[2]);
+        mass += (tree->Nodes[p].mom.mass);
+        s[0] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[0]);
+        s[1] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[1]);
+        s[2] += (tree->Nodes[p].mom.mass * tree->Nodes[p].mom.cofm[2]);
 
-        if(tree->Nodes[p].u.d.hmax > hmax)
-            hmax = tree->Nodes[p].u.d.hmax;
+        if(tree->Nodes[p].mom.hmax > hmax)
+            hmax = tree->Nodes[p].mom.hmax;
 
-        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].u.d.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
+        force_adjust_node_softening(&tree->Nodes[no], tree->Nodes[p].mom.MaxSoftening, tree->Nodes[p].f.MixedSofteningsInNode);
 
-        p = tree->Nodes[p].u.d.sibling;
+        p = tree->Nodes[p].sibling;
     }
 
     if(mass)
@@ -1016,12 +1016,12 @@ void force_treeupdate_pseudos(int no, const ForceTree * tree)
         s[2] = tree->Nodes[no].center[2];
     }
 
-    tree->Nodes[no].u.d.s[0] = s[0];
-    tree->Nodes[no].u.d.s[1] = s[1];
-    tree->Nodes[no].u.d.s[2] = s[2];
-    tree->Nodes[no].u.d.mass = mass;
+    tree->Nodes[no].mom.cofm[0] = s[0];
+    tree->Nodes[no].mom.cofm[1] = s[1];
+    tree->Nodes[no].mom.cofm[2] = s[2];
+    tree->Nodes[no].mom.mass = mass;
 
-    tree->Nodes[no].u.d.hmax = hmax;
+    tree->Nodes[no].mom.hmax = hmax;
 }
 
 /*! This function updates the hmax-values in tree nodes that hold SPH
@@ -1053,9 +1053,9 @@ void force_update_hmax(int * activeset, int size, ForceTree * tree, DomainDecomp
 
         while(no >= 0)
         {
-            if(P[p_i].Hsml <= tree->Nodes[no].u.d.hmax)
+            if(P[p_i].Hsml <= tree->Nodes[no].mom.hmax)
                 break;
-            tree->Nodes[no].u.d.hmax = P[p_i].Hsml;
+            tree->Nodes[no].mom.hmax = P[p_i].Hsml;
             no = tree->Nodes[no].father;
         }
     }
@@ -1065,7 +1065,7 @@ void force_update_hmax(int * activeset, int size, ForceTree * tree, DomainDecomp
 
     for(i = ddecomp->Tasks[ThisTask].StartLeaf; i < ddecomp->Tasks[ThisTask].EndLeaf; i ++) {
         int no = ddecomp->TopLeaves[i].treenode;
-        TopLeafhmax[i] = tree->Nodes[no].u.d.hmax;
+        TopLeafhmax[i] = tree->Nodes[no].mom.hmax;
     }
 
     /* share the hmax-data of the dirty nodes accross CPUs */
@@ -1090,13 +1090,13 @@ void force_update_hmax(int * activeset, int size, ForceTree * tree, DomainDecomp
             continue; /* bypass ThisTask since it is already up to date */
         for(i = ddecomp->Tasks[ta].StartLeaf; i < ddecomp->Tasks[ta].EndLeaf; i ++) {
             int no = ddecomp->TopLeaves[i].treenode;
-            tree->Nodes[no].u.d.hmax = TopLeafhmax[i];
+            tree->Nodes[no].mom.hmax = TopLeafhmax[i];
 
             while(no >= 0)
             {
-                if(TopLeafhmax[i] <= tree->Nodes[no].u.d.hmax)
+                if(TopLeafhmax[i] <= tree->Nodes[no].mom.hmax)
                     break;
-                tree->Nodes[no].u.d.hmax = TopLeafhmax[i];
+                tree->Nodes[no].mom.hmax = TopLeafhmax[i];
                 no = tree->Nodes[no].father;
             }
          }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -609,23 +609,6 @@ force_get_father(int no, const ForceTree * tree)
 }
 
 int
-force_get_next_node(int no, const ForceTree * tree)
-{
-    if(no >= tree->firstnode && no < tree->lastnode) {
-        /* internal node */
-        return tree->Nodes[no].u.d.nextnode;
-    }
-    if(no < tree->firstnode) {
-        /* Particle */
-        return tree->Nextnode[no];
-    }
-    else { //if(no >= tb.lastnode) {
-        /* Pseudo Particle */
-        return tree->Nextnode[no - (tree->lastnode - tree->firstnode)];
-    }
-}
-
-int
 force_set_next_node(int no, int next, const ForceTree * tree)
 {
     if(no < 0) return next;
@@ -711,7 +694,7 @@ force_update_pseudo_node(int no, int sib, const ForceTree * tree)
     tree->Nodes[no].u.d.sibling = sib;
 
     /*The pseudo-particle is the return value of this function.*/
-    return force_get_next_node(no, tree);
+    return tree->Nodes[no].u.d.nextnode;
 }
 
 static int

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -645,25 +645,6 @@ force_set_next_node(int no, int next, const ForceTree * tree)
     return next;
 }
 
-int
-force_get_prev_node(int no, const ForceTree * tree)
-{
-    if(node_is_particle(no, tree)) {
-        /* Particle */
-        int t = tree->Father[no];
-        int next = force_get_next_node(t, tree);
-        while(next != no) {
-            t = next;
-            next = force_get_next_node(t, tree);
-        }
-        return t;
-    } else {
-        /* not implemented yet */
-        endrun(1, "get_prev_node on non particles is not implemented yet\n");
-        return 0;
-    }
-}
-
 /* Sets the node softening on a node.
  *
  * */

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -329,8 +329,8 @@ create_new_node_layer(int firstparent, int p_toplace,
             struct NODE * nchild = &tb.Nodes[child];
             nchild->u.d.nextnode = nchild->u.d.sibling = nprnt->u.s.suns[i+1];
         }
-        /* Final child needs special handling: we don't use its nextnode, so set to -1.*/
-        tb.Nodes[nprnt->u.s.suns[7]].u.d.nextnode = -1;
+        /* Final child needs special handling: set to the parent's sibling/nextnode.*/
+        tb.Nodes[nprnt->u.s.suns[7]].u.d.nextnode = tb.Nodes[nprnt->u.s.suns[7]].u.d.sibling = nprnt->u.d.sibling;
 
         /*Initialize the remaining entries to empty*/
         for(i=8; i<NMAXCHILD;i++)
@@ -393,6 +393,8 @@ int force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * 
             nfreep->u.s.suns[i] = -1;
         nfreep->u.s.noccupied = 0;
         nfreep->father = -1;
+        nfreep->u.d.sibling = -1;
+        nfreep->u.d.nextnode = -1;
         nfreep->f.TopLevel = 1;
         nfreep->f.InternalTopLevel = 0;
         nfreep->f.ChildType = PARTICLE_NODE_TYPE;
@@ -566,10 +568,24 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
 
                 if(*nextfree >= lastnode)
                     endrun(11, "Not enough force nodes to topnode grid: need %d\n",lastnode);
-
-                force_create_node_for_topnode(*nextfree - 1, ddecomp->TopNodes[topnode].Daughter + sub, Nodes, ddecomp,
+            }
+    /* Set nextnode on the parent, sibling on the child*/
+    Nodes[no].u.d.nextnode = Nodes[no].u.s.suns[0];
+    for(j=0; j<7; j++) {
+        int chld = Nodes[no].u.s.suns[j];
+        Nodes[chld].u.d.nextnode = Nodes[chld].u.d.sibling = Nodes[no].u.s.suns[j+1];
+    }
+    Nodes[Nodes[no].u.s.suns[7]].u.d.nextnode = Nodes[Nodes[no].u.s.suns[7]].u.d.sibling = Nodes[no].u.d.sibling;
+    for(i = 0; i < 2; i++)
+        for(j = 0; j < 2; j++)
+            for(k = 0; k < 2; k++)
+            {
+                int sub = 7 & peano_hilbert_key((x << 1) + i, (y << 1) + j, (z << 1) + k, bits);
+                int count = i + 2 * j + 4 * k;
+                force_create_node_for_topnode(Nodes[no].u.s.suns[count], ddecomp->TopNodes[topnode].Daughter + sub, Nodes, ddecomp,
                         bits + 1, 2 * x + i, 2 * y + j, 2 * z + k, nextfree, lastnode);
             }
+
 }
 
 /*! this function inserts pseudo-particles which will represent the mass

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -134,7 +134,7 @@ ForceTree force_tree_build(int npart, DomainDecomp * ddecomp, const double BoxSi
 
     do
     {
-        int maxnodes = ForceTreeParams.TreeAllocFactor * PartManager->MaxPart + ddecomp->NTopNodes;
+        int maxnodes = ForceTreeParams.TreeAllocFactor * PartManager->NumPart + ddecomp->NTopNodes;
         /* Allocate memory. */
         tree = force_treeallocate(maxnodes, PartManager->MaxPart, ddecomp);
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -52,6 +52,11 @@ struct NODE
                          * open the node if a particle is closer.*/
     } mom;
 
+    /* In principle storing this here wastes memory, because we only use it for the leaf nodes.
+     * However, in practice the wasted memory is fairly small: there are sum(1/8^n) ~ 0.15 internal nodes
+     * for each leaf node, and we are losing 30% of the memory per node, so the total lost is 5%.
+     * Any attempt to get it back by using a separate allocation means we lost the ability to resize
+     * the Nodes array and that is always worse.*/
     struct NodeChild s;
 };
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -27,10 +27,12 @@ struct NodeChild
 
 struct NODE
 {
+    int sibling;		/*!< this gives the next node in the walk in case the current node can be used */
+    int nextnode;		/*!< this gives the next node in case the current node needs to be opened */
+    int father;		/*!< this gives the parent node of each node (or -1 if we have the root node) */
     MyFloat len;			/*!< sidelength of treenode */
     MyFloat center[3];		/*!< geometrical center of node */
 
-    int father;		/*!< this gives the parent node of each node (or -1 if we have the root node) */
     struct {
         unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
@@ -38,25 +40,19 @@ struct NODE
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
         unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
                                     * (should be an enum, but not standard in C).*/
+        unsigned int unused : 2; /* Spare bits*/
     } f;
 
-    struct
-    {
-        struct NodeChild s;
-        struct
-        {
-            MyFloat s[3];		/*!< center of mass of node */
-            MyFloat mass;		/*!< mass of node */
-            int sibling;		/*!< this gives the next node in the walk in case the current node can be used */
-            int nextnode;		/*!< this gives the next node in case the current node needs to be opened */
-            MyFloat hmax;			/*!< maximum SPH smoothing length in node. Only used for gas particles */
-            MyFloat MaxSoftening;  /* Stores the largest softening in the node. The short-range
-                                 * gravitational force solver will check this and use it
-                                 * open the node if a particle is closer.*/
-        }
-        d;
-    }
-    u;
+    struct {
+        MyFloat cofm[3];		/*!< center of mass of node */
+        MyFloat mass;		/*!< mass of node */
+        MyFloat hmax;			/*!< maximum SPH smoothing length in node. Only used for gas particles */
+        MyFloat MaxSoftening;  /* Stores the largest softening in the node. The short-range
+                         * gravitational force solver will check this and use it
+                         * open the node if a particle is closer.*/
+    } mom;
+
+    struct NodeChild s;
 };
 
 /*Structure containing the Node pointer, and various Tree metadata.*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -37,10 +37,9 @@ struct NODE
         unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
-        unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
         unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
                                     * (should be an enum, but not standard in C).*/
-        unsigned int unused : 2; /* Spare bits*/
+        unsigned int unused : 3; /* Spare bits*/
     } f;
 
     struct {

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -16,6 +16,15 @@
 #define NODE_NODE_TYPE 1
 #define PSEUDO_NODE_TYPE 2
 
+struct NodeChild
+{
+    /*!< pointers to daughter nodes or daughter particles. */
+    int suns[NMAXCHILD];
+    /* Number of daughter particles if node contains particles.
+     * During treebuild >= (1<<16) if node contains nodes.*/
+    int noccupied;
+};
+
 struct NODE
 {
     MyFloat len;			/*!< sidelength of treenode */
@@ -33,14 +42,7 @@ struct NODE
 
     struct
     {
-        struct
-        {
-            /*!< temporary pointers to daughter nodes or daughter particles. */
-            int suns[NMAXCHILD];
-            /* Number of daughter particles if node contains particles.
-             * During treebuild >= (1<<16) if node contains nodes.*/
-            int noccupied;
-        } s;
+        struct NodeChild s;
         struct
         {
             MyFloat s[3];		/*!< center of mass of node */

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -128,12 +128,6 @@ node_is_node(int no, const ForceTree * tree)
 }
 
 int
-force_get_next_node(int no, const ForceTree * tb);
-
-int
-force_set_next_node(int no, int next, const ForceTree * tb);
-
-int
 force_get_father(int no, const ForceTree * tt);
 
 #endif

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -86,11 +86,6 @@ typedef struct ForceTree {
      * The exception is the crazy memory shifting done in sfr_eff.c*/
     /*This points to the actual memory allocated for the nodes.*/
     struct NODE * Nodes_base;
-    /* Gives next node in the tree walk for particles and pseudo particles.
-     * next node for the actual nodes is stored in Nodes*/
-    int * Nextnode;
-    /*Allocated length of the Nextnode array*/
-    int Nnextnode;
     /*!< gives parent node in tree for every particle */
     int *Father;
     /*!< Store the size of the box used to build the tree, for periodic walking.*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -30,7 +30,8 @@ struct NODE
         unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
                                     * (should be an enum, but not standard in C).*/
     } f;
-    union
+
+    struct
     {
         struct
         {

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -133,9 +133,6 @@ node_is_node(int no, const ForceTree * tree)
 }
 
 int
-force_get_prev_node(int no, const ForceTree * tb);
-
-int
 force_get_next_node(int no, const ForceTree * tb);
 
 int

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -122,7 +122,7 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
 
         if(!(tree->Nodes[no].f.DependsOnLocalMass)) {
             /* node doesn't contain particles on this process, do not open */
-            no = tree->Nodes[no].u.d.sibling;
+            no = tree->Nodes[no].sibling;
             continue;
         }
         if(
@@ -135,11 +135,11 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
             regions[r].no = no;
             r ++;
             /* do not open */
-            no = tree->Nodes[no].u.d.sibling;
+            no = tree->Nodes[no].sibling;
             continue;
         }
         /* open */
-        no = tree->Nodes[no].u.d.nextnode;
+        no = tree->Nodes[no].nextnode;
     }
 
     *Nregions = r;
@@ -193,14 +193,14 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
 static int pm_mark_region_for_node(int startno, int rid, int * RegionInd, const ForceTree * tree) {
     int numpart = 0;
     int no = startno;
-    int endno = tree->Nodes[startno].u.d.sibling;
+    int endno = tree->Nodes[startno].sibling;
     while(no >= 0 && no != endno)
     {
         struct NODE * nop = &tree->Nodes[no];
         if(nop->f.ChildType == PARTICLE_NODE_TYPE) {
             int i;
-            for(i = 0; i < nop->u.s.noccupied; i++) {
-                int p = nop->u.s.suns[i];
+            for(i = 0; i < nop->s.noccupied; i++) {
+                int p = nop->s.suns[i];
                 RegionInd[p] = rid;
 #ifdef DEBUG
                 /* when we are in PM, all particles must have been synced. */
@@ -222,17 +222,17 @@ static int pm_mark_region_for_node(int startno, int rid, int * RegionInd, const 
                 }
 #endif
             }
-            numpart += nop->u.s.noccupied;
+            numpart += nop->s.noccupied;
             /* Move to sibling*/
-            no = nop->u.d.sibling;
+            no = nop->sibling;
         }
         /* Generally this function should be handed top leaves which do not contain pseudo particles.
          * However, sometimes it will receive an internal top node which can, if that top node is small enough.
          * In this case, just move to the sibling: no particles to mark here.*/
         else if(nop->f.ChildType == PSEUDO_NODE_TYPE)
-            no = nop->u.d.sibling;
+            no = nop->sibling;
         else if(nop->f.ChildType == NODE_NODE_TYPE)
-            no = nop->u.d.nextnode;
+            no = nop->nextnode;
         else
             endrun(122, "Unrecognised Node type %d, memory corruption!\n", nop->f.ChildType);
     }

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -226,9 +226,11 @@ static int pm_mark_region_for_node(int startno, int rid, int * RegionInd, const 
             /* Move to sibling*/
             no = nop->u.d.sibling;
         }
-        /* This should never occur: this function should be handed only top leaves which cannot contain pseudo particles*/
+        /* Generally this function should be handed top leaves which do not contain pseudo particles.
+         * However, sometimes it will receive an internal top node which can, if that top node is small enough.
+         * In this case, just move to the sibling: no particles to mark here.*/
         else if(nop->f.ChildType == PSEUDO_NODE_TYPE)
-            endrun(122, "Region marking encountered a pseudo-particle, which should never happen!\n");
+            no = nop->u.d.sibling;
         else if(nop->f.ChildType == NODE_NODE_TYPE)
             no = nop->u.d.nextnode;
         else

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -298,38 +298,38 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             int i;
             double dx[3];
             for(i = 0; i < 3; i++)
-                dx[i] = NEAREST(nop->u.d.s[i] - inpos[i], BoxSize);
+                dx[i] = NEAREST(nop->mom.cofm[i] - inpos[i], BoxSize);
             const double r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
 
             /* Discard this node, move to sibling*/
             if(shall_we_discard_node(nop->len, r2, nop->center, inpos, BoxSize, rcut, rcut2))
             {
-                no = nop->u.d.sibling;
+                no = nop->sibling;
                 /* Don't add this node*/
                 continue;
             }
 
             /* This node accelerates the particle directly, and is not opened.*/
-            if(!shall_we_open_node(nop->len, nop->u.d.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2))
+            if(!shall_we_open_node(nop->len, nop->mom.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2))
             {
-                double h = DMAX(input->Soft, nop->u.d.MaxSoftening);
+                double h = DMAX(input->Soft, nop->mom.MaxSoftening);
                 /* Always open the node if it has a larger softening than the particle,
                  * and the particle is inside its softening radius.
                  * This condition essentially never happens, and it is not clear how much sense it makes. */
-                if(input->Soft < nop->u.d.MaxSoftening)
+                if(input->Soft < nop->mom.MaxSoftening)
                 {
                     if(r2 < h * h)
                         if(nop->f.MixedSofteningsInNode)
                         {
-                            no = nop->u.d.nextnode;
+                            no = nop->nextnode;
                             continue;
                         }
                 }
 
                 /* ok, node can be used */
-                no = nop->u.d.sibling;
+                no = nop->sibling;
                 /* Compute the acceleration and apply it to the output structure*/
-                apply_accn_to_output(output, dx, r2, h, nop->u.d.mass, cellsize);
+                apply_accn_to_output(output, dx, r2, h, nop->mom.mass, cellsize);
                 continue;
             }
 
@@ -338,27 +338,27 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             if(nop->f.ChildType == PARTICLE_NODE_TYPE)
             {
                 /* Loop over child particles*/
-                for(i = 0; i < nop->u.s.noccupied; i++) {
-                    int pp = nop->u.s.suns[i];
+                for(i = 0; i < nop->s.noccupied; i++) {
+                    int pp = nop->s.suns[i];
                     lv->ngblist[numcand++] = pp;
                 }
-                no = nop->u.d.sibling;
+                no = nop->sibling;
             }
             else if (nop->f.ChildType == PSEUDO_NODE_TYPE)
             {
                 if(lv->mode == 0)
                 {
-                    if(-1 == treewalk_export_particle(lv, nop->u.d.nextnode))
+                    if(-1 == treewalk_export_particle(lv, nop->nextnode))
                         return -1;
                 }
 
                 /* Move to the sibling (likely also a pseudo node)*/
-                no = nop->u.d.sibling;
+                no = nop->sibling;
             }
             else if(nop->f.ChildType == NODE_NODE_TYPE)
             {
                 /* This node contains other nodes and we need to open it.*/
-                no = nop->u.d.nextnode;
+                no = nop->nextnode;
             }
         }
         int i;

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -319,11 +319,10 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 if(input->Soft < nop->mom.MaxSoftening)
                 {
                     if(r2 < h * h)
-                        if(nop->f.MixedSofteningsInNode)
-                        {
-                            no = nop->nextnode;
-                            continue;
-                        }
+                    {
+                        no = nop->nextnode;
+                        continue;
+                    }
                 }
 
                 /* ok, node can be used */

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -348,7 +348,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             {
                 if(lv->mode == 0)
                 {
-                    if(-1 == treewalk_export_particle(lv, nop->u.s.suns[0]))
+                    if(-1 == treewalk_export_particle(lv, nop->u.d.nextnode))
                         return -1;
                 }
 

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -268,13 +268,19 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     const double * inpos = input->base.Pos;
 
     /*Start the tree walk*/
-    int no = input->base.NodeList[0];
-    int listindex = 1;
-    no = tree->Nodes[no].u.d.nextnode;	/* open it */
+    int listindex;
 
-    while(no >= 0)
+    /* Primary treewalk only ever has one nodelist entry*/
+    for(listindex = 0; listindex < NODELISTLENGTH && (lv->mode == 1 || listindex < 1); listindex++)
     {
         int numcand = 0;
+        /* Use the next node in the node list if we are doing a secondary walk.
+         * For a primary walk the node list only ever contains one node. */
+        int no = input->base.NodeList[listindex];
+        int startno = no;
+        if(no < 0)
+            break;
+
         while(no >= 0)
         {
             /* The tree always walks internal nodes*/
@@ -282,7 +288,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
             if(lv->mode == 1)
             {
-                if(nop->f.TopLevel)	/* we reached a top-level node again, which means that we are done with the branch */
+                if(nop->f.TopLevel && no != startno)	/* we reached a top-level node again, which means that we are done with the branch */
                 {
                     no = -1;
                     continue;
@@ -373,19 +379,6 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             /* Compute the acceleration and apply it to the output structure*/
             apply_accn_to_output(output, dx, r2, h, P[pp].Mass, cellsize);
         }
-
-        /* Use the next node in the node list if we are doing a secondary walk.
-         * For a primary walk the node list only ever contains one node. */
-        if(lv->mode == 1 && listindex < NODELISTLENGTH)
-        {
-            no = input->base.NodeList[listindex];
-            if(no >= 0)
-            {
-                no = tree->Nodes[no].u.d.nextnode;	/* open it */
-                listindex++;
-            }
-        }
-
     }
 
     lv->Ninteractions += output->Ninteractions;

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -276,7 +276,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
 
             int no = force_get_father(i, &Tree);
 
-            while(10 * DesNumNgb * P[i].Mass > massfactor * Tree.Nodes[no].u.d.mass)
+            while(10 * DesNumNgb * P[i].Mass > massfactor * Tree.Nodes[no].mom.mass)
             {
                 int p = force_get_father(no, &Tree);
 
@@ -287,7 +287,7 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp)
             }
 
             P[i].Hsml =
-                pow(3.0 / (4 * M_PI) * DesNumNgb * P[i].Mass / (massfactor * Tree.Nodes[no].u.d.mass),
+                pow(3.0 / (4 * M_PI) * DesNumNgb * P[i].Mass / (massfactor * Tree.Nodes[no].mom.mass),
                         1.0 / 3) * Tree.Nodes[no].len;
 
             /* recover from a poor initial guess */

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -326,7 +326,6 @@ sfr_reserve_slots(ActiveParticles * act, int * NewStars, int NumNewStar, ForceTr
         }
         /*Move the tree to upper memory*/
         struct NODE * nodes_base_tmp=NULL;
-        int *Nextnode_tmp=NULL;
         int *Father_tmp=NULL;
         int *ActiveParticle_tmp=NULL;
         if(force_tree_allocated(tree)) {
@@ -336,9 +335,6 @@ sfr_reserve_slots(ActiveParticles * act, int * NewStars, int NumNewStar, ForceTr
             Father_tmp = mymalloc2("Father_tmp", PartManager->MaxPart * sizeof(int));
             memmove(Father_tmp, tree->Father, PartManager->MaxPart * sizeof(int));
             myfree(tree->Father);
-            Nextnode_tmp = mymalloc2("Nextnode_tmp", tree->Nnextnode * sizeof(int));
-            memmove(Nextnode_tmp, tree->Nextnode, tree->Nnextnode * sizeof(int));
-            myfree(tree->Nextnode);
         }
         if(act->ActiveParticle) {
             ActiveParticle_tmp = mymalloc2("ActiveParticle_tmp", act->NumActiveParticle * sizeof(int));
@@ -360,9 +356,6 @@ sfr_reserve_slots(ActiveParticles * act, int * NewStars, int NumNewStar, ForceTr
             myfree(ActiveParticle_tmp);
         }
         if(force_tree_allocated(tree)) {
-            tree->Nextnode = mymalloc("Nextnode", tree->Nnextnode * sizeof(int));
-            memmove(tree->Nextnode, Nextnode_tmp, tree->Nnextnode * sizeof(int));
-            myfree(Nextnode_tmp);
             tree->Father = mymalloc("Father", PartManager->MaxPart * sizeof(int));
             memmove(tree->Father, Father_tmp, PartManager->MaxPart * sizeof(int));
             myfree(Father_tmp);

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -123,9 +123,8 @@ slots_split_particle(int parent, double childmass, struct part_manager_type * pm
     pman->Base[child].PI = -1;
 
     /*! When a new additional star particle is created, we can put it into the
-     *  tree at the position of the spawning gas particle. This is possible
-     *  because the Nextnode[] array essentially describes the full tree walk as a
-     *  link list. Multipole moments of tree nodes need not be changed.
+     *  tree at the position of the spawning gas particle. Multipole moments
+     *  of tree nodes need not be changed.
      */
     /* emit event for forcetree to deal with the new particle */
     EISlotsFork event = {

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -41,7 +41,7 @@ static void set_init_hsml(ForceTree * Tree)
         int no = force_get_father(i, Tree);
 
         double DesNumNgb = GetNumNgb(GetDensityKernelType());
-        while(10 * DesNumNgb * P[i].Mass > Tree->Nodes[no].u.d.mass)
+        while(10 * DesNumNgb * P[i].Mass > Tree->Nodes[no].mom.mass)
         {
             int p = force_get_father(no, Tree);
 
@@ -52,7 +52,7 @@ static void set_init_hsml(ForceTree * Tree)
         }
 
         P[i].Hsml =
-            pow(3.0 / (4 * M_PI) * DesNumNgb * P[i].Mass / (Tree->Nodes[no].u.d.mass),
+            pow(3.0 / (4 * M_PI) * DesNumNgb * P[i].Mass / (Tree->Nodes[no].mom.mass),
                     1.0 / 3) * Tree->Nodes[no].len;
     }
 }

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -126,12 +126,11 @@ static int check_moments(const ForceTree * tb, const int numpart, const int nrea
             sibcntr++;
 
         if(!(tb->Nodes[node].mom.mass < 0.5 && tb->Nodes[node].mom.mass > -0.5)) {
-            printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g MSN %d ITL %d\n",
+            printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g ITL %d\n",
                 node, node - tb->firstnode, tb->Nodes[node].mom.mass, oldmass[node - tb->firstnode],
                 tb->Nodes[node].f.TopLevel,
                 tb->Nodes[node].f.DependsOnLocalMass,
                 tb->Nodes[node].mom.MaxSoftening,
-                tb->Nodes[node].f.MixedSofteningsInNode,
                 tb->Nodes[node].f.InternalTopLevel
             );
             /* something is wrong show the particles */

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -246,9 +246,7 @@ static void do_tree_test(const int numpart, const ForceTree tb, DomainDecomp * d
     int nrealnode = check_tree(&tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
-    int tail = force_update_node_parallel(&tb, 0);
-    force_set_next_node(tail, -1, &tb);
-/*     assert_true(tail < nodes); */
+    force_update_node_parallel(&tb, 0);
     end = MPI_Wtime();
     ms = (end - start)*1000;
     printf("Updated moments in %.3g ms. Total mass: %g\n", ms, tb.Nodes[numpart].u.d.mass);

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -902,7 +902,7 @@ cull_node(const TreeWalkQueryBase * const I, const TreeWalkNgbIterBase * const i
 {
     double dist;
     if(iter->symmetric == NGB_TREEFIND_SYMMETRIC) {
-        dist = DMAX(current->u.d.hmax, iter->Hsml) + 0.5 * current->len;
+        dist = DMAX(current->mom.hmax, iter->Hsml) + 0.5 * current->len;
     } else {
         dist = iter->Hsml + 0.5 * current->len;
     }
@@ -979,19 +979,19 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
         /* Cull the node */
         if(0 == cull_node(I, iter, current, BoxSize)) {
             /* in case the node can be discarded */
-            no = current->u.d.sibling;
+            no = current->sibling;
             continue;
         }
 
         /* Node contains relevant particles, add them.*/
         if(current->f.ChildType == PARTICLE_NODE_TYPE) {
             int i;
-            int * suns = current->u.s.suns;
-            for (i = 0; i < current->u.s.noccupied; i++) {
+            int * suns = current->s.suns;
+            for (i = 0; i < current->s.noccupied; i++) {
                 lv->ngblist[numcand++] = suns[i];
             }
             /* Move sideways*/
-            no = current->u.d.sibling;
+            no = current->sibling;
             continue;
         }
         else if(current->f.ChildType == PSEUDO_NODE_TYPE) {
@@ -1000,15 +1000,15 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 endrun(12312, "Touching outside of my domain from a node list of a ghost. This shall not happen.");
             } else {
                 /* Export the pseudo particle*/
-                if(-1 == treewalk_export_particle(lv, current->u.d.nextnode))
+                if(-1 == treewalk_export_particle(lv, current->nextnode))
                     return -1;
                 /* Move sideways*/
-                no = current->u.d.sibling;
+                no = current->sibling;
                 continue;
             }
         }
         /* ok, we need to open the node */
-        no = current->u.d.nextnode;
+        no = current->nextnode;
     }
 
     return numcand;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -830,9 +830,7 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
 
     for(inode = 0; inode < NODELISTLENGTH && I->NodeList[inode] >= 0; inode++)
     {
-        int startnode = lv->tw->tree->Nodes[I->NodeList[inode]].u.d.nextnode;  /* open it */
-
-        int numcand = ngb_treefind_threads(I, O, iter, startnode, lv);
+        int numcand = ngb_treefind_threads(I, O, iter, I->NodeList[inode], lv);
         /* Export buffer is full end prematurally */
         if(numcand < 0) return numcand;
 
@@ -952,6 +950,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
 
     const ForceTree * tree = lv->tw->tree;
     const double BoxSize = tree->BoxSize;
+
     no = startnode;
 
     while(no >= 0)
@@ -970,7 +969,8 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
         /* When walking exported particles we start from the encompassing top-level node,
          * so if we get back to a top-level node again we are done.*/
         if(lv->mode == 1) {
-            if(current->f.TopLevel) {
+            /* The first node is always top-level*/
+            if(current->f.TopLevel && no != startnode) {
                 /* we reached a top-level node again, which means that we are done with the branch */
                 break;
             }

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1000,9 +1000,12 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 endrun(12312, "Touching outside of my domain from a node list of a ghost. This shall not happen.");
             } else {
                 /* Export the pseudo particle*/
-                no = force_get_next_node(no, tree);
-                if(-1 == treewalk_export_particle(lv, no))
+                int * suns = current->u.s.suns;
+                if(-1 == treewalk_export_particle(lv, suns[0]))
                     return -1;
+                /* Move sideways*/
+                no = current->u.d.sibling;
+                continue;
             }
         }
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1000,8 +1000,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 endrun(12312, "Touching outside of my domain from a node list of a ghost. This shall not happen.");
             } else {
                 /* Export the pseudo particle*/
-                int * suns = current->u.s.suns;
-                if(-1 == treewalk_export_particle(lv, suns[0]))
+                if(-1 == treewalk_export_particle(lv, current->u.d.nextnode))
                     return -1;
                 /* Move sideways*/
                 no = current->u.d.sibling;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1008,10 +1008,8 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 continue;
             }
         }
-
-        int nextnode = force_get_next_node(no, tree);
         /* ok, we need to open the node */
-        no = nextnode;
+        no = current->u.d.nextnode;
     }
 
     return numcand;

--- a/tests/stub.c
+++ b/tests/stub.c
@@ -33,7 +33,7 @@ _cmocka_run_group_tests_mpi(const char * name, const struct CMUnitTest tests[], 
     }
     /* allocate some memory for MAIN and TEMP */
 
-    allocator_init(A_MAIN, "MAIN", 256 * 1024 * 1024, 1, NULL);
+    allocator_init(A_MAIN, "MAIN", 360 * 1024 * 1024, 1, NULL);
     allocator_init(A_TEMP, "TEMP", 8 * 1024 * 1024, 1, A_MAIN);
 
     message(0, "GADGET_TESTDATA_ROOT : %s\n", GADGET_TESTDATA_ROOT);


### PR DESCRIPTION
This commit keeps around the suns array in the force tree node and uses it for leaf tree walks. In principle this should make the tree walking faster because all leaf particle accesses are linear, and the tree build faster because memcpy is no longer needed at every step. It also makes debugging easier (because now one can see the tree structure at all times) and removes a common source of bugs. 

It does bloat the size of the tree nodes by ~30%, but we get some of the memory back because we don't need the Nextnode array anymore. 

Mostly this is a reorganisation: the real reason is that it enables future optimizations, like skipping the moments build (because nextnode and sibling can now be set during the initial node creation) and walking the tree for all particles in a node at once.

Please review! Lightly tested so far.