### PR TITLE
Nospinlocks

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -100,8 +100,6 @@ struct BHPriv {
      * in the feedback treewalk*/
     MyFloat * BH_FeedbackWeightSum;
 
-    /* Particle SpinLocks*/
-    struct SpinLocks * spin;
     /* Counters*/
     int64_t * N_sph_swallowed;
     int64_t * N_BH_swallowed;
@@ -247,9 +245,7 @@ blackhole(const ActiveParticles * act, ForceTree * tree, FILE * FdBlackHoles)
     priv->BH_SurroundingGasVel = (MyFloat (*) [3]) mymalloc("BH_SurroundVel", 3* SlotsManager->info[5].size * sizeof(priv->BH_SurroundingGasVel[0]));
 
     /* This allocates memory*/
-    priv[0].spin = init_spinlocks(PartManager->NumPart);
     treewalk_run(tw_accretion, act->ActiveParticle, act->NumActiveParticle);
-    free_spinlocks(priv[0].spin);
 
     myfree(priv->BH_SurroundingGasVel);
     myfree(priv->BH_Entropy);
@@ -463,31 +459,33 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     /* Accretion / merger doesn't do self interaction */
     if(P[other].ID == I->ID) return;
 
-    struct SpinLocks * spin = BH_GET_PRIV(lv->tw)->spin;
-
     if(P[other].Type == 5 && r2 < iter->accretion_kernel.HH)	/* we have a black hole merger */
     {
         /* We do not depend on the BH relative velocity.
          * Because the BHs are not dissipative, their relative velocities
          * can be large, causing clumps of BHs to build up
          * at the same position without merging. */
+        MyIDType readid, newswallowid;
 
-        lock_spinlock(other, spin);
-        if(BHP(other).SwallowID != (MyIDType) -1) {
-           /* Here we mark the black hole as "ready to be swallowed" using the SwallowID.
-            * The actual swallowing is done in the feedback treewalk by setting Swallowed = 1
-            * and merging the masses.*/
-            /* Already marked, prefer to be swallowed by a bigger ID */
-            if(BHP(other).SwallowID < I->ID) {
-                BHP(other).SwallowID = I->ID;
+        #pragma omp atomic read
+        readid = (BHP(other).SwallowID);
+
+        /* Here we mark the black hole as "ready to be swallowed" using the SwallowID.
+         * The actual swallowing is done in the feedback treewalk by setting Swallowed = 1
+         * and merging the masses.*/
+        do {
+            /* Generate the new ID from the old*/
+            if(readid != (MyIDType) -1 && readid < I->ID ) {
+                /* Already marked, prefer to be swallowed by a bigger ID */
+                newswallowid = I->ID;
+            } else if(readid == (MyIDType) -1 && P[other].ID < I->ID) {
+                /* Unmarked, the BH with bigger ID swallows */
+                newswallowid = I->ID;
             }
-        } else {
-            /* Unmarked, the BH with bigger ID swallows */
-            if(P[other].ID < I->ID) {
-                BHP(other).SwallowID = I->ID;
-            }
-        }
-        unlock_spinlock(other, spin);
+            else
+                break;
+        /* Swap in the new id only if the old one hasn't changed*/
+        } while(!__atomic_compare_exchange_n(&(BHP(other).SwallowID), &readid, newswallowid, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
     }
 
     if(P[other].Type == 0) {
@@ -517,13 +515,19 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             if(w < p)
             {
                 MyIDType * SPH_SwallowID = BH_GET_PRIV(lv->tw)->SPH_SwallowID;
-                lock_spinlock(other, spin);
-                /* Already marked, prefer to be swallowed by a bigger ID.
-                 * Not marked, the SwallowID is 0 */
-                if(SPH_SwallowID[P[other].PI] < I->ID+1) {
-                    SPH_SwallowID[P[other].PI] = I->ID+1;
-                }
-                unlock_spinlock(other, spin);
+                MyIDType readid, newswallowid;
+                #pragma omp atomic read
+                readid = SPH_SwallowID[P[other].PI];
+                do {
+                    /* Already marked, prefer to be swallowed by a bigger ID.
+                     * Not marked, the SwallowID is 0 */
+                    if(readid < I->ID + 1) {
+                        newswallowid = I->ID + 1;
+                    }
+                    else
+                        break;
+                    /* Swap in the new id only if the old one hasn't changed*/
+                } while(!__atomic_compare_exchange_n(&SPH_SwallowID[P[other].PI], &readid, newswallowid, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
             }
         }
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -484,7 +484,8 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             }
             else
                 break;
-        /* Swap in the new id only if the old one hasn't changed*/
+        /* Swap in the new id only if the old one hasn't changed:
+         * in principle an extension, but supported on at least clang >= 9, gcc >= 5 and icc >= 18.*/
         } while(!__atomic_compare_exchange_n(&(BHP(other).SwallowID), &readid, newswallowid, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
     }
 

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -159,7 +159,6 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
 static int* NPLeft;
 
 struct WindPriv {
-    struct SpinLocks * spin;
 };
 #define WIND_GET_PRIV(tw) ((struct WindPriv *) (tw->priv))
 
@@ -230,9 +229,7 @@ winds_and_feedback(int * NewStars, int NumNewStars, ForceTree * tree)
     struct WindPriv priv[1];
     tw->priv = priv;
 
-    priv[0].spin = init_spinlocks(PartManager->NumPart);
     treewalk_run(tw, NewStars, NumNewStars);
-    free_spinlocks(priv[0].spin);
     myfree(Winddata);
     walltime_measure("/Cooling/Wind");
 }
@@ -439,19 +436,23 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
         get_wind_dir(other, dir);
         /* in this case the particle is already locked by the tree walker */
         /* we may want to add another lock to avoid this. */
-        if(P[other].ID != I->base.ID)
-            lock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
         int j;
         for(j = 0; j < 3; j++)
         {
+            #pragma omp atomic update
             P[other].Vel[j] += v * dir[j];
         }
         /* If the particle is already a wind, just use the largest DelayTime, and still add wind energy.
          * If we ignore wind particles, as was done before, we end up giving each particle the velocity dispersion
          * associated with the first particle that hits it, which is very timing dependent in threaded environments. */
-        SPHP(other).DelayTime = DMAX(wind_params.WindFreeTravelLength / (v / All.cf.a), SPHP(other).DelayTime);
-        if(P[other].ID != I->base.ID)
-            unlock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
+        MyFloat readdelay, newdelay;
+        #pragma omp atomic read
+        readdelay = SPHP(other).DelayTime;
+        do {
+            newdelay = DMAX(wind_params.WindFreeTravelLength / (v / All.cf.a), readdelay);
+            /* Swap in the new id only if the old one hasn't changed:
+             * in principle an extension, but supported on at least clang >= 9, gcc >= 5 and icc >= 18.*/
+        } while(!__atomic_compare_exchange(&(SPHP(other).DelayTime), &readdelay, &newdelay, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
     }
 }
 


### PR DESCRIPTION
This is attempt 2 at removing the spinlocks. It is documented to work (unless I have made a bug). It is a compare exchange algorithm which will work best when the memory is uncontended (often for us). Technically it is a gcc extension (from v 5) but it looks like icc and clang both support it on the versions that we care about. If we find a compiler that doesn't support it, I may back this out.