### PR TITLE
Fix load balance

### DIFF
--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -414,8 +414,10 @@ domain_balance(DomainDecomp * ddecomp)
 
     walltime_measure("/Domain/Decompose/Sumcost");
 
-    /* first try work balance */
-    domain_assign_balanced(ddecomp, TopLeafWork, 1);
+    /* Use a particle load balance instead of work balance.
+     * I was unable to find a workload where the work balance
+     * was significantly faster and several where it was much slower. */
+    domain_assign_balanced(ddecomp, TopLeafCount, 1);
 
     walltime_measure("/Domain/Decompose/assignbalance");
 

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -71,7 +71,7 @@ struct local_topnode_data
 struct local_particle_data
 {
     peano_t Key;
-    int64_t Cost;
+    uint64_t Cost;
 };
 
 /*This is a helper for the tests*/
@@ -326,14 +326,11 @@ void domain_free(DomainDecomp * ddecomp)
     }
 }
 
-static int64_t
+static uint64_t
 domain_particle_costfactor(int i)
 {
     /* We round off GravCost to integer*/
-    if(P[i].TimeBin)
-        return (1 + P[i].GravCost) * (TIMEBASE / (1 << P[i].TimeBin));
-    else
-        return (1 + P[i].GravCost); /* assuming on the full step */
+    return (1 + P[i].GravCost); /* assuming on the full step */
 }
 
 /*! This function carries out the actual domain decomposition for all

--- a/libgadget/gravshort.h
+++ b/libgadget/gravshort.h
@@ -95,7 +95,7 @@ grav_short_reduce(int place, TreeWalkResultGravShort * result, enum TreeWalkRedu
     for(k = 0; k < 3; k++)
         TREEWALK_REDUCE(P[place].GravAccel[k], result->Acc[k]);
 
-    TREEWALK_REDUCE(P[place].GravCost, result->Ninteractions);
+    P[place].GravCost += result->Ninteractions;
     TREEWALK_REDUCE(P[place].Potential, result->Potential);
 }
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -205,7 +205,11 @@ run(int RestartSnapNum)
         /* at first step this is a noop */
         if(is_PM) {
             /* full decomposition rebuilds the tree */
+            int i;
             domain_decompose_full(ddecomp);
+            #pragma omp parallel for
+            for(i = 0; i < PartManager->NumPart; i++)
+                P[i].GravCost = 1;
         } else {
             /* FIXME: add a parameter for ddecomp_decompose_incremental */
             /* currently we drift all particles every step */


### PR DESCRIPTION
I did a quick test and I found that our load balancing is making the final time to solution for the simulation substantially *worse*.

Generally it looks like the tree was helped by the load balancing (the wait times were shorter), but the density and hydro were hurt and this dominated. Setting HydroCostFactor = 0 by default helped, but I could not do better than a simple particle load balance! It might be that our shift towards doing more gravity in the PM code means the load balancing has too few samples to work.

@rainwoodman  what do you think? The total time to solution drops by about 10% with this PR.