### PR TITLE
Fix a floating point roundoff crash when resuming from some snapshots

### DIFF
--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -182,6 +182,8 @@ run(int RestartSnapNum)
 
         /*Convert back to floating point time*/
         set_global_time(All.Ti_Current);
+        if(All.TimeStep < 0)
+            endrun(1, "Negative timestep: %g New Time: %g!\n", All.TimeStep, All.Time);
 
         int is_PM = is_PM_timestep(All.Ti_Current);
 

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -173,9 +173,6 @@ set_global_time(const inttime_t Ti_Current) {
     All.cf.a3inv = 1 / (All.Time * All.Time * All.Time);
     All.cf.hubble = hubble_function(&All.CP, All.Time);
 
-    if(All.TimeStep < 0)
-        endrun(1, "Negative timestep: %g New Time: %g!\n", All.TimeStep, All.Time);
-
 #ifdef LIGHTCONE
     lightcone_set_time(All.cf.a);
 #endif


### PR DESCRIPTION
Simple fix: avoid the check on init.