### PR TITLE
Provide an alternative, non-pthread spinlock implementation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Compile-time options may be set in Options.mk. The remaining compile time option
 - DEBUG which enables various internal code consistency checks for debugging.
 - VALGRIND which if set disables the internal memory allocator and allocates memory from the system. This is required for debugging memory allocation errors with valgrind of the address sanitizer.
 - NO_ISEND_IRECV_IN_DOMAIN disables the use of asynchronous send and receive in our custom MPI_Alltoallv implementation, for buggy MPI libraries.
-- NO_OPENMP_SPINLOCK disables the use of OpenMP spinlocks and thus effectively disables threading. Necessary for platforms which do not provide an OpenMP header, such as Mac.
+- NO_OPENMP_SPINLOCK uses the OpenMP default locking routines. These are often much slower than the default pthread spinlocks. However, they are necessary for Mac, which does not provide pthreads.
 
 If compilation fails with errors related to the GSL, you may also need to set the GSL_INC or GSL_LIB variables in Options.mk to the filesystem path containing the GSL headers and libraries.
 

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -59,12 +59,7 @@ int main(int argc, char **argv)
 
     message(0, "This is MP-Gadget, version %s.\n", GADGET_VERSION);
     message(0, "Running on %d MPI Ranks.\n", NTask);
-#ifdef NO_OPENMP_SPINLOCK
-    message(0,"Code compiled with NO_OPENMP_SPINLOCK (no locks), so no OpenMP threads.\n");
-    omp_set_num_threads(1);
-#else
     message(0, "           %d OpenMP Threads.\n", omp_get_max_threads());
-#endif
     message(0, "Code was compiled with settings:\n"
            "%s\n", GADGET_COMPILER_SETTINGS);
     message(0, "Size of particle structure       %td  [bytes]\n",sizeof(struct particle_data));

--- a/libgadget/utils/spinlocks.c
+++ b/libgadget/utils/spinlocks.c
@@ -3,6 +3,8 @@
 
 #ifndef NO_OPENMP_SPINLOCK
 #include <pthread.h>
+#else
+#include <omp.h>
 #endif
 
 /* Temporary array for spinlocks*/
@@ -10,6 +12,8 @@ struct SpinLocks
 {
 #ifndef NO_OPENMP_SPINLOCK
     pthread_spinlock_t * SpinLocks;
+#else
+    omp_lock_t * SpinLocks;
 #endif
     int NumSpinLock;
 };
@@ -19,11 +23,15 @@ static struct SpinLocks spin;
 void lock_spinlock(int i, struct SpinLocks * spin) {
 #ifndef NO_OPENMP_SPINLOCK
     pthread_spin_lock(&spin->SpinLocks[i]);
+#else
+    omp_set_lock(&spin->SpinLocks[i]);
 #endif
 }
 void unlock_spinlock(int i,  struct SpinLocks * spin) {
 #ifndef NO_OPENMP_SPINLOCK
     pthread_spin_unlock(&spin->SpinLocks[i]);
+#else
+    omp_unset_lock(&spin->SpinLocks[i]);
 #endif
 }
 
@@ -32,33 +40,43 @@ int try_lock_spinlock(int i,  struct SpinLocks * spin)
 #ifndef NO_OPENMP_SPINLOCK
     return pthread_spin_trylock(&spin->SpinLocks[i]);
 #else
-    return 0;
+    /* omp returns true if successful, ie, lock taken.
+     * pthread_spin_lock returns 0 on success*/
+    return !omp_test_lock(&spin->SpinLocks[i]);
 #endif
 }
 
 struct SpinLocks * init_spinlocks(int NumLock)
 {
-#ifndef NO_OPENMP_SPINLOCK
     int i;
     /* Initialize the spinlocks*/
+#ifndef NO_OPENMP_SPINLOCK
     spin.SpinLocks = mymalloc("SpinLocks", NumLock * sizeof(pthread_spinlock_t));
+#else
+    spin.SpinLocks = mymalloc("SpinLocks", NumLock * sizeof(omp_lock_t));
+#endif
     #pragma omp parallel for
     for(i = 0; i < NumLock; i ++) {
+#ifndef NO_OPENMP_SPINLOCK
         pthread_spin_init(&spin.SpinLocks[i], PTHREAD_PROCESS_PRIVATE);
-    }
+#else
+        omp_init_lock(&spin.SpinLocks[i]);
 #endif
+    }
     spin.NumSpinLock = NumLock;
     return &spin;
 }
 
 void free_spinlocks(struct SpinLocks * spin)
 {
-#ifndef NO_OPENMP_SPINLOCK
     int i;
     for(i = 0; i < spin->NumSpinLock; i ++) {
+#ifndef NO_OPENMP_SPINLOCK
         pthread_spin_destroy(&(spin->SpinLocks[i]));
+#else
+        omp_destroy_lock(&(spin->SpinLocks[i]));
+#endif
     }
     myfree((void *) spin->SpinLocks);
-#endif
 }
 

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -5,6 +5,6 @@ OPTIMIZE += -fnocommon
 
 #OPT += -DVALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#Disable openmp locking. This means no threading. Required on mac.
+#Use alternative OpenMP locks, instead of the pthread spinlocks. Required on mac.
 OPT += -DNO_OPENMP_SPINLOCK
 #OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
Selected by the compile flag and enabled for Mac. It is slower but for
Mac that will be ok.