### PR TITLE
Softeningcleanup

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -175,7 +175,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "PairwiseActiveFraction", OPTIONAL, 5e-7, "Pairwise gravity instead of tree gravity is used if N(active particles) / N(particles) is less than this.");
 
     param_declare_double(ps, "GravitySoftening", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM. ForceSoftening is 2.8 times this.");
-    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisional particles (Gas); units of mean separation of DM; 0 to use Hsml of last step. ");
+    param_declare_int(ps, "GravitySofteningGas", OPTIONAL, 1, "0 to use adaptive softening, where the gas softening is the smoothing length of the last step.");
 
     param_declare_int(ps, "ImportBufferBoost", OPTIONAL, 2, "Memory factor to allow for there being more particles imported during treewlk than exported. Increase this if code crashes during treewalk with out of memory.");
     param_declare_double(ps, "PartAllocFactor", OPTIONAL, 1.5, "Over-allocation factor of particles. The load can be imbalanced to allow for the work to be more balanced.");

--- a/libgadget/allvars.h
+++ b/libgadget/allvars.h
@@ -125,9 +125,6 @@ extern struct global_data_all_processes
 
     double HydroCostFactor; /* cost factor for hydro in load balancing. */
 
-    double GravitySoftening; /* Softening as a fraction of DM mean separation. */
-    double GravitySofteningGas;  /* if 0, enable adaptive gravitational softening for gas particles, which uses the Hsml as ForceSoftening */
-
     double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
     /* some filenames */

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -242,7 +242,7 @@ density(const ActiveParticles * act, int update_hsml, int DoEgyDensity, int Blac
     DENSITY_GET_PRIV(tw)->NIteration = 0;
 
     DENSITY_GET_PRIV(tw)->DesNumNgb = GetNumNgb(DensityParams.DensityKernelType);
-    DENSITY_GET_PRIV(tw)->MinGasHsml = DensityParams.MinGasHsmlFractional * FORCE_SOFTENING(1, 1);
+    DENSITY_GET_PRIV(tw)->MinGasHsml = DensityParams.MinGasHsmlFractional * (FORCE_SOFTENING(1, 1)/2.8);
 
     DENSITY_GET_PRIV(tw)->BlackHoleOn = BlackHoleOn;
     DENSITY_GET_PRIV(tw)->HydroCostFactor = HydroCostFactor * atime;

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -15,6 +15,7 @@
 #include "slotsmanager.h"
 #include "timestep.h"
 #include "utils.h"
+#include "gravity.h"
 
 #define MAXITER 400
 
@@ -241,7 +242,7 @@ density(const ActiveParticles * act, int update_hsml, int DoEgyDensity, int Blac
     DENSITY_GET_PRIV(tw)->NIteration = 0;
 
     DENSITY_GET_PRIV(tw)->DesNumNgb = GetNumNgb(DensityParams.DensityKernelType);
-    DENSITY_GET_PRIV(tw)->MinGasHsml = DensityParams.MinGasHsmlFractional * GravitySofteningTable[1];
+    DENSITY_GET_PRIV(tw)->MinGasHsml = DensityParams.MinGasHsmlFractional * FORCE_SOFTENING(1, 1);
 
     DENSITY_GET_PRIV(tw)->BlackHoleOn = BlackHoleOn;
     DENSITY_GET_PRIV(tw)->HydroCostFactor = HydroCostFactor * atime;

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -46,9 +46,6 @@ struct NODE
         MyFloat cofm[3];		/*!< center of mass of node */
         MyFloat mass;		/*!< mass of node */
         MyFloat hmax;           /*!< maximum amount by which Pos + Hsml of all gas particles in the node exceeds len for this node. */
-        MyFloat MaxSoftening;  /* Stores the largest softening in the node. The short-range
-                         * gravitational force solver will check this and use it
-                         * open the node if a particle is closer.*/
     } mom;
 
     /* In principle storing this here wastes memory, because we only use it for the leaf nodes.

--- a/libgadget/gravity.h
+++ b/libgadget/gravity.h
@@ -14,6 +14,10 @@ struct gravshort_tree_params
     /*! RCUT gives the maximum distance (in units of the scale used for the force split) out to which short-range
      * forces are evaluated in the short-range tree walk.*/
     double Rcut;
+    /* Softening as a fraction of DM mean separation. */
+    double FractionalGravitySoftening;
+    /* if 1, enable adaptive gravitational softening for gas particles, which uses the Hsml as the ForceSoftening */
+    int AdaptiveSoftening;
 };
 
 enum ShortRangeForceWindowType {
@@ -23,6 +27,13 @@ enum ShortRangeForceWindowType {
 
 /* Fill the short-range gravity table*/
 void gravshort_fill_ntab(const enum ShortRangeForceWindowType ShortRangeForceWindowType, const double Asmth);
+
+/*! Sets the (comoving) softening length, converting from units of the mean DM separation to comoving internal units. */
+void gravshort_set_softenings(double MeanDMSeparation);
+
+/* gravitational softening length
+ * (given in terms of an `equivalent' Plummer softening length) */
+double FORCE_SOFTENING(int i, int type);
 
 /*Defined in gravpm.c*/
 void gravpm_init_periodic(PetaPM * pm, double BoxSize, double Asmth, int Nmesh, double G);

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -90,7 +90,7 @@ grav_short_pair_ngbiter(
     double mass = P[other].Mass;
 
     double h = I->Soft;
-    double otherh = FORCE_SOFTENING(other);
+    double otherh = FORCE_SOFTENING(other, P[other].Type);
     if (otherh > h) h = otherh;
 
     double fac, pot;

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -27,6 +27,29 @@
  */
 
 static struct gravshort_tree_params TreeParams;
+/*Softening length*/
+double GravitySoftening;
+
+/* gravitational softening length
+ * (given in terms of an `equivalent' Plummer softening length)
+ */
+double FORCE_SOFTENING(int i, int type)
+{
+    if (TreeParams.AdaptiveSoftening == 1 && type == 0) {
+        return P[i].Hsml;
+    }
+    /* Force is Newtonian beyond this.*/
+    return 2.8 * GravitySoftening;
+}
+
+/*! Sets the (comoving) softening length, converting from units of the mean separation to comoving internal units. */
+void
+gravshort_set_softenings(double MeanSeparation)
+{
+    GravitySoftening = TreeParams.FractionalGravitySoftening * MeanSeparation;
+    /* 0: Gas is collisional */
+    message(0, "GravitySoftening = %g\n", GravitySoftening);
+}
 
 /*This is a helper for the tests*/
 void set_gravshort_treepar(struct gravshort_tree_params tree_params)
@@ -51,6 +74,10 @@ set_gravshort_tree_params(ParameterSet * ps)
         TreeParams.BHOpeningAngle = param_get_double(ps, "BHOpeningAngle");
         TreeParams.TreeUseBH= param_get_int(ps, "TreeUseBH");
         TreeParams.Rcut = param_get_double(ps, "TreeRcut");
+        TreeParams.FractionalGravitySoftening = param_get_double(ps, "GravitySoftening");
+        TreeParams.AdaptiveSoftening = !param_get_int(ps, "GravitySofteningGas");
+
+
     }
     MPI_Bcast(&TreeParams, sizeof(struct gravshort_tree_params), MPI_BYTE, 0, MPI_COMM_WORLD);
 }
@@ -316,7 +343,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             if(!shall_we_open_node(nop->len, nop->mom.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2))
             {
                 double h = input->Soft;
-                if(GravitySofteningTable[0] == 0 && (input->Soft < nop->mom.hmax))
+                if(TreeParams.AdaptiveSoftening == 1 && (input->Soft < nop->mom.hmax))
                 {
                     /* Always open the node if it has a larger softening than the particle,
                      * and the particle is inside its softening radius.
@@ -378,7 +405,9 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 dx[j] = NEAREST(P[pp].Pos[j] - inpos[j], BoxSize);
             const double r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
 
-            double h = DMAX(input->Soft, FORCE_SOFTENING(pp));
+            double h = input->Soft;
+            if(TreeParams.AdaptiveSoftening == 1)
+                h = DMAX(h, FORCE_SOFTENING(pp, P[pp].Type));
             /* Compute the acceleration and apply it to the output structure*/
             apply_accn_to_output(output, dx, r2, h, P[pp].Mass, cellsize);
         }

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -315,12 +315,13 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             /* This node accelerates the particle directly, and is not opened.*/
             if(!shall_we_open_node(nop->len, nop->mom.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2))
             {
-                double h = DMAX(input->Soft, nop->mom.MaxSoftening);
-                /* Always open the node if it has a larger softening than the particle,
-                 * and the particle is inside its softening radius.
-                 * This condition essentially never happens, and it is not clear how much sense it makes. */
-                if(input->Soft < nop->mom.MaxSoftening)
+                double h = input->Soft;
+                if(GravitySofteningTable[0] == 0 && (input->Soft < nop->mom.hmax))
                 {
+                    /* Always open the node if it has a larger softening than the particle,
+                     * and the particle is inside its softening radius.
+                     * This condition only ever applies for adaptive softenings. It may or may not make sense. */
+                    h = DMAX(input->Soft, nop->mom.hmax);
                     if(r2 < h * h)
                     {
                         no = nop->nextnode;

--- a/libgadget/gravshort.h
+++ b/libgadget/gravshort.h
@@ -65,7 +65,7 @@ grav_short_postprocess(int i, TreeWalk * tw)
     P[i].GravAccel[2] *= G;
     /* calculate the potential */
     /* remove self-potential */
-    P[i].Potential += P[i].Mass / (FORCE_SOFTENING(i) / 2.8);
+    P[i].Potential += P[i].Mass / (FORCE_SOFTENING(i, P[i].Type) / 2.8);
 
     P[i].Potential -= 2.8372975 * pow(P[i].Mass, 2.0 / 3) * GRAV_GET_PRIV(tw)->cbrtrho0;
 
@@ -76,7 +76,7 @@ static void
 grav_short_copy(int place, TreeWalkQueryGravShort * input, TreeWalk * tw)
 {
     input->Type = P[place].Type;
-    input->Soft = FORCE_SOFTENING(place);
+    input->Soft = FORCE_SOFTENING(place, input->Type);
     /*Compute old acceleration before we over-write things*/
     double aold=0;
     int i;

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -88,9 +88,6 @@ set_init_params(ParameterSet * ps)
         All.TimeBetweenSeedingSearch = param_get_double(ps, "TimeBetweenSeedingSearch");
         All.RandomParticleOffset = param_get_double(ps, "RandomParticleOffset");
 
-        All.GravitySoftening = param_get_double(ps, "GravitySoftening");
-        All.GravitySofteningGas = param_get_double(ps, "GravitySofteningGas");
-
         All.PartAllocFactor = param_get_double(ps, "PartAllocFactor");
         All.SlotsIncreaseFactor = param_get_double(ps, "SlotsIncreaseFactor");
 

--- a/libgadget/partmanager.c
+++ b/libgadget/partmanager.c
@@ -9,9 +9,6 @@
  */
 struct part_manager_type PartManager[1] = {{0}};
 
-/*Softening table*/
-double GravitySofteningTable[6];
-
 void
 particle_alloc_memory(int MaxPart)
 {

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -77,23 +77,6 @@ extern struct part_manager_type {
 /*Allocate memory for the particles*/
 void particle_alloc_memory(int MaxPart);
 
-/* gravitational and hydrodynamical softening lengths (given in terms of an `equivalent' Plummer softening
-    * length)
-    *
-    * five groups of particles are supported 0=gas,1=halo,2=disk,3=bulge,4=stars
-    */
-extern double GravitySofteningTable[6];
-
-static inline double FORCE_SOFTENING(int i)
-{
-    if (GravitySofteningTable[0] == 0 && P[i].Type == 0) {
-        return P[i].Hsml;
-    } else {
-        /* Force is newtonian beyond this.*/
-        return 2.8 * GravitySofteningTable[P[i].Type];
-    }
-}
-
 /* Finds the correct relative position accounting for periodicity*/
 #define NEAREST(x, BoxSize) (((x)>0.5*BoxSize)?((x)-BoxSize):(((x)<-0.5*BoxSize)?((x)+BoxSize):(x)))
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -69,7 +69,6 @@ static void update_random_offset(double * rel_random_shift);
 
 
 static void set_units();
-static void set_softenings();
 
 static void
 open_outputfiles(int RestartSnapNum);
@@ -106,7 +105,6 @@ int begrun(int RestartFlag, int RestartSnapNum)
     if(All.BlackHoleOn || All.NTotalInit[5] > 0)
         slots_set_enabled(5, sizeof(struct bh_particle_data), SlotsManager);
 
-    set_softenings();
     set_units();
 
 #ifdef DEBUG
@@ -122,6 +120,7 @@ int begrun(int RestartFlag, int RestartSnapNum)
 
     init_cooling_and_star_formation();
 
+    gravshort_set_softenings(All.MeanSeparation[1]);
     gravshort_fill_ntab(All.ShortRangeForceWindowType, All.Asmth);
 
     set_random_numbers(All.RandomSeed);
@@ -649,23 +648,3 @@ set_units(void)
     }
     message(0, "\n");
 }
-
-/*! This function sets the (comoving) softening length of all particle
- *  types in the table All.SofteningTable[...].  We check that the physical
- *  softening length is bounded by the Softening-MaxPhys values.
- */
-static void
-set_softenings()
-{
-    int i;
-    for(i = 0; i < 6; i ++)
-        GravitySofteningTable[i] = All.GravitySoftening * All.MeanSeparation[1];
-
-    /* 0: Gas is collisional */
-    GravitySofteningTable[0] = All.GravitySofteningGas * All.MeanSeparation[1];
-
-    for(i = 0; i < 6; i ++) {
-        message(0, "GravitySoftening[%d] = %g\n", i, GravitySofteningTable[i]);
-    }
-}
-

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -18,6 +18,7 @@
 #include <libgadget/domain.h>
 #include <libgadget/forcetree.h>
 #include <libgadget/timestep.h>
+#include <libgadget/gravity.h>
 
 #include "stub.h"
 
@@ -318,7 +319,11 @@ static int setup_density(void **state) {
     data->dp.DensityKernelType = DENSITY_KERNEL_CUBIC_SPLINE;
     BoxSize = 8;
     data->dp.MinGasHsmlFractional = 0.006;
-    gravshort_set_softenings(MeanDMSeparation);
+    struct gravshort_tree_params tree_params = {0};
+    tree_params.FractionalGravitySoftening = 1;
+    set_gravshort_treepar(tree_params);
+
+    gravshort_set_softenings(1);
     data->dp.BlackHoleMaxAccretionRadius = 99999.;
 
     set_densitypar(data->dp);

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -318,7 +318,7 @@ static int setup_density(void **state) {
     data->dp.DensityKernelType = DENSITY_KERNEL_CUBIC_SPLINE;
     BoxSize = 8;
     data->dp.MinGasHsmlFractional = 0.006;
-    GravitySofteningTable[1] = 1;
+    gravshort_set_softenings(MeanDMSeparation);
     data->dp.BlackHoleMaxAccretionRadius = 99999.;
 
     set_densitypar(data->dp);

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -126,11 +126,10 @@ static int check_moments(const ForceTree * tb, const int numpart, const int nrea
             sibcntr++;
 
         if(!(tb->Nodes[node].mom.mass < 0.5 && tb->Nodes[node].mom.mass > -0.5)) {
-            printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g ITL %d\n",
+            printf("node %d (%d) mass %g / %g TL %d DLM %d ITL %d\n",
                 node, node - tb->firstnode, tb->Nodes[node].mom.mass, oldmass[node - tb->firstnode],
                 tb->Nodes[node].f.TopLevel,
                 tb->Nodes[node].f.DependsOnLocalMass,
-                tb->Nodes[node].mom.MaxSoftening,
                 tb->Nodes[node].f.InternalTopLevel
             );
             /* something is wrong show the particles */

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -31,7 +31,6 @@ force_update_node_parallel(const ForceTree * tree, const int HybridNuGrav);
 
 /*Particle data.*/
 struct part_manager_type PartManager[1] = {{0}};
-double GravitySofteningTable[6];
 double BoxSize;
 
 /* The true struct for the state variable*/
@@ -377,10 +376,6 @@ static int setup_tree(void **state) {
     /*Set up the important parts of the All structure.*/
     /*Particles should not be outside this*/
     BoxSize = 8;
-    int i;
-    for(i=0; i<6; i++)
-        GravitySofteningTable[i] = 0.1 / 2.8;
-
     init_forcetree_params(2);
     /*Set up the top-level domain grid*/
     struct forcetree_testdata *data = malloc(sizeof(struct forcetree_testdata));

--- a/libgadget/tests/test_gravity.c
+++ b/libgadget/tests/test_gravity.c
@@ -48,7 +48,7 @@ grav_force(const int this, const int other, const double * offset, double * accn
 
     const double r = sqrt(r2);
 
-    const double h = FORCE_SOFTENING(1);
+    const double h = FORCE_SOFTENING(1, 1);
 
     double fac = 1 / (r2 * r);
     if(r < h) {
@@ -193,8 +193,11 @@ static void do_force_test(double BoxSize, int Nmesh, double Asmth, double ErrTol
     treeacc.TreeUseBH = 1;
     treeacc.Rcut = 7;
     treeacc.ErrTolForceAcc = ErrTolForceAcc;
+    treeacc.AdaptiveSoftening = 0;
+    treeacc.FractionalGravitySoftening = 1./30.;
 
     set_gravshort_treepar(treeacc);
+    gravshort_set_softenings(All.BoxSize / cbrt(PartManager->NumPart));
 
     /* Twice so the opening angle is consistent*/
     grav_short_tree(&act, &pm, &Tree, rho0, 0, 2);
@@ -331,10 +334,6 @@ static int setup_tree(void **state) {
     All.UnitLength_in_cm = CM_PER_MPC/1000.;
     strncpy(All.OutputDir, ".", 5);
     PartManager->NumPart = 16*16*16;
-
-    int i;
-    for(i=0; i<6; i++)
-        GravitySofteningTable[i] = All.BoxSize / cbrt(PartManager->NumPart) / 30.;
 
     struct DomainParams dp = {0};
     dp.DomainOverDecompositionFactor = 2;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -451,7 +451,7 @@ get_timestep_dloga(const int p)
         ac = 1.0e-30;
 
     /* mind the factor 2.8 difference between gravity and softening used here. */
-    dt = sqrt(2 * TimestepParams.ErrTolIntAccuracy * All.cf.a * (FORCE_SOFTENING(p) / 2.8) / ac);
+    dt = sqrt(2 * TimestepParams.ErrTolIntAccuracy * All.cf.a * (FORCE_SOFTENING(p, P[p].Type) / 2.8) / ac);
 
     if(P[p].Type == 0)
     {


### PR DESCRIPTION
Cleanup the force softening code and remove a parameter from the Node structure. This removes the ability to have different softening parameters for different particle types, which is probably a bad idea from the point of view of force accuracy.