### PR TITLE
Largedebug

### DIFF
--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -108,6 +108,10 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
         MPI_Type_commit(&MPI_TYPE_PLAN_ENTRY);
     }
 
+#ifdef DEBUG
+        slots_check_id_consistency(pman, sman);
+#endif
+
     /*Structure for building a list of particles that will be exchanged*/
     ExchangePlan plan = domain_init_exchangeplan(Comm);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -977,6 +977,8 @@ cull_node(const TreeWalkQueryBase * const I, const TreeWalkNgbIterBase * const i
  * iter->base.other, iter->base.dist iter->base.r2, iter->base.r, are properly initialized.
  *
  * */
+#define NHIST 100
+
 static int
 ngb_treefind_threads(TreeWalkQueryBase * I,
         TreeWalkResultBase * O,
@@ -989,11 +991,23 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
 
     const ForceTree * tree = lv->tw->tree;
     const double BoxSize = tree->BoxSize;
+    int walkhist[NHIST] = {0};
+    int walks = 0;
 
     no = startnode;
 
     while(no >= 0)
     {
+        if(walks < NHIST) {
+            /* Store the last few walks*/
+            walkhist[walks++] = no;
+            /* Reset it*/
+            if(walks == NHIST-1)
+            {
+                memcpy(walkhist, walkhist + NHIST - 10, 10 * sizeof(int));
+                walks = 9;
+            }
+        }
         if(node_is_particle(no, tree)) {
             int fat = force_get_father(no, tree);
             endrun(12312, "Particles should be added before getting here! no = %d, father = %d (ptype = %d) start=%d mode = %d\n", no, fat, tree->Nodes[fat].f.ChildType, startnode, lv->mode);
@@ -1020,7 +1034,16 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
             /* in case the node can be discarded */
             if(current->sibling != -1 && !node_is_node(current->sibling, tree)) {
                 int fat = force_get_father(no, tree);
-                endrun(12312, "Culling to invalid node! no = %d, sib %d, father = %d (ptype = %d) start = %d\n", no, current->sibling, fat, tree->Nodes[no].f.ChildType, startnode);
+                int i;
+                for(i = 0; i < walks; i++)
+                    message(1, "walking: %d\n", walkhist[i]);
+                endrun(12312, "Culling to invalid node! no = %d, next %d sib %d, father = %d (ptype = %d) len %g center (%g %g %g) mass %g cofm %g %g %g TL %d DLM %d ITL %d nocc %d suns %d %d %d %d start = %d mode %d Ipos %g %g %g\n",
+                no, current->nextnode, current->sibling, fat, current->f.ChildType,
+                current->len, current->center[0], current->center[1], current->center[2],
+                current->mom.mass, current->mom.cofm[0], current->mom.cofm[1], current->mom.cofm[2],
+                current->f.TopLevel, current->f.DependsOnLocalMass, current->f.InternalTopLevel, current->s.noccupied,
+                current->s.suns[0], current->s.suns[1], current->s.suns[2], current->s.suns[3],
+                startnode, lv->mode, I->Pos[0], I->Pos[1], I->Pos[2]);
             }
             no = current->sibling;
             continue;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1018,6 +1018,10 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
         /* Cull the node */
         if(0 == cull_node(I, iter, current, BoxSize)) {
             /* in case the node can be discarded */
+            if(current->sibling != -1 && !node_is_node(current->sibling, tree)) {
+                int fat = force_get_father(no, tree);
+                endrun(12312, "Culling to invalid node! no = %d, sib %d, father = %d (ptype = %d) start = %d\n", no, current->sibling, fat, tree->Nodes[no].f.ChildType, startnode);
+            }
             no = current->sibling;
             continue;
         }
@@ -1030,6 +1034,10 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 lv->ngblist[numcand++] = suns[i];
             }
             /* Move sideways*/
+            if(current->sibling != -1 && !node_is_node(current->sibling, tree)) {
+                int fat = force_get_father(no, tree);
+                endrun(12312, "Moving sideways to a non node! no = %d, sib %d father = %d (ptype = %d)\n", no, current->sibling, fat, tree->Nodes[fat].f.ChildType);
+            }
             no = current->sibling;
             continue;
         }
@@ -1042,11 +1050,19 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
                 if(-1 == treewalk_export_particle(lv, current->nextnode))
                     return -1;
                 /* Move sideways*/
+        if(current->sibling != -1 && !node_is_node(current->sibling, tree)) {
+            int fat = force_get_father(no, tree);
+            endrun(12312, "After export moving to a non node! no = %d, sib %d father = %d (ptype = %d)\n", no, current->sibling, fat, tree->Nodes[no].f.ChildType);
+        }
                 no = current->sibling;
                 continue;
             }
         }
         /* ok, we need to open the node */
+        if(current->nextnode != -1 && !node_is_node(current->nextnode, tree)) {
+            int fat = force_get_father(no, tree);
+            endrun(12312, "Moving down to a particles from a non particle node! no = %d, sib %d next %d father = %d (ptype = %d)\n", no, current->sibling, current->nextnode, fat, tree->Nodes[fat].f.ChildType);
+        }
         no = current->nextnode;
     }
 


### PR DESCRIPTION
A new PR for debugging the large run. Current error output looks like:
[ 000643.16 ] local topTree size before appending=35177
[ 000643.17 ] Final local topTree size = 37297 per segment = 5.30994.
[ 000643.17 ] NTopLeaves= 32635  NTopNodes=37297 (space for 221412301)
[ 000643.98 ] Expected segment cost 2.46014e+08
[ 000643.98 ] Created 1756 segments in 1 rounds. Max leaf cost: 0.433799
[ 000643.98 ] Largest particle load particle=1.22904
[ 000647.86 ] Using 72030681376 bytes for exchange.
[ 000661.23 ] iter=0 exchange of 0431840039979 particles
[ 000700.95 ] GC : Reducing Particle slots from 432000000000 to 159960021
[ 000702.27 ] Task 0: GC: Used slots for type 0 is 15074401
[ 000707.23 ] Task 0: GC: Used slots for type 0 is 15074401
[ 000707.24 ] GC: Reducing number of slots for 0 from 216000000000 to 80027672
[ 001463.82 ] Task 0: GC: Used slots for type 0 is 123561432
[ 001463.83 ] Domain decomposition done.
[ 001463.85 ] Tree construction.  (presently allocated=93111.7 MB)
[ 001468.02 ] Allocated 15276.9 MByte for 98941981 tree nodes. firstnode 442824601. (presently allocated 108389 MB)
[ 001536.86 ] Tree constructed (moments: 1). First node 442824601, number of nodes 54036721, first pseudo 541766582. NTopLeaves 32635
[ 001538.77 ] Task 1283: Culling to invalid node! no = 482172298, sib 157670383, father = 58376560 (ptype = 0) start = 442824601
