### PR TITLE
Cooling strang split

### DIFF
--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -676,8 +676,6 @@ slots_allocate_sph_scratch_data(int sph_grad_rho, int nsph, struct sph_scratch_d
         sph_scratch->GradRho = mymalloc2("SPH_GradRho", sizeof(MyFloat) * 3 * nsph);
     else
         sph_scratch->GradRho = NULL;
-    /* Allocated in black hole, freed in sfr.*/
-    sph_scratch->Injected_BH_Energy = NULL;
     sph_scratch->EntVarPred = mymalloc2("EntVarPred", sizeof(MyFloat) * nsph);
     sph_scratch->VelPred = mymalloc2("VelPred", sizeof(MyFloat) * 3 * nsph);
 }

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -103,8 +103,6 @@ struct sph_scratch_data
      * which defeats the lookup cache in timefac.c. Because VelPred is used multiple times,
      * it is much quicker to compute it once and re-use this*/
     MyFloat * VelPred;            /*!< Predicted velocity at current particle drift time for SPH. 3x vector.*/
-    /*Used to store the BH feedback energy if black holes are on*/
-    MyFloat * Injected_BH_Energy;
 };
 
 extern struct slots_manager_type {


### PR DESCRIPTION
This PR follows upstream Gadget-3 and Arepo in computing the cooling and BH operators after the kicks. It is the recommended way of permanently solving the short timestep problem, because the cooling and BH operators now happen at a consistent time and do not affect DtEntropy (so the predicted entropy in hydra is not off), rather changing Entropy directly.