### PR TITLE
Forcetree moments

### DIFF
--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -806,8 +806,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree)
         if(tree->Nodes[p].f.ChildType == PARTICLE_NODE_TYPE)
             force_update_particle_node(p, tree);
         if(tree->Nodes[p].f.ChildType == NODE_NODE_TYPE) {
-            /* Don't spawn a new task if we are deep enough that we already spawned a lot.
-             * Note: final clause is much slower for some reason. */
+            /* Don't spawn a new task if we are deep enough that we already spawned a lot.*/
             if(childcnt > 1 && level < 256) {
                 #pragma omp task default(none) shared(level, childcnt, tree) firstprivate(nextsib, p)
                 force_update_node_recursive(p, nextsib, level*childcnt, tree);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -807,7 +807,7 @@ force_update_node_recursive(int no, int sib, int level, const ForceTree * tree)
             force_update_particle_node(p, tree);
         if(tree->Nodes[p].f.ChildType == NODE_NODE_TYPE) {
             /* Don't spawn a new task if we are deep enough that we already spawned a lot.*/
-            if(childcnt > 1 && level < 256) {
+            if(childcnt > 1 && level < 64) {
                 #pragma omp task default(none) shared(level, childcnt, tree) firstprivate(nextsib, p)
                 force_update_node_recursive(p, nextsib, level*childcnt, tree);
             }

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -21,7 +21,7 @@
 /*Defined in forcetree.c*/
 /*Next three are not static as tested.*/
 int
-force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * ddecomp, const double BoxSize);
+force_tree_create_nodes(const ForceTree tb, const int npart, DomainDecomp * ddecomp, const double BoxSize, const int HybridNuGrav);
 
 ForceTree
 force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp);
@@ -235,7 +235,7 @@ static void do_tree_test(const int numpart, ForceTree tb, DomainDecomp * ddecomp
     /*Time creating the nodes*/
     double start, end;
     start = MPI_Wtime();
-    int nodes = force_tree_create_nodes(tb, numpart, ddecomp, BoxSize);
+    int nodes = force_tree_create_nodes(tb, numpart, ddecomp, BoxSize, 0);
     tb.numnodes = nodes;
     assert_true(nodes < maxnode);
     end = MPI_Wtime();

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -27,7 +27,7 @@ ForceTree
 force_treeallocate(int maxnodes, int maxpart, DomainDecomp * ddecomp);
 
 int
-force_update_node_parallel(const ForceTree * tree, const int HybridNuGrav);
+force_update_node_parallel(const ForceTree * tree);
 
 /*Particle data.*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -244,7 +244,7 @@ static void do_tree_test(const int numpart, ForceTree tb, DomainDecomp * ddecomp
     int nrealnode = check_tree(&tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
-    force_update_node_parallel(&tb, 0);
+    force_update_node_parallel(&tb);
     end = MPI_Wtime();
     ms = (end - start)*1000;
     printf("Updated moments in %.3g ms. Total mass: %g\n", ms, tb.Nodes[numpart].mom.mass);


### PR DESCRIPTION
I noticed in a profile that the forcetree moment calculation time was dominated by the memory access of the particles. In the node build this is already inside cache. This computes the lowest order moments inside the node build, thus speeding up moment calculation by a factor of about 2.

Some numbers: 
master:
[ 000000.00 ] [ RUN      ] test_rebuild_flat
[ 000000.13 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 374785. Built tree in 20.3 ms
Tree filling factor: 0.501983 on 373881 nodes (wasted: 904 empty: 0)
Updated moments in 15.1 ms. Total mass: 2.09715e+06
[ 000000.89 ] [       OK ] test_rebuild_flat
[ 000000.89 ] [ RUN      ] test_rebuild_close
[ 000001.03 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 1111969. Built tree in 28.1 ms
Tree filling factor: 0.967176 on 1111017 nodes (wasted: 952 empty: 2838)
Updated moments in 18.3 ms. Total mass: 2.09715e+06
[ 000001.94 ] [       OK ] test_rebuild_close
[ 000001.94 ] [ RUN      ] test_rebuild_random
[ 000001.95 ] Allocated 35.0001 MByte for 262144 tree nodes. firstnode 262144. (presently allocated 51.004 MB)
Number of nodes used: 112705. Built tree in 2.79 ms
Tree filling factor: 0.909887 on 111745 nodes (wasted: 960 empty: 19576)
Updated moments in 4.8 ms. Total mass: 262144
Number of nodes used: 112417. Built tree in 2.69 ms
Tree filling factor: 0.909341 on 111537 nodes (wasted: 880 empty: 19349)
Updated moments in 4.47 ms. Total mass: 262144
[ 000002.17 ] [       OK ] test_rebuild_random

After 66fdb679:
 000000.13 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 374785. Built tree in 19.3 ms
Tree filling factor: 0.501983 on 373881 nodes (wasted: 904 empty: 0)
Updated moments in 2.23 ms. Total mass: 2.09715e+06
[ 000000.88 ] [       OK ] test_rebuild_flat
[ 000000.88 ] [ RUN      ] test_rebuild_close
[ 000001.02 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 1112065. Built tree in 26.6 ms
Tree filling factor: 0.967176 on 1111017 nodes (wasted: 1048 empty: 2838)
Updated moments in 9.09 ms. Total mass: 2.09715e+06
[ 000001.93 ] [       OK ] test_rebuild_close
[ 000001.93 ] [ RUN      ] test_rebuild_random
[ 000001.94 ] Allocated 35.0001 MByte for 262144 tree nodes. firstnode 262144. (presently allocated 51.004 MB)
Number of nodes used: 112705. Built tree in 2.83 ms
Tree filling factor: 0.909887 on 111745 nodes (wasted: 960 empty: 19576)
Updated moments in 1.84 ms. Total mass: 262144
Number of nodes used: 112513. Built tree in 2.84 ms
Tree filling factor: 0.909341 on 111537 nodes (wasted: 976 empty: 19349)
Updated moments in 1.69 ms. Total mass: 262144
[ 000002.16 ] [       OK ] test_rebuild_random

After aac7d60d:
[ 000000.00 ] [ RUN      ] test_rebuild_flat
[ 000000.13 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 374977. Built tree in 19.7 ms
Tree filling factor: 0.501998 on 373889 nodes (wasted: 1088 empty: 0)
Updated moments in 2.2 ms. Total mass: 2.09715e+06
[ 000000.88 ] [       OK ] test_rebuild_flat
[ 000000.88 ] [ RUN      ] test_rebuild_close
[ 000001.02 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 1112065. Built tree in 27.3 ms
Tree filling factor: 0.967176 on 1111017 nodes (wasted: 1048 empty: 2838)
Updated moments in 9.06 ms. Total mass: 2.09715e+06
[ 000001.93 ] [       OK ] test_rebuild_close
[ 000001.94 ] [ RUN      ] test_rebuild_random
[ 000001.94 ] Allocated 35.0001 MByte for 262144 tree nodes. firstnode 262144. (presently allocated 51.004 MB)
Number of nodes used: 112705. Built tree in 2.92 ms
Tree filling factor: 0.909887 on 111745 nodes (wasted: 960 empty: 19576)
Updated moments in 1.74 ms. Total mass: 262144
Number of nodes used: 112417. Built tree in 2.92 ms
Tree filling factor: 0.909341 on 111537 nodes (wasted: 880 empty: 19349)
Updated moments in 5.55 ms. Total mass: 262144
[ 000002.17 ] [       OK ] test_rebuild_random

Final:
[ 000000.13 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 374785. Built tree in 19.4 ms
Tree filling factor: 0.501998 on 373889 nodes (wasted: 896 empty: 0)
Updated moments in 2.13 ms. Total mass: 2.09715e+06
[ 000000.88 ] [       OK ] test_rebuild_flat
[ 000000.88 ] [ RUN      ] test_rebuild_close
[ 000001.01 ] Allocated 280 MByte for 2097152 tree nodes. firstnode 2097152. (presently allocated 296.004 MB)
Number of nodes used: 1111969. Built tree in 26.9 ms
Tree filling factor: 0.967176 on 1111017 nodes (wasted: 952 empty: 2838)
Updated moments in 9.06 ms. Total mass: 2.09715e+06
[ 000001.92 ] [       OK ] test_rebuild_close
[ 000001.92 ] [ RUN      ] test_rebuild_random
[ 000001.93 ] Allocated 35.0001 MByte for 262144 tree nodes. firstnode 262144. (presently allocated 51.004 MB)
Number of nodes used: 112801. Built tree in 2.89 ms
Tree filling factor: 0.909887 on 111745 nodes (wasted: 1056 empty: 19576)
Updated moments in 1.99 ms. Total mass: 262144
Number of nodes used: 112417. Built tree in 2.95 ms
Tree filling factor: 0.909341 on 111537 nodes (wasted: 880 empty: 19349)
Updated moments in 1.96 ms. Total mass: 262144
[ 000002.15 ] [       OK ] test_rebuild_random