### PR TITLE
Iotweaks

### DIFF
--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -131,7 +131,7 @@ set_init_params(ParameterSet * ps)
     MPI_Bcast(&All, sizeof(All), MPI_BYTE, 0, MPI_COMM_WORLD);
 }
 
-static void check_omega(void);
+static void check_omega(int generations);
 static void check_positions(void);
 
 static void
@@ -175,7 +175,7 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
 
     domain_test_id_uniqueness(PartManager);
 
-    check_omega();
+    check_omega(get_generations());
 
     check_positions();
 
@@ -240,14 +240,19 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
 /*! This routine computes the mass content of the box and compares it to the
  * specified value of Omega-matter.  If discrepant, the run is terminated.
  */
-void check_omega(void)
+void check_omega(int generations)
 {
     double mass = 0, masstot, omega;
     int i;
 
     #pragma omp parallel for reduction(+: mass)
-    for(i = 0; i < PartManager->NumPart; i++)
+    for(i = 0; i < PartManager->NumPart; i++) {
+        /* In case zeros have been written to the saved mass array,
+         * recover the true masses*/
+        if(P[i].Mass == 0)
+            P[i].Mass = All.MassTable[P[i].Type] * ( 1. - (double)P[i].Generation/generations);
         mass += P[i].Mass;
+    }
 
     MPI_Allreduce(&mass, &masstot, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -243,18 +243,25 @@ void init(int RestartSnapNum, DomainDecomp * ddecomp)
 void check_omega(int generations)
 {
     double mass = 0, masstot, omega;
-    int i;
+    int i, badmass = 0;
+    int64_t totbad;
 
-    #pragma omp parallel for reduction(+: mass)
+    #pragma omp parallel for reduction(+: mass) reduction(+: badmass)
     for(i = 0; i < PartManager->NumPart; i++) {
         /* In case zeros have been written to the saved mass array,
          * recover the true masses*/
-        if(P[i].Mass == 0)
+        if(P[i].Mass == 0) {
             P[i].Mass = All.MassTable[P[i].Type] * ( 1. - (double)P[i].Generation/generations);
+            badmass++;
+        }
         mass += P[i].Mass;
     }
 
     MPI_Allreduce(&mass, &masstot, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+
+    sumup_large_ints(1, &badmass, &totbad);
+    if(totbad)
+        message(0, "Warning: recovering from %ld Mass entries corrupted on disc\n",totbad);
 
     omega =
         masstot / (All.BoxSize * All.BoxSize * All.BoxSize) / (3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.G));

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -970,9 +970,11 @@ void register_io_blocks(struct IOTable * IOTable, int WriteGroupID) {
     IOTable->ent = mymalloc2("IOTable", IOTable->allocated * sizeof(IOTableEntry));
     /* Bare Bone Gravity*/
     for(i = 0; i < 6; i ++) {
+        /* We put Mass first because sometimes there is
+         * corruption in the first array and we can recover from Mass corruption*/
+        IO_REG(Mass,     "f4", 1, i, IOTable);
         IO_REG(Position, "f8", 3, i, IOTable);
         IO_REG(Velocity, "f4", 3, i, IOTable);
-        IO_REG(Mass,     "f4", 1, i, IOTable);
         IO_REG(ID,       "u8", 1, i, IOTable);
         if(All.OutputPotential)
             IO_REG_WRONLY(Potential, "f4", 1, i, IOTable);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -481,6 +481,10 @@ petaio_read_header_internal(BigFile * bf) {
     if(0!= big_block_get_attr(&bh, "TimeIC", &All.TimeIC, "f8", 1))
         All.TimeIC = Time;
 
+    /* Set a reasonable MassTable entry for stars and BHs*/
+    All.MassTable[4] = All.MassTable[0] / get_generations();
+    All.MassTable[5] = All.MassTable[4];
+
     /* fall back to traditional MP-Gadget Units if not given in the snapshot file. */
     All.UnitVelocity_in_cm_per_s = _get_attr_double(&bh, "UnitVelocity_in_cm_per_s", 1e5); /* 1 km/sec */
     All.UnitLength_in_cm = _get_attr_double(&bh, "UnitLength_in_cm",  3.085678e21); /* 1.0 Kpc /h */

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -66,6 +66,12 @@ static struct SFRParams
     char ReionHistFile[100];
 } sfr_params;
 
+
+int get_generations(void)
+{
+    return sfr_params.Generations;
+}
+
 /* Structure storing the results of an evaluation of the star formation model*/
 struct sfr_eeqos_data
 {

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -40,4 +40,8 @@ double get_helium_neutral_fraction_sfreff(int ion, double redshift, struct parti
 
 /* Return whether we are using a star formation model that needs grad rho computed for the gas particles*/
 int sfr_need_to_compute_sph_grad_rho(void);
+
+/* Get the number of generations of stars that may form*/
+int get_generations(void);
+
 #endif


### PR DESCRIPTION
I am wondering if the zeros in the Position array are not because it is large but because it is the first array written. So the recursive mkdir in big_file_mpi_create_block() has to create multiple directories. Maybe there is a race somewhere in the fs code related to writing to a directory before creation of the parent has completed?

This works on that theory. First I create the 0/ 1/ etc subdirectories separately before writing the blocks. Then in case this doesn't work I make sure the first array written is not Position but Potential or Mass and that we can recover from a corrupted Mass array.

If it is a subdirectory creation race then I think this fix in bigfile should also do it:

in big_file_mpi_create_block():

 BCAST_AND_RAISEIF(rt, comm);
+    MPI_Barrier(comm);
   
on line 109

@rainwoodman what do you think?
