### PR TITLE
Use compare exchange in the FoF code

### DIFF
--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -505,16 +505,17 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
         }
     } else /* mode is 1, target is a ghost */
     {
-            struct SpinLocks * spin = FOF_PRIMARY_GET_PRIV(tw)->spin;
+        int head = HEAD(other, tw);
+        struct SpinLocks * spin = FOF_PRIMARY_GET_PRIV(tw)->spin;
 //        printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        lock_spinlock(other, spin);
-        if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
+        lock_spinlock(head, spin);
+        if(HaloLabel[head].MinID > I->MinID)
         {
-            HaloLabel[HEAD(other, tw)].MinID = I->MinID;
-            HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
+            HaloLabel[head].MinID = I->MinID;
+            HaloLabel[head].MinIDTask = I->MinIDTask;
         }
 //        printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
-        unlock_spinlock(other, spin);
+        unlock_spinlock(head, spin);
     }
 }
 

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -315,7 +315,10 @@ update_root(int i, const int r, int * Head)
             t = Head[i];
             Head[i]= r;
         }
-    } while(t != i);
+        /* Stop if we reached the top (new head is the same as the old)
+         * or if the new head is less than or equal to the desired head, indicating
+         * another thread changed us*/
+    } while(t != i && (t > r));
 }
 
 /* Find the current head particle by walking the tree. No updates are done

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -359,6 +359,7 @@ void fof_label_primary(ForceTree * tree, MPI_Comm Comm)
 
     t0 = second();
 
+    #pragma omp parallel for
     for(i = 0; i < PartManager->NumPart; i++)
     {
         FOF_PRIMARY_GET_PRIV(tw)->Head[i] = i;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -283,11 +283,12 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, int * curr
     /* We must schedule monotonically so that if the export buffer fills up
      * it is guaranteed that earlier particles are already done.
      * However, we schedule dynamically so that we have reduced imbalance.
-     * chunk size: 1 and 1000 were slightly (3 percent) slower than 8.
      * We do not use the openmp dynamic scheduling, but roll our own
      * so that we can break from the loop if needed.*/
     int chnk = 0;
-    const int chnksz = 8;
+    /* chunk size: 1 and 1000 were slightly (3 percent) slower than 8.
+     * FoF treewalk needs a larger chnksz to avoid contention.*/
+    const int chnksz = 200;
     do {
         /* Get another chunk from the global queue*/
         chnk = atomic_fetch_and_add(currentIndex, chnksz);


### PR DESCRIPTION
This PR cleans up the locking in the FoF code. I noticed there was a catastrophic performance dropoff when we switched to dynamic treewalking, because particles in the same halos were on different threads and there was massive contention. This fixes it by moving to a lockless algorithm and by increasing the chunk size. Also fix a locking bug in the secondary treewalk.