### PR TITLE
Fofcmpxchg16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 install:
     - sh bootstrap.sh
     - cp platform-options/Options.mk.travis Options.mk
+    - mpicc --version
     - make
 
 script:

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -25,6 +25,17 @@ LIBS  = -lm $(GSL_LIBS)
 LIBS += -L../depends/lib $(BUNDLEDLIBS)
 V ?= 0
 
+#Detect gcc: if so we need an extra library for cmpxchg16 in fof
+CCVER:=$(shell $(MPICC) --version)
+ifeq (gcc,$(findstring gcc,${CCVER}))
+       LIBS += -latomic
+endif
+#Enable cmpxchg16 instruction generation on clang
+ifeq (clang,$(findstring clang,${CCVER}))
+       LIBS += -mcx16
+endif
+#icc does this automatically.
+
 .objs/%.o: %.c $(INCL) Makefile $(CONFIG)
 	@cmd="$(MPICC) -c -o $@ $(CFLAGS) $<"; \
 	if test "x$(V)" = "x1" ; then echo $$cmd; fi; \

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -26,8 +26,9 @@ LIBS += -L../depends/lib $(BUNDLEDLIBS)
 V ?= 0
 
 #Detect gcc: if so we need an extra library for cmpxchg16 in fof
+#Look for the FSF string in the copyright version info
 CCVER:=$(shell $(MPICC) --version)
-ifeq (gcc,$(findstring gcc,${CCVER}))
+ifeq (Free Software Foundation,$(findstring Free Software Foundation,${CCVER}))
        LIBS += -latomic
 endif
 #Enable cmpxchg16 instruction generation on clang

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -473,9 +473,7 @@ fofp_merge(int target, int other, TreeWalk * tw)
      * so we need to double check later.*/
     __aint128 h1minread, h2minread;
     do {
-        #pragma omp atomic read
         h1minread = HaloLabel[h1].MinIDandTask;
-        #pragma omp atomic read
         h2minread = HaloLabel[h2].MinIDandTask;
         /* We want the minimum ID. No update if that didn't change. */
         if(MinID(h1minread) <= MinID(h2minread))
@@ -522,7 +520,6 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
         /* update MinID.*/
         __aint128 hminread;
         do {
-            #pragma omp atomic read
             hminread = HaloLabel[head].MinIDandTask;
             /* We want the minimum ID. No update if that didn't change. */
             if(MinID(hminread) <= MinID(I->MinIDandTask))


### PR DESCRIPTION
This implements compare exchange on the final spinlock in fof, using the __int128 types suggested by @rainwoodman . I'm a little worried about portability issues.

The example code from the gcc mailing list is here: https://godbolt.org/z/ntEkDG
icc generates a straight cmpxchg16b. clang generates the instruction if -mcx16 is passed to it. gcc though always generates a call to a library, libatomic (which needs an extra link flag not mentioned in the docs). There is some indication that the call actually does a mutex, ie reduces this to a critical section, which would be worse than the spinlock. See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878

In practice all our production runs are done with icc so this may not be too much of a problem, but I am concerned about relying on something that differs on different compilers. @rainwoodman what do you think? I could also have some magic calls to __atomic_is_lock_free, but I don't think I want to maintain two implementations for this.

I will check performance.