### PR TITLE
Windfix

### DIFF
--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -280,6 +280,8 @@ winds_and_feedback(int * NewStars, int NumNewStars, const double Time, const dou
     tw->postprocess = NULL;
     tw->reduce = NULL;
 
+    message(0, "Starting feedback treewalk\n");
+
     priv->spin = init_spinlocks(SlotsManager->info[0].size);
     treewalk_run(tw, NewStars, NumNewStars);
     free_spinlocks(priv->spin);
@@ -507,18 +509,19 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     double random = get_random_number(I->ID + P[other].ID);
 
     if (random < p) {
+        int PI = P[other].PI;
         /* If this is the closest star, do the kick*/
-        lock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
-        if(WIND_GET_PRIV(lv->tw)->StarDistance[P[other].PI] > r ||
+        lock_spinlock(PI, WIND_GET_PRIV(lv->tw)->spin);
+        if(WIND_GET_PRIV(lv->tw)->StarDistance[PI] > r ||
             /* Break ties with ID*/
-            ((WIND_GET_PRIV(lv->tw)->StarDistance[P[other].PI] == r) &&
-            (WIND_GET_PRIV(lv->tw)->StarID[P[other].PI] < I->ID))
+            ((WIND_GET_PRIV(lv->tw)->StarDistance[PI] == r) &&
+            (WIND_GET_PRIV(lv->tw)->StarID[PI] < I->ID))
         ) {
-            WIND_GET_PRIV(lv->tw)->StarDistance[P[other].PI] = r;
-            WIND_GET_PRIV(lv->tw)->StarID[P[other].PI] = I->ID;
-            WIND_GET_PRIV(lv->tw)->StarKickVelocity[P[other].PI] = v;
+            WIND_GET_PRIV(lv->tw)->StarDistance[PI] = r;
+            WIND_GET_PRIV(lv->tw)->StarID[PI] = I->ID;
+            WIND_GET_PRIV(lv->tw)->StarKickVelocity[PI] = v;
         }
-        unlock_spinlock(other, WIND_GET_PRIV(lv->tw)->spin);
+        unlock_spinlock(PI, WIND_GET_PRIV(lv->tw)->spin);
     }
 }
 

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -428,6 +428,10 @@ sfr_wind_weight_ngbiter(TreeWalkQueryWind * I,
 
     if(P[other].Type == 0) {
         if(r > I->Hsml) return;
+        /* skip earlier wind particles, which receive
+         * no feedback energy */
+        if(SPHP(other).DelayTime > 0) return;
+
         /* NOTE: think twice if we want a symmetric tree walk when wk is used. */
         //double wk = density_kernel_wk(&kernel, r);
         double wk = 1.0;
@@ -491,6 +495,12 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
     /* this is radius cut is redundant because the tree walk is asymmetric
      * we may want to use fancier weighting that requires symmetric in the future. */
     if(r > I->Hsml) return;
+
+    /* skip earlier wind particles */
+    if(SPHP(other).DelayTime > 0) return;
+
+    /* No eligible gas particles not in wind*/
+    if(I->TotalWeight == 0) return;
 
     double windeff=0;
     double v=0;


### PR DESCRIPTION
The original wind feedback model was dependent on the ordering in which the particles were evaluated: once a particle had DelayTime set it was immune to feedback from any other nearby stars. Because this makes the final result uncomfortably sensitive to the threading, I changed this so that extra star formation just kicks particles a little more. Unfortunately this a) changes the model and b) introduces a potential bug where partially evaluated star particles (when the export buffer fills up) may kick gas twice. This is extremely rare for the wind treewalk, but with the big run it is a concern.

This PR fixes the problem more comprehensively by first treewalking to find the closest star to the gas particle, then using that to kick.