### PR TITLE
Ensure tree is allocated before generating FOF tables for checkpoint.

### DIFF
--- a/libgadget/checkpoint.c
+++ b/libgadget/checkpoint.c
@@ -21,16 +21,14 @@
  */
 
 void
-write_checkpoint(int snapnum, int WriteSnapshot, int WriteFOF, double Time, const char * OutputDir, const char * SnapshotFileBase, const int OutputDebugFields, ForceTree * tree)
+write_checkpoint(int snapnum, int WriteSnapshot, int WriteGroupID, double Time, const char * OutputDir, const char * SnapshotFileBase, const int OutputDebugFields)
 {
-    if(!WriteSnapshot && !WriteFOF) return;
-
     walltime_measure("/Misc");
     if(WriteSnapshot)
     {
         /* write snapshot of particles */
         struct IOTable IOTable = {0};
-        register_io_blocks(&IOTable, WriteFOF);
+        register_io_blocks(&IOTable, WriteGroupID);
         if(OutputDebugFields)
             register_debug_io_blocks(&IOTable);
         petaio_save_snapshot(&IOTable, 1, "%s/%s_%03d", OutputDir, SnapshotFileBase, snapnum);
@@ -48,19 +46,6 @@ write_checkpoint(int snapnum, int WriteSnapshot, int WriteFOF, double Time, cons
             myfree(buf);
         }
      }
-
-    if(WriteFOF) {
-        /* Compute and save FOF*/
-        message(0, "computing group catalogue...\n");
-
-        FOFGroups fof = fof_fof(tree, MPI_COMM_WORLD);
-        /* Tree is invalid now because of the exchange in FoF.*/
-        force_tree_free(tree);
-        fof_save_groups(&fof, snapnum, MPI_COMM_WORLD);
-        fof_finish(&fof);
-
-        message(0, "done with group catalogue.\n");
-    }
 }
 
 void

--- a/libgadget/checkpoint.h
+++ b/libgadget/checkpoint.h
@@ -1,9 +1,7 @@
 #ifndef CHECKPOINT_H
 #define CHECKPOINT_H
 
-#include "forcetree.h"
-
-void write_checkpoint(int snapnum, int WriteSnapshot, int WriteFOF, double Time, const char * OutputDir, const char * SnapshotFileBase, const int OutputDebugFields, ForceTree * tree);
+void write_checkpoint(int snapnum, int WriteSnapshot, int WriteGroupID, double Time, const char * OutputDir, const char * SnapshotFileBase, const int OutputDebugFields);
 void dump_snapshot(const char * dump, const char * OutputDir);
 int find_last_snapnum(const char * OutputDir);
 


### PR DESCRIPTION
Fixes: #453

Also ensures that the GroupID in the particle tables is up to date by
moving fof before checkpoint. write_checkpoint now only writes the
checkpoint, not the fof.