### PR TITLE
set initial BHDynMass

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -213,6 +213,7 @@ create_gadget_parameter_set()
     param_declare_double(ps,"BH_DFbmax",OPTIONAL, 20, "Maximum impact range for dynamical friction. We use 20 pkpc as default value.");
     param_declare_int(ps,"BH_DRAG",OPTIONAL, 0, "Add drag force to the BH dynamic");
     param_declare_int(ps,"MergeGravBound",OPTIONAL, 1, "If set to 1, apply gravitational bound criteria for merging event. This criteria would be automatically turned off if reposition is enabled."); 
+    param_declare_double(ps, "SeedBHDynMass", OPTIONAL, -1, "The initial dynamic mass of BH, default -1 will use the mass of gas particle. Larger Mdyn would help to stablize the BH in the early phase if turning off reposition.");
     
     static ParameterEnum BlackHoleFeedbackMethodEnum [] = {
         {"mass", BH_FEEDBACK_MASS},

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -52,6 +52,7 @@ struct bh_particle_data {
      * The black hole timebin is then set to this.*/
     int minTimeBin;
     int encounter; /* mark the event when BH encounters another BH */
+    double Mtrack; /*Swallow gas particle when BHP.Mass accretes from SeedBHMass to SeedDynMass for mass conservation */
 };
 
 /*Data for each star particle*/


### PR DESCRIPTION
Add a mass tracer Mtrack in the BHP struct. When SeedBHDynMass is much larger than SeedBHMass, in order to keep mass conservation, this Mtrack would stochastically swallow gas when BH is growing to SeedBHDynMass. 
Mtrack would stop functioning once Mtrack > SeedBHDynMass.
We also use the Mtrack to do BH-BH merger.