### PR TITLE
Fixes

### DIFF
--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -33,7 +33,7 @@
 static struct cooling_units coolunits;
 
 /*Do initialisation for the cooling module*/
-void init_cooling(char * TreeCoolFile, char * MetalCoolFile, char * reion_hist_file, struct cooling_units cu, Cosmology * CP)
+void init_cooling(const char * TreeCoolFile, const char * MetalCoolFile, char * reion_hist_file, struct cooling_units cu, Cosmology * CP)
 {
     coolunits = cu;
     /* Get mean cosmic baryon density for photoheating rate from long mean free path photons */

--- a/libgadget/cooling.c
+++ b/libgadget/cooling.c
@@ -39,7 +39,8 @@ void init_cooling(const char * TreeCoolFile, const char * MetalCoolFile, char * 
     /* Get mean cosmic baryon density for photoheating rate from long mean free path photons */
     coolunits.rho_crit_baryon =  3 * pow(CP->HubbleParam * HUBBLE,2) * CP->OmegaBaryon / (8 * M_PI * GRAVITY);
     /*Initialize the cooling rates*/
-    init_cooling_rates(TreeCoolFile, MetalCoolFile, CP);
+    if(coolunits.CoolingOn)
+        init_cooling_rates(TreeCoolFile, MetalCoolFile, CP);
     /* Initialize the helium reionization model*/
     init_qso_lightup(reion_hist_file);
 }

--- a/libgadget/cooling.h
+++ b/libgadget/cooling.h
@@ -31,7 +31,7 @@ struct cooling_units
 };
 
 /*Initialise the cooling module.*/
-void init_cooling(char * TreeCoolFile, char * MetalCoolFile, char * reion_hist_file, struct cooling_units cu, Cosmology * CP);
+void init_cooling(const char * TreeCoolFile, const char * MetalCoolFile, char * reion_hist_file, struct cooling_units cu, Cosmology * CP);
 
 /*Reads and initialises the tables for a spatially varying redshift of reionization*/
 void init_uvf_table(const char * UVFluctuationFile, const double BoxSize, const double UnitLength_in_cm);

--- a/libgadget/cooling_rates.c
+++ b/libgadget/cooling_rates.c
@@ -970,7 +970,7 @@ init_cooling_rates(const char * TreeCoolFile, const char * MetalCoolFile, Cosmol
     GrayOpac = gsl_interp_alloc(gsl_interp_linear,NGRAY);
     gsl_interp_init(GrayOpac,GrayOpac_zz,GrayOpac_ydata, NGRAY);
 
-    if(strnlen(TreeCoolFile,100) == 0) {
+    if(!TreeCoolFile || strnlen(TreeCoolFile,100) == 0) {
         CoolingParams.PhotoIonizationOn = 0;
         message(0, "No TreeCool file is provided. Cooling is broken. OK for DM only runs. \n");
     }

--- a/libgadget/cooling_rates.c
+++ b/libgadget/cooling_rates.c
@@ -965,8 +965,9 @@ init_cooling_rates(const char * TreeCoolFile, const char * MetalCoolFile, Cosmol
     CoolingParams.fBar = CP->OmegaBaryon / CP->OmegaCDM;
     CoolingParams.rho_crit_baryon = CP->OmegaBaryon * 3.0 * pow(CP->HubbleParam*HUBBLE,2.0) /(8.0*M_PI*GRAVITY);
 
-    /*Initialize the interpolation for the self-shielding module as a function of redshift.*/
-    GrayOpac = gsl_interp_alloc(gsl_interp_cspline,NGRAY);
+    /* Initialize the interpolation for the self-shielding module as a function of redshift.
+     * A crash has been observed in GSL with a cspline interpolator. */
+    GrayOpac = gsl_interp_alloc(gsl_interp_linear,NGRAY);
     gsl_interp_init(GrayOpac,GrayOpac_zz,GrayOpac_ydata, NGRAY);
 
     if(strlen(TreeCoolFile) == 0) {

--- a/libgadget/cooling_rates.c
+++ b/libgadget/cooling_rates.c
@@ -970,7 +970,7 @@ init_cooling_rates(const char * TreeCoolFile, const char * MetalCoolFile, Cosmol
     GrayOpac = gsl_interp_alloc(gsl_interp_linear,NGRAY);
     gsl_interp_init(GrayOpac,GrayOpac_zz,GrayOpac_ydata, NGRAY);
 
-    if(strlen(TreeCoolFile) == 0) {
+    if(strnlen(TreeCoolFile,100) == 0) {
         CoolingParams.PhotoIonizationOn = 0;
         message(0, "No TreeCool file is provided. Cooling is broken. OK for DM only runs. \n");
     }

--- a/libgadget/cooling_rates.c
+++ b/libgadget/cooling_rates.c
@@ -72,7 +72,7 @@ static gsl_interp * GrayOpac;
 /*Tables for the self-shielding correction. Note these are not well-measured for z > 5!*/
 #define NGRAY 6
 /*  Gray Opacity for the Faucher-Giguere 2009 UVB. HM2018 is a little larger and would lead to a 10% higher self-shielding threshold.*/
-static double GrayOpac_ydata[NGRAY] = { 2.59e-18, 2.37e-18, 2.27e-18, 2.15e-18, 2.02e-18, 1.94e-18};
+static const double GrayOpac_ydata[NGRAY] = { 2.59e-18, 2.37e-18, 2.27e-18, 2.15e-18, 2.02e-18, 1.94e-18};
 static const double GrayOpac_zz[NGRAY] = {0, 1, 2, 3, 4, 5};
 
 /*Convenience structure bundling together the gsl interpolation routines.*/

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -118,7 +118,7 @@ int begrun(int RestartFlag, int RestartSnapNum)
 
     init_forcetree_params(All.FastParticleType);
 
-    init_cooling_and_star_formation();
+    init_cooling_and_star_formation(All.CoolingOn);
 
     gravshort_set_softenings(All.MeanSeparation[1]);
     gravshort_fill_ntab(All.ShortRangeForceWindowType, All.Asmth);
@@ -319,7 +319,8 @@ run(int RestartSnapNum)
             blackhole(&Act, &Tree, FdBlackHoles, FdBlackholeDetails);
 
             /**** radiative cooling and star formation *****/
-            cooling_and_starformation(&Act, &Tree, GradRho, FdSfr);
+            if(All.CoolingOn)
+                cooling_and_starformation(&Act, &Tree, GradRho, FdSfr);
 
             if(GradRho) {
                 myfree(GradRho);

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -721,6 +721,10 @@ void init_cooling_and_star_formation(int CoolingOn)
     All.MinEgySpec = 1 / meanweight * (1.0 / GAMMA_MINUS1) * (BOLTZMANN / PROTONMASS) * sfr_params.MinGasTemp / coolunits.uu_in_cgs;
 
     init_cooling(sfr_params.TreeCoolFile, sfr_params.MetalCoolFile, sfr_params.ReionHistFile, coolunits, &All.CP);
+
+    if(!CoolingOn)
+        return;
+
     /*Initialize the uv fluctuation table*/
     init_uvf_table(sfr_params.UVFluctuationFile, All.BoxSize, All.UnitLength_in_cm);
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -128,9 +128,6 @@ void set_sfr_params(ParameterSet * ps)
 void
 cooling_and_starformation(ActiveParticles * act, ForceTree * tree, MyFloat * GradRho, FILE * FdSfr)
 {
-    if(!All.CoolingOn)
-        return;
-
     const int nthreads = omp_get_max_threads();
     /*This is a queue for the new stars and their parents, so we can reallocate the slots after the main cooling loop.*/
     int * NewStars = NULL;
@@ -709,10 +706,10 @@ get_egyeff(double redshift, double dens, struct UVBG * uvbg)
     return egyhot * (1 - x) + sfr_params.EgySpecCold * x;
 }
 
-void init_cooling_and_star_formation(void)
+void init_cooling_and_star_formation(int CoolingOn)
 {
     struct cooling_units coolunits;
-    coolunits.CoolingOn = All.CoolingOn;
+    coolunits.CoolingOn = CoolingOn;
     coolunits.density_in_phys_cgs = All.UnitDensity_in_cgs * All.CP.HubbleParam * All.CP.HubbleParam;
     coolunits.uu_in_cgs = All.UnitEnergy_in_cgs / All.UnitMass_in_g;
     coolunits.tt_in_s = All.UnitTime_in_s / All.CP.HubbleParam;

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -24,7 +24,7 @@ enum StarformationCriterion {
 /*Set the parameters of the star formation module*/
 void set_sfr_params(ParameterSet * ps);
 
-void init_cooling_and_star_formation(void);
+void init_cooling_and_star_formation(int CoolingOn);
 /*Do the cooling and the star formation. The tree is required for the winds only.*/
 void cooling_and_starformation(ActiveParticles * act, ForceTree * tree, MyFloat * GradRho, FILE * FdSfr);
 


### PR DESCRIPTION
This is a collection of fixes to work around problems with the Frontera MPI 19.1.1. which crashes in 

Program received signal SIGSEGV, Segmentation fault.
0x00002b94f32d3935 in gsl_linalg_solve_symm_tridiag () from /opt/apps/intel19/gsl/2.5/lib/libgsl.so.23
