### PR TITLE
Microopts

### DIFF
--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -131,7 +131,7 @@ force_tree_eh_slots_fork(EIBase * event, void * userdata)
      * participate in the SPH tree walk.*/
     if(nop->s.noccupied < NMAXCHILD) {
        nop->s.suns[nop->s.noccupied] = child;
-       nop->s.Types += P[child].Type << (3*nop->s.noccupied);
+       nop->s.Types += (1Lu * P[child].Type) << (3*nop->s.noccupied);
        nop->s.noccupied++;
     }
     tree->Father[child] = no;
@@ -335,7 +335,7 @@ modify_internal_node(int parent, int subnode, int p_toplace, const ForceTree tb,
     tb.Father[p_toplace] = parent;
     tb.Nodes[parent].s.suns[subnode] = p_toplace;
     /* Encode the type in the Types array*/
-    tb.Nodes[parent].s.Types += P[p_toplace].Type << (3*subnode);
+    tb.Nodes[parent].s.Types += (1Lu * P[p_toplace].Type) << (3*subnode);
     if(!HybridNuGrav || P[p_toplace].Type != ForceTreeParams.FastParticleType)
         add_particle_moment_to_node(&tb.Nodes[parent], p_toplace);
     return 0;

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -131,7 +131,7 @@ force_tree_eh_slots_fork(EIBase * event, void * userdata)
      * participate in the SPH tree walk.*/
     if(nop->s.noccupied < NMAXCHILD) {
        nop->s.suns[nop->s.noccupied] = child;
-       nop->s.Types += (1Lu * P[child].Type) << (3*nop->s.noccupied);
+       nop->s.Types += P[child].Type << (3*nop->s.noccupied);
        nop->s.noccupied++;
     }
     tree->Father[child] = no;
@@ -335,7 +335,7 @@ modify_internal_node(int parent, int subnode, int p_toplace, const ForceTree tb,
     tb.Father[p_toplace] = parent;
     tb.Nodes[parent].s.suns[subnode] = p_toplace;
     /* Encode the type in the Types array*/
-    tb.Nodes[parent].s.Types += (1Lu * P[p_toplace].Type) << (3*subnode);
+    tb.Nodes[parent].s.Types += P[p_toplace].Type << (3*subnode);
     if(!HybridNuGrav || P[p_toplace].Type != ForceTreeParams.FastParticleType)
         add_particle_moment_to_node(&tb.Nodes[parent], p_toplace);
     return 0;

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -9,7 +9,7 @@
  */
 
 /* Total allowed number of particle children for a node*/
-#define NMAXCHILD 11
+#define NMAXCHILD 8
 
 /* Defines for the type of node, classified by type of children.*/
 #define PARTICLE_NODE_TYPE 0
@@ -20,7 +20,7 @@ struct NodeChild
 {
     /* Stores the types of the child particles. Uses a bit field, 3 bits per particle.
      */
-    uint64_t Types;
+    unsigned int Types;
     /*!< pointers to daughter nodes or daughter particles. */
     int suns[NMAXCHILD];
     /* Number of daughter particles if node contains particles.

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -18,6 +18,9 @@
 
 struct NodeChild
 {
+    /* Stores the types of the child particles. Uses a bit field, 3 bits per particle.
+     */
+    uint64_t Types;
     /*!< pointers to daughter nodes or daughter particles. */
     int suns[NMAXCHILD];
     /* Number of daughter particles if node contains particles.

--- a/libgadget/gravity.c
+++ b/libgadget/gravity.c
@@ -57,14 +57,11 @@ grav_apply_short_range_window(double r, double * fac, double * pot, const double
     const double dx = shortrange_force_kernels[1][0];
     double i = (r / cellsize / dx);
     int tabindex = floor(i);
-    if(tabindex < NTAB - 1)
-    {
-        /* use a linear interpolation; */
-        *fac *= (tabindex + 1 - i) * shortrange_table[tabindex] + (i - tabindex) * shortrange_table[tabindex + 1];
-        *pot *= (tabindex + 1 - i) * shortrange_table_potential[tabindex] + (i - tabindex) * shortrange_table_potential[tabindex];
-        return 0;
-    } else {
+    if(tabindex >= NTAB - 1)
         return 1;
-    }
+    /* use a linear interpolation; */
+    *fac *= (tabindex + 1 - i) * shortrange_table[tabindex] + (i - tabindex) * shortrange_table[tabindex + 1];
+    *pot *= (tabindex + 1 - i) * shortrange_table_potential[tabindex] + (i - tabindex) * shortrange_table_potential[tabindex];
+    return 0;
 }
 

--- a/libgadget/gravity.c
+++ b/libgadget/gravity.c
@@ -28,7 +28,7 @@ gravshort_fill_ntab(const enum ShortRangeForceWindowType ShortRangeForceWindowTy
         }
     }
 
-    int i;
+    size_t i;
     for(i = 0; i < NTAB; i++)
     {
         /* force_kernels is in units of mesh points; */
@@ -56,7 +56,7 @@ grav_apply_short_range_window(double r, double * fac, double * pot, const double
 {
     const double dx = shortrange_force_kernels[1][0];
     double i = (r / cellsize / dx);
-    int tabindex = floor(i);
+    size_t tabindex = floor(i);
     if(tabindex >= NTAB - 1)
         return 1;
     /* use a linear interpolation; */

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -399,8 +399,9 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 dx[j] = NEAREST(P[pp].Pos[j] - inpos[j], BoxSize);
             const double r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
 
-            /* This is always the Newtonian softening*/
-            double h = FORCE_SOFTENING(pp, 1);
+            /* This is always the Newtonian softening,
+             * match the default from FORCE_SOFTENING. */
+            double h = 2.8 * GravitySoftening;
             if(TreeParams.AdaptiveSoftening == 1) {
                 h = DMAX(input->Soft, FORCE_SOFTENING(pp, P[pp].Type));
             }

--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -181,21 +181,16 @@ grav_short_tree(const ActiveParticles * act, PetaPM * pm, ForceTree * tree, doub
 static void
 apply_accn_to_output(TreeWalkResultGravShort * output, const double dx[3], const double r2, const double h, const double mass, const double cellsize)
 {
-    double facpot, fac;
-
     const double r = sqrt(r2);
 
-    if(r >= h)
-    {
-        fac = mass / (r2 * r);
-        facpot = -mass / r;
-    }
-    else
+    double fac = mass / (r2 * r);
+    double facpot = -mass / r;
+
+    if(r2 < h*h)
     {
         double wp;
-        const double h_inv = 1.0 / h;
-        const double h3_inv = h_inv * h_inv * h_inv;
-        const double u = r * h_inv;
+        const double h3_inv = 1.0 / h / h / h;
+        const double u = r / h;
         if(u < 0.5) {
             fac = mass * h3_inv * (10.666666666667 + u * u * (32.0 * u - 38.4));
             wp = -2.8 + u * u * (5.333333333333 + u * u * (6.4 * u - 9.6));
@@ -208,8 +203,7 @@ apply_accn_to_output(TreeWalkResultGravShort * output, const double dx[3], const
                 -3.2 + 0.066666666667 / u + u * u * (10.666666666667 +
                         u * (-16.0 + u * (9.6 - 2.133333333333 * u)));
         }
-
-        facpot = mass * h_inv * wp;
+        facpot = mass / h * wp;
     }
 
     if(0 == grav_apply_short_range_window(r, &fac, &facpot, cellsize)) {
@@ -405,9 +399,11 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 dx[j] = NEAREST(P[pp].Pos[j] - inpos[j], BoxSize);
             const double r2 = dx[0] * dx[0] + dx[1] * dx[1] + dx[2] * dx[2];
 
-            double h = input->Soft;
-            if(TreeParams.AdaptiveSoftening == 1)
-                h = DMAX(h, FORCE_SOFTENING(pp, P[pp].Type));
+            /* This is always the Newtonian softening*/
+            double h = FORCE_SOFTENING(pp, 1);
+            if(TreeParams.AdaptiveSoftening == 1) {
+                h = DMAX(input->Soft, FORCE_SOFTENING(pp, P[pp].Type));
+            }
             /* Compute the acceleration and apply it to the output structure*/
             apply_accn_to_output(output, dx, r2, h, P[pp].Mass, cellsize);
         }

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -903,10 +903,11 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
             /* Skip garbage*/
             if(P[other].IsGarbage)
                 continue;
-
-            /* must be the correct type */
-            if(!((1<<P[other].Type) & iter->mask))
+            /* In case the type of the particle has changed since the tree was built.
+             * Happens for wind treewalk for gas turned into stars on this timestep.*/
+            if(!((1<<P[other].Type) & iter->mask)) {
                 continue;
+            }
 
             double dist;
 
@@ -1043,6 +1044,14 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
             int i;
             int * suns = current->s.suns;
             for (i = 0; i < current->s.noccupied; i++) {
+                /* must be the correct type: compare the
+                 * current type for this subnode extracted
+                 * from the bitfield to the mask.*/
+                int type = (current->s.Types >> (3*i)) % 8;
+
+                if(!((1<<type) & iter->mask))
+                    continue;
+
                 lv->ngblist[numcand++] = suns[i];
             }
             /* Move sideways*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -908,10 +908,6 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
             if(!((1<<P[other].Type) & iter->mask))
                 continue;
 
-            /* must be the correct time bin */
-            if(lv->tw->type == TREEWALK_SPLIT && !(BINMASK(P[other].TimeBin) & lv->tw->bgmask))
-                continue;
-
             double dist;
 
             if(iter->symmetric == NGB_TREEFIND_SYMMETRIC) {


### PR DESCRIPTION
Store the particle Type in the node structure so we can filter particles without loading them into memory. This seems to have a marginal effect on simulation speed.