### PR TITLE
Fix a bug

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -292,9 +292,7 @@ density(const ActiveParticles * act, int update_hsml, int DoEgyDensity, int Blac
     DENSITY_GET_PRIV(tw)->NPRedo = ta_malloc("NPRedo", int *, NumThreads);
     int alloc_high = 0;
     int * ReDoQueue = act->ActiveParticle;
-    int size = SlotsManager->info[0].size + SlotsManager->info[5].size;
-    if(size > act->NumActiveParticle)
-        size = act->NumActiveParticle;
+    int size = act->NumActiveParticle;
 
     /* we will repeat the whole thing for those particles where we didn't find enough neighbours */
     do {


### PR DESCRIPTION
treewalk_build_queue only iterates up to size so our memory optimization in density() could cause some particles to be skipped.

This doesn't seem to have been happening often, but should be fixed!