### PR TITLE
Log Mseed for blackholes and append SnapNum to BlackholeDetail file

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1443,6 +1443,8 @@ void blackhole_make_one(int index) {
         BHP(child).Mass = bh_powerlaw_seed_mass(P[child].ID);
     else
         BHP(child).Mass = blackhole_params.SeedBlackHoleMass;
+    
+    BHP(child).Mseed = BHP(child).Mass;
     BHP(child).Mdot = 0;
     BHP(child).FormationTime = All.Time;
     BHP(child).SwallowID = (MyIDType) -1;

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -860,6 +860,7 @@ SIMPLE_PROPERTY_PI(BlackholeSwallowID, SwallowID, uint64_t, 1, struct bh_particl
 SIMPLE_PROPERTY_PI(BlackholeSwallowTime, SwallowTime, float, 1, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeJumpToMinPot, JumpToMinPot, int, 1, struct bh_particle_data)
 SIMPLE_PROPERTY_PI(BlackholeMtrack, Mtrack, float, 1, struct bh_particle_data)
+SIMPLE_PROPERTY_PI(BlackholeMseed, Mseed, float, 1, struct bh_particle_data)
 
 SIMPLE_SETTER_PI(STBlackholeMinPotPos , MinPotPos[0], double, 3, struct bh_particle_data)
 static void GTBlackholeMinPotPos(int i, double * out, void * baseptr, void * smanptr) {
@@ -1033,6 +1034,7 @@ void register_io_blocks(struct IOTable * IOTable, int WriteGroupID) {
     IO_REG(BlackholeMinPotPos, "f8", 3, 5, IOTable);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5, IOTable);
     IO_REG(BlackholeMtrack,         "f4", 1, 5, IOTable);
+    IO_REG(BlackholeMseed,         "f4", 1, 5, IOTable);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -1034,7 +1034,7 @@ void register_io_blocks(struct IOTable * IOTable, int WriteGroupID) {
     IO_REG(BlackholeMinPotPos, "f8", 3, 5, IOTable);
     IO_REG(BlackholeJumpToMinPot,   "i4", 1, 5, IOTable);
     IO_REG(BlackholeMtrack,         "f4", 1, 5, IOTable);
-    IO_REG(BlackholeMseed,         "f4", 1, 5, IOTable);
+    IO_REG_NONFATAL(BlackholeMseed,         "f4", 1, 5, IOTable);
 
     /* Smoothing lengths for black hole: this is a new addition*/
     IO_REG_NONFATAL(SmoothingLength,  "f4", 1, 5, IOTable);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -574,10 +574,16 @@ open_outputfiles(int RestartSnapNum)
     FdBlackHoles = NULL;
     FdSfr = NULL;
     FdBlackholeDetails = NULL;
+    
+    if(RestartSnapNum != -1) {
+        postfix = fastpm_strdup_printf("-R%03d", RestartSnapNum);
+    } else {
+        postfix = fastpm_strdup_printf("%s", "");
+    }
 
     /* all the processors write to separate files*/
     if(All.BlackHoleOn && All.WriteBlackHoleDetails){
-        buf = fastpm_strdup_printf("%s/%s/%06X", All.OutputDir,"BlackholeDetails",ThisTask);
+        buf = fastpm_strdup_printf("%s/%s%s/%06X", All.OutputDir,"BlackholeDetails",postfix,ThisTask);
         fastpm_path_ensure_dirname(buf);
         if(!(FdBlackholeDetails = fopen(buf,"a")))
             endrun(1, "Failed to open blackhole detail %s\n", buf);
@@ -587,12 +593,6 @@ open_outputfiles(int RestartSnapNum)
     /* only the root processors writes to the log files */
     if(ThisTask != 0) {
         return;
-    }
-
-    if(RestartSnapNum != -1) {
-        postfix = fastpm_strdup_printf("-R%03d", RestartSnapNum);
-    } else {
-        postfix = fastpm_strdup_printf("%s", "");
     }
 
     buf = fastpm_strdup_printf("%s/%s%s", All.OutputDir, All.CpuFile, postfix);

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -53,6 +53,7 @@ struct bh_particle_data {
     int minTimeBin;
     int encounter; /* mark the event when BH encounters another BH */
     double Mtrack; /*Swallow gas particle when BHP.Mass accretes from SeedBHMass to SeedDynMass for mass conservation */
+    double Mseed; /*Log the seed mass of BH, would be useful in case of the powerlaw seeding*/
 };
 
 #define NMETALS 9


### PR DESCRIPTION
When doing the power law seeding, we might need to log the seed mass for each black hole (e.g. when calculating the faint end population we might only want to account for the BH accretes well beyond the seed mass).  We can also extract this information from BlackholeDetail history, but that's a lot of work when we have tons of BHs.

I also want to append the RestartSnapNum to BlackholeDetail file, otherwise the binary file would be huge (and sometimes be re-written) and would be hard to post process.