### PR TITLE
Treeopts

### DIFF
--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -478,6 +478,7 @@ metal_return(const ActiveParticles * act, const ForceTree * const tree, Cosmolog
     tw->postprocess = (TreeWalkProcessFunction) metal_return_postprocess;
     tw->query_type_elsize = sizeof(TreeWalkQueryMetals);
     tw->result_type_elsize = sizeof(TreeWalkResultMetals);
+    tw->repeatdisallowed = 1;
     tw->tree = tree;
     tw->priv = priv;
     priv->hub = CP->HubbleParam;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -462,14 +462,9 @@ ev_primary(TreeWalk * tw)
     ev_free_threadlocals(export);
 
     /* Set the place to start the next iteration. Note that because lastSucceeded
-     * is the minimum entry across all threads, some particles may have their trees walked twice locally.
-     * This could be a problem if the export buffer filled up in a physics module with locks,
-     * ie, which is pairwise and changes the other particle in the treewalk.
-     * In practice almost all of these algorithms either set a flag
-     * in the particle to indicate that it has been finished (HeIII reion),
-     * or find a maximum (BH). Exceptions are the wind velocity and metal return codes,
-     * but there are few enough stars in a treewalk that this
-     * should not fill up often.*/
+     * is the minimum entry across all threads, some particles may have their trees partially walked twice locally.
+     * This is fine because we walk the tree to fill up the Ngbiter list.
+     * Only a full Ngbiter list is executed; partial lists are discarded.*/
     tw->WorkSetStart = lastSucceeded + 1;
 
     tend = second();

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -302,6 +302,9 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, LocalTreeW
         /* Make sure we do not overflow the loop*/
         if(end > tw->WorkSetSize)
             end = tw->WorkSetSize;
+        /* Reduce the chunk size towards the end of the walk*/
+        if(((size_t) tw->WorkSetSize  < end + chnksz * tw->NThread) && chnksz >= 2)
+            chnksz /= 2;
         int k;
         for(k = chnk; k < end; k++) {
             /* Skip already evaluated particles. This is only used if the buffer fills up.*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -50,7 +50,7 @@ static struct data_index
 {
     int Task;
     int Index;
-    int IndexGet;
+    size_t IndexGet;
 } *DataIndexTable;
 
 /*Initialise global treewalk parameters*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1070,7 +1070,7 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
         else if(current->f.ChildType == PSEUDO_NODE_TYPE) {
             /* pseudo particle */
             if(lv->mode == 1) {
-                endrun(12312, "Touching outside of my domain from a node list of a ghost. This shall not happen.");
+                endrun(12312, "Secondary for particle %d from node %d found pseudo at %d.\n", lv->target, startnode, current);
             } else {
                 /* Export the pseudo particle*/
                 if(-1 == treewalk_export_particle(lv, current->s.suns[0]))

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -289,7 +289,11 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, LocalTreeW
     int chnk = 0;
     /* chunk size: 1 and 1000 were slightly (3 percent) slower than 8.
      * FoF treewalk needs a larger chnksz to avoid contention.*/
-    const int chnksz = 200;
+    int chnksz = tw->WorkSetSize / (4*tw->NThread);
+    if(chnksz < 1)
+        chnksz = 1;
+    if(chnksz > 200)
+        chnksz = 200;
     do {
         /* Get another chunk from the global queue*/
         chnk = atomic_fetch_and_add(currentIndex, chnksz);

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -49,9 +49,14 @@ typedef struct {
     int mode; /* 0 for Primary, 1 for Secondary */
     int target; /* defined only for primary (mode == 0) */
 
+    /* Thread local export variables*/
+    size_t Nexport;
+    size_t BunchSize;
     int *exportflag;
     int *exportnodecount;
     size_t *exportindex;
+    size_t DataIndexOffset;
+
     int * ngblist;
     int64_t Ninteractions;
     int64_t Nnodesinlist;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -105,9 +105,15 @@ struct TreeWalk {
     size_t NThread; /*Number of OpenMP threads*/
 
     /* Unlike in Gadget-3, when exporting we now always send tree branches.*/
-
     char * dataget;
     char * dataresult;
+
+    /* The metal return alters neighbours,
+     * which cannot be evaluated twice.
+     * If repeatdisallowd is true, we allocate memory
+     * to keep track of the evaluated particles.*/
+    int repeatdisallowed;
+    char * evaluated;
 
     /* performance metrics */
     double timewait1;


### PR DESCRIPTION
Optimize the threaded work splitting in the tree, removing the globally locked export queue and ensuring that small numbers of particles are more evenly distributed across threads.