### PR TITLE
Memprint

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -455,7 +455,7 @@ blackhole(const ActiveParticles * act, ForceTree * tree, FILE * FdBlackHoles, FI
         return;
     /* Do nothing if no black holes*/
     int64_t totbh;
-    sumup_large_ints(1, &SlotsManager->info[5].size, &totbh);
+    MPI_Allreduce(&SlotsManager->info[5].size, &totbh, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     if(totbh == 0)
         return;
     int i;

--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -369,7 +369,7 @@ gas_ionization_fraction(void)
     /* Get total ionization fraction: note this is only the current gas particles.
      * Particles that become stars are not counted.*/
     sumup_large_ints(1, &n_ionized, &n_ionized_tot);
-    sumup_large_ints(1, &SlotsManager->info[0].size, &n_gas_tot);
+    MPI_Allreduce(&SlotsManager->info[0].size, &n_gas_tot, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     return (double) n_ionized_tot / (double) n_gas_tot;
 }
 
@@ -529,7 +529,7 @@ turn_on_quasars(double redshift, FOFGroups * fof, ForceTree * tree)
     int ncand = 0;
     int * qso_cand = NULL;
     int64_t n_gas_tot=0, tot_n_ionized=0, ncand_tot=0;
-    sumup_large_ints(1, &SlotsManager->info[0].size, &n_gas_tot);
+    MPI_Allreduce(&SlotsManager->info[0].size, &n_gas_tot, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     double atime = 1./(1 + redshift);
     double desired_ion_frac = gsl_interp_eval(HeIII_intp, He_zz, XHeIII, atime, NULL);
     /* If the desired ionization fraction is above a threshold (by default 0.95)

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -464,7 +464,7 @@ domain_check_memory_bound(const DomainDecomp * ddecomp, int64_t *TopLeafWork, in
     /*Leave a small number of particles for star formation */
     if(max_load > PartManager->MaxPart * domain_params.SetAsideFactor)
     {
-        message(0, "desired memory imbalance=%g  (limit=%g, needed=%d)\n",
+        message(0, "desired memory imbalance=%g  (limit=%g, needed=%ld)\n",
                     (max_load * ((double) sumload ) / NTask ) / PartManager->MaxPart, domain_params.SetAsideFactor * PartManager->MaxPart, max_load);
         message(0, "Balance breakdown:\n");
         int i;

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -253,7 +253,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
     }
 
     int64_t newNumPart;
-    int newSlots[6] = {0};
+    int64_t newSlots[6] = {0};
     newNumPart = pman->NumPart + plan->toGetSum.base;
 
     for(ptype = 0; ptype < 6; ptype ++) {

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -197,9 +197,9 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
 
     /* Check whether the domain exchange will succeed.
      * Garbage particles will be collected after the particles are exported, so do not need to count.*/
-    int needed = pman->NumPart + plan->toGetSum.base - plan->toGoSum.base  - plan->ngarbage;
+    int64_t needed = pman->NumPart + plan->toGetSum.base - plan->toGoSum.base  - plan->ngarbage;
     if(needed > pman->MaxPart)
-        message(1,"Too many particles for exchange: NumPart=%d count_get = %d count_togo=%d garbage = %d MaxPart=%d\n",
+        message(1,"Too many particles for exchange: NumPart=%ld count_get = %d count_togo=%d garbage = %d MaxPart=%ld\n",
                 pman->NumPart, plan->toGetSum.base, plan->toGoSum.base, plan->ngarbage, pman->MaxPart);
     if(MPIU_Any(needed > pman->MaxPart, Comm))
         return 1;
@@ -252,7 +252,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
         walltime_measure("/Domain/exchange/garbage");
     }
 
-    int newNumPart;
+    int64_t newNumPart;
     int newSlots[6] = {0};
     newNumPart = pman->NumPart + plan->toGetSum.base;
 
@@ -262,7 +262,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
     }
 
     if(newNumPart > pman->MaxPart) {
-        endrun(787878, "NumPart=%d MaxPart=%d\n", newNumPart, pman->MaxPart);
+        endrun(787878, "NumPart=%ld MaxPart=%ld\n", newNumPart, pman->MaxPart);
     }
 
     slots_reserve(1, newSlots, sman);
@@ -305,7 +305,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
     for(src = 0; src < plan->NTask; src++) {
         /* unpack each source rank */
         int newPI[6];
-        int i;
+        int64_t i;
         for(ptype = 0; ptype < 6; ptype ++) {
             newPI[ptype] = sman->info[ptype].size + plan->toGetOffset[src].slots[ptype];
         }
@@ -529,7 +529,7 @@ mp_order_by_id(const void * data, void * radix, void * arg) {
 void
 domain_test_id_uniqueness(struct part_manager_type * pman)
 {
-    int i;
+    int64_t i;
     MyIDType *ids;
     int NTask, ThisTask;
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
@@ -549,7 +549,7 @@ domain_test_id_uniqueness(struct part_manager_type * pman)
     mpsort_mpi(ids, pman->NumPart, sizeof(MyIDType), mp_order_by_id, 8, NULL, MPI_COMM_WORLD);
 
     /*Remove garbage from the end*/
-    int nids = pman->NumPart;
+    int64_t nids = pman->NumPart;
     while(nids > 0 && (ids[nids-1] == (MyIDType)-1)) {
         nids--;
     }
@@ -558,7 +558,7 @@ domain_test_id_uniqueness(struct part_manager_type * pman)
     for(i = 1; i < nids; i++) {
         if(ids[i] <= ids[i - 1])
         {
-            endrun(12, "non-unique (or non-ordered) ID=%013ld found on task=%d (i=%d NumPart=%d)\n",
+            endrun(12, "non-unique (or non-ordered) ID=%013ld found on task=%d (i=%d NumPart=%ld)\n",
                     ids[i], ThisTask, i, nids);
         }
     }

--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -1339,8 +1339,8 @@ void fof_seed(FOFGroups * fof, ForceTree * tree, ActiveParticles * act, MPI_Comm
         }
 
         /*Now we can extend the slots! */
-        int atleast[6];
-        int i;
+        int64_t atleast[6];
+        int64_t i;
         for(i = 0; i < 6; i++)
             atleast[i] = SlotsManager->info[i].maxsize;
         atleast[5] += ntot*1.1;

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -187,7 +187,7 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
         halo_sman->info[i].maxsize = 0;
     }
 
-    int atleast[6]={0};
+    int64_t atleast[6]={0};
     /* Count how many particles we have*/
     //#pragma omp parallel for reduction(+: NpigLocal)
     for(i = 0; i < PartManager->NumPart; i ++) {

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -175,9 +175,9 @@ order_by_type_and_grnr(const void *a, const void *b)
 
 static int
 fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_manager_type * halo_sman, MPI_Comm Comm) {
-    int i, ThisTask;
+    int ThisTask;
     MPI_Comm_rank(Comm, &ThisTask);
-    int NpigLocal = 0;
+    int64_t i, NpigLocal = 0;
     /* SlotsManager Needs initializing!*/
     memcpy(halo_sman, SlotsManager, sizeof(struct slots_manager_type));
 
@@ -236,7 +236,7 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
         NpigLocal ++;
     }
     if(NpigLocal != halo_pman->NumPart)
-        endrun(3, "Error in NpigLocal %d != %d!\n", NpigLocal, halo_pman->NumPart);
+        endrun(3, "Error in NpigLocal %ld != %ld!\n", NpigLocal, halo_pman->NumPart);
     MPI_Allreduce(&GrNrMax, &GrNrMaxGlobal, 1, MPI_INT, MPI_MAX, Comm);
     message(0, "GrNrMax before exchange is %d\n", GrNrMaxGlobal);
     /* sort pi to decide targetTask */

--- a/libgadget/gravpm.c
+++ b/libgadget/gravpm.c
@@ -147,7 +147,7 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
     MPI_Reduce(&r, &maxNregions, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
     message(0, "max number of regions is %d\n", maxNregions);
 
-    int i;
+    int64_t i;
     int numswallowed = 0;
     #pragma omp parallel for reduction(+: numswallowed)
     for(i =0; i < PartManager->NumPart; i ++) {
@@ -162,7 +162,7 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
     }
 
     /* now lets mark particles to their hosting region */
-    int numpart = 0;
+    int64_t numpart = 0;
 #pragma omp parallel for reduction(+: numpart)
     for(r = 0; r < *Nregions; r++) {
         regions[r].numpart = pm_mark_region_for_node(regions[r].no, r, pstruct->RegionInd, tree);
@@ -175,7 +175,7 @@ static PetaPMRegion * _prepare(PetaPM * pm, PetaPMParticleStruct * pstruct, void
     }
     /* All particles shall have been processed just once. Otherwise we die */
     if((numpart+numswallowed) != PartManager->NumPart) {
-        endrun(1, "Processed only %d particles out of %d\n", numpart, PartManager->NumPart);
+        endrun(1, "Processed only %ld particles out of %ld\n", numpart, PartManager->NumPart);
     }
     for(r =0; r < *Nregions; r++) {
         convert_node_to_region(pm, &regions[r], tree->Nodes);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -413,8 +413,8 @@ setup_smoothinglengths(int RestartSnapNum, DomainDecomp * ddecomp, const inttime
     const double a3 = All.Time * All.Time * All.Time;
 
     int64_t tot_sph, tot_bh;
-    sumup_large_ints(1, &SlotsManager->info[0].size, &tot_sph);
-    sumup_large_ints(1, &SlotsManager->info[5].size, &tot_bh);
+    MPI_Allreduce(&SlotsManager->info[0].size, &tot_sph, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&SlotsManager->info[5].size, &tot_bh, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
 
     /* Do nothing if we are a pure DM run*/
     if(tot_sph + tot_bh == 0)

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -463,7 +463,7 @@ metal_return(const ActiveParticles * act, const ForceTree * const tree, Cosmolog
 
     /* Do nothing if no stars yet*/
     int64_t totstar;
-    sumup_large_ints(1, &SlotsManager->info[4].size, &totstar);
+    MPI_Allreduce(&SlotsManager->info[4].size, &totstar, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     if(totstar == 0)
         return;
 

--- a/libgadget/partmanager.c
+++ b/libgadget/partmanager.c
@@ -10,12 +10,14 @@
 struct part_manager_type PartManager[1] = {{0}};
 
 void
-particle_alloc_memory(int MaxPart)
+particle_alloc_memory(int64_t MaxPart)
 {
     size_t bytes;
     PartManager->Base = (struct particle_data *) mymalloc("P", bytes = MaxPart * sizeof(struct particle_data));
     PartManager->MaxPart = MaxPart;
     PartManager->NumPart = 0;
+    if(MaxPart >= 1L<<31 || MaxPart < 0)
+        endrun(5, "Trying to store %ld particles on a single node, more than fit in an int32, not supported\n", MaxPart);
     memset(PartManager->CurrentParticleOffset, 0, 3*sizeof(double));
 
     /* clear the memory to avoid valgrind errors;
@@ -27,5 +29,5 @@ particle_alloc_memory(int MaxPart)
      * (memory lock etc?)
      * */
     memset(P, 0, sizeof(struct particle_data) * MaxPart);
-    message(0, "Allocated %g MByte for particle storage.\n", bytes / (1024.0 * 1024.0));
+    message(0, "Allocated %g MByte for storing %ld particles.\n", bytes / (1024.0 * 1024.0), MaxPart);
 }

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -74,7 +74,7 @@ extern struct part_manager_type {
 #define P PartManager->Base
 
 /*Allocate memory for the particles*/
-void particle_alloc_memory(int MaxPart);
+void particle_alloc_memory(int64_t MaxPart);
 
 /* Finds the correct relative position accounting for periodicity*/
 #define NEAREST(x, BoxSize) (((x)>0.5*BoxSize)?((x)-BoxSize):(((x)<-0.5*BoxSize)?((x)+BoxSize):(x)))

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -61,9 +61,9 @@ struct particle_data
 extern struct part_manager_type {
     struct particle_data *Base; /* Pointer to particle data on local processor. */
     /*!< number of particles on the LOCAL processor: number of valid entries in P array. */
-    int NumPart;
+    int64_t NumPart;
     /*!< Amount of memory we have available for particles locally: maximum size of P array. */
-    int MaxPart;
+    int64_t MaxPart;
     /* Random shift applied to the box. This is changed
      * every domain decomposition to prevent correlated
      * errors building up in the tree force. */

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -243,7 +243,7 @@ void petaio_read_internal(char * fname, int ic, struct IOTable * IOTable, MPI_Co
      * This will be dynamically increased as needed.*/
 
     if(PartManager->NumPart >= PartManager->MaxPart) {
-        endrun(1, "Overwhelmed by part: %d > %d\n", PartManager->NumPart, PartManager->MaxPart);
+        endrun(1, "Overwhelmed by part: %ld > %ld\n", PartManager->NumPart, PartManager->MaxPart);
     }
 
     /* Now allocate memory for the secondary particle data arrays.

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -231,7 +231,7 @@ void petaio_read_internal(char * fname, int ic, struct IOTable * IOTable, MPI_Co
     /*Allocate the particle memory*/
     particle_alloc_memory(MaxPart);
 
-    int NLocal[6];
+    int64_t NLocal[6];
     for(ptype = 0; ptype < 6; ptype ++) {
         int64_t start = ThisTask * NTotal[ptype] / NTask;
         int64_t end = (ThisTask + 1) * NTotal[ptype] / NTask;
@@ -250,10 +250,10 @@ void petaio_read_internal(char * fname, int ic, struct IOTable * IOTable, MPI_Co
      * This may be dynamically resized later!*/
 
     /*Ensure all processors have initially the same number of particle slots*/
-    int newSlots[6] = {0};
+    int64_t newSlots[6] = {0};
 
     /* Can't use MPI_IN_PLACE, which is broken for arrays and MPI_MAX at least on intel mpi 19.0.5*/
-    MPI_Allreduce(NLocal, newSlots, 6, MPI_INT, MPI_MAX, Comm);
+    MPI_Allreduce(NLocal, newSlots, 6, MPI_INT64, MPI_MAX, Comm);
 
     for(ptype = 0; ptype < 6; ptype ++) {
             newSlots[ptype] *= All.PartAllocFactor;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -138,8 +138,8 @@ use_pairwise_gravity(ActiveParticles * Act, struct part_manager_type * PartManag
 {
     /* Find total number of active particles*/
     int64_t total_active, total_particle;
-    sumup_large_ints(1, &Act->NumActiveParticle, &total_active);
-    sumup_large_ints(1, &PartManager->NumPart, &total_particle);
+    MPI_Allreduce(&Act->NumActiveParticle, &total_active, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&PartManager->NumPart, &total_particle, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
 
     /* Since the pairwise step is O(N^2) and tree is O(NlogN) we should scale the condition like O(N)*/
     return total_active < All.PairwiseActiveFraction * total_particle;

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -47,7 +47,7 @@ double copy_and_mean_accn(double (* PairAccn)[3])
         }
     }
     int64_t tot_npart;
-    sumup_large_ints(1, &PartManager->NumPart, &tot_npart);
+    MPI_Allreduce(&PartManager->NumPart, &tot_npart, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(MPI_IN_PLACE, &meanacc, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
     meanacc/= (tot_npart*3.);
     return meanacc;
@@ -74,8 +74,7 @@ void check_accns(double * meanerr_tot, double * maxerr_tot, double (*PairAccn)[3
     MPI_Allreduce(&meanerr, meanerr_tot, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&maxerr, maxerr_tot, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
     int64_t tot_npart;
-    sumup_large_ints(1, &PartManager->NumPart, &tot_npart);
-
+    MPI_Allreduce(&PartManager->NumPart, &tot_npart, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     *meanerr_tot/= (tot_npart*3.);
 }
 

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -331,8 +331,8 @@ sfr_reserve_slots(ActiveParticles * act, int * NewStars, int NumNewStar, ForceTr
             myfree(act->ActiveParticle);
         }
         /*Now we can extend the slots! */
-        int atleast[6];
-        int i;
+        int64_t atleast[6];
+        int64_t i;
         for(i = 0; i < 6; i++)
             atleast[i] = SlotsManager->info[i].maxsize;
         atleast[4] += NumNewStar;

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -105,7 +105,7 @@ slots_split_particle(int parent, double childmass, struct part_manager_type * pm
     int64_t child = atomic_fetch_and_add_64(&pman->NumPart, 1);
 
     if(child >= pman->MaxPart)
-        endrun(8888, "Tried to spawn: NumPart=%d MaxPart = %d. Sorry, no space left.\n", child, pman->MaxPart);
+        endrun(8888, "Tried to spawn: NumPart=%ld MaxPart = %ld. Sorry, no space left.\n", child, pman->MaxPart);
 
     pman->Base[parent].Generation ++;
     uint64_t g = pman->Base[parent].Generation;
@@ -114,7 +114,7 @@ slots_split_particle(int parent, double childmass, struct part_manager_type * pm
     /* change the child ID according to the generation. */
     pman->Base[child].ID = (pman->Base[parent].ID & 0x00ffffffffffffffL) + (g << 56L);
     if(g >= (1 << (64-56L)))
-        endrun(1, "Particle %d (ID: %ld) generated too many particles: generation %d wrapped.\n", parent, pman->Base[parent].ID, g);
+        endrun(1, "Particle %d (ID: %ld) generated too many particles: generation %ld wrapped.\n", parent, pman->Base[parent].ID, g);
 
     pman->Base[child].Mass = childmass;
     pman->Base[parent].Mass -= childmass;

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -8,8 +8,8 @@
 
 struct slot_info {
     char * ptr; /* aliasing ptr for this slot */
-    int maxsize; /* max number of supported slots */
-    int size; /* currently used slots*/
+    int64_t maxsize; /* max number of supported slots */
+    int64_t size; /* currently used slots*/
     size_t elsize; /* itemsize */
     int enabled;
 };

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -135,13 +135,13 @@ void slots_init(double increase, struct slots_manager_type * sman);
 void slots_set_enabled(int ptype, size_t elsize, struct slots_manager_type * sman);
 void slots_free(struct slots_manager_type * sman);
 void slots_mark_garbage(int i, struct part_manager_type * pman, struct slots_manager_type * sman);
-void slots_setup_topology(struct part_manager_type * pman, int * NLocal, struct slots_manager_type * sman);
+void slots_setup_topology(struct part_manager_type * pman, int64_t * NLocal, struct slots_manager_type * sman);
 void slots_setup_id(const struct part_manager_type * pman, struct slots_manager_type * sman);
 int slots_split_particle(int parent, double childmass, struct part_manager_type * pman);
 int slots_convert(int parent, int ptype, int placement, struct part_manager_type * pman, struct slots_manager_type * sman);
 int slots_gc(int * compact_slots, struct part_manager_type * pman, struct slots_manager_type * sman);
 void slots_gc_sorted(struct part_manager_type * pman, struct slots_manager_type * sman);
-size_t slots_reserve(int where, int atleast[6], struct slots_manager_type * sman);
+size_t slots_reserve(int where, int64_t atleast[6], struct slots_manager_type * sman);
 void slots_check_id_consistency(struct part_manager_type * pman, struct slots_manager_type * sman);
 
 typedef struct {

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -319,10 +319,10 @@ static int setup_density(void **state) {
     /*Reserve space for the slots*/
     slots_init(0.01 * PartManager->MaxPart, SlotsManager);
     slots_set_enabled(0, sizeof(struct sph_particle_data), SlotsManager);
-    int atleast[6] = {0};
+    int64_t atleast[6] = {0};
     atleast[0] = pow(32,3);
     atleast[5] = 2;
-    int maxpart = 0;
+    int64_t maxpart = 0;
     int i;
     for(i = 0; i < 6; i++)
         maxpart+=atleast[i];

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -32,7 +32,7 @@ int TotNumPart;
 
 #define NUMPART1 8
 static int
-setup_particles(int NType[6])
+setup_particles(int64_t NType[6])
 {
     MPI_Barrier(MPI_COMM_WORLD);
     PartManager->MaxPart = 1024;
@@ -95,7 +95,7 @@ test_exchange_layout_func(int i, const void * userdata)
 static void
 test_exchange(void **state)
 {
-    int newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
+    int64_t newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
 
     setup_particles(newSlots);
 
@@ -119,7 +119,7 @@ test_exchange(void **state)
 static void
 test_exchange_zero_slots(void **state)
 {
-    int newSlots[6] = {NUMPART1, 0, NUMPART1, 0, NUMPART1, 0};
+    int64_t newSlots[6] = {NUMPART1, 0, NUMPART1, 0, NUMPART1, 0};
 
     setup_particles(newSlots);
 
@@ -143,7 +143,7 @@ test_exchange_zero_slots(void **state)
 static void
 test_exchange_with_garbage(void **state)
 {
-    int newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
+    int64_t newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
 
     setup_particles(newSlots);
     int i;
@@ -181,7 +181,7 @@ test_exchange_layout_func_uneven(int i, const void * userdata)
 static void
 test_exchange_uneven(void **state)
 {
-    int newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
+    int64_t newSlots[6] = {NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1, NUMPART1};
 
     setup_particles(newSlots);
     int i;

--- a/libgadget/tests/test_gravity.c
+++ b/libgadget/tests/test_gravity.c
@@ -72,7 +72,7 @@ grav_force(const int this, const int other, const double * offset, double * accn
 void check_accns(double * meanerr_tot, double * maxerr_tot, double *PairAccn, double meanacc)
 {
     double meanerr=0, maxerr=-1;
-    int i;
+    int64_t i;
     /* This checks that the short-range force accuracy is being correctly estimated.*/
     #pragma omp parallel for reduction(+: meanerr) reduction(max: maxerr)
     for(i = 0; i < PartManager->NumPart; i++)
@@ -88,7 +88,7 @@ void check_accns(double * meanerr_tot, double * maxerr_tot, double *PairAccn, do
     MPI_Allreduce(&meanerr, meanerr_tot, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&maxerr, maxerr_tot, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
     int64_t tot_npart;
-    sumup_large_ints(1, &PartManager->NumPart, &tot_npart);
+    MPI_Allreduce(&PartManager->NumPart, &tot_npart, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
 
     *meanerr_tot/= (tot_npart*3.);
 }
@@ -108,7 +108,7 @@ static void find_means(double * meangrav, double * suppmean, double * suppaccns)
         }
     }
     int64_t tot_npart;
-    sumup_large_ints(1, &PartManager->NumPart, &tot_npart);
+    MPI_Allreduce(&PartManager->NumPart, &tot_npart, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     if(suppaccns) {
         MPI_Allreduce(&meanacc, suppmean, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
         *suppmean/= (tot_npart*3.);
@@ -244,7 +244,7 @@ static void test_force_flat(void ** state) {
     MPI_Allreduce(MPI_IN_PLACE, &meanerr, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(MPI_IN_PLACE, &maxerr, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
     int64_t tot_npart;
-    sumup_large_ints(1, &PartManager->NumPart, &tot_npart);
+    MPI_Allreduce(&PartManager->NumPart, &tot_npart, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
     meanerr/= (tot_npart*3.);
 
     message(0, "Max force %g, mean grav force %g\n", maxerr, meanerr);

--- a/libgadget/tests/test_slotsmanager.c
+++ b/libgadget/tests/test_slotsmanager.c
@@ -23,7 +23,7 @@ setup_particles(void ** state)
     PartManager->MaxPart = 1024;
     PartManager->NumPart = 128 * 6;
 
-    int newSlots[6] = {128, 128, 128, 128, 128, 128};
+    int64_t newSlots[6] = {128, 128, 128, 128, 128, 128};
 
     PartManager->Base = (struct particle_data *) mymalloc("P", PartManager->MaxPart* sizeof(struct particle_data));
     memset(PartManager->Base, 0, sizeof(struct particle_data) * PartManager->MaxPart);
@@ -41,7 +41,7 @@ setup_particles(void ** state)
 
     slots_setup_topology(PartManager, newSlots, SlotsManager);
 
-    int i;
+    int64_t i;
     #pragma omp parallel for
     for(i = 0; i < PartManager->NumPart; i ++) {
         P[i].ID = i;
@@ -109,8 +109,8 @@ test_slots_reserve(void **state)
      * moving those numbers to All.* we shall rework the code here. */
     setup_particles(state);
 
-    int newSlots[6] = {128, 128, 128, 128, 128, 128};
-    int oldSize[6];
+    int64_t newSlots[6] = {128, 128, 128, 128, 128, 128};
+    int64_t oldSize[6];
     int ptype;
     for(ptype = 0; ptype < 6; ptype++) {
         oldSize[ptype] = SlotsManager->info[ptype].maxsize;

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -87,7 +87,7 @@ timestep_eh_slots_fork(EIBase * event, void * userdata)
     ActiveParticles * act = (ActiveParticles *) userdata;
 
     if(is_timebin_active(P[parent].TimeBin, P[parent].Ti_drift)) {
-        int childactive = atomic_fetch_and_add(&act->NumActiveParticle, 1);
+        int64_t childactive = atomic_fetch_and_add_64(&act->NumActiveParticle, 1);
         if(act->ActiveParticle) {
             /* This should never happen because we allocate as much space for active particles as we have space
              * for particles, but just in case*/

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -92,7 +92,7 @@ timestep_eh_slots_fork(EIBase * event, void * userdata)
             /* This should never happen because we allocate as much space for active particles as we have space
              * for particles, but just in case*/
             if(childactive >= act->MaxActiveParticle)
-                endrun(5, "Tried to add %d active particles, more than %d allowed\n", childactive, act->MaxActiveParticle);
+                endrun(5, "Tried to add %ld active particles, more than %ld allowed\n", childactive, act->MaxActiveParticle);
             act->ActiveParticle[childactive] = child;
         }
     }

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -8,8 +8,8 @@
 set in rebuild_activelist.*/
 typedef struct ActiveParticles
 {
-    int MaxActiveParticle;
-    int NumActiveParticle;
+    int64_t MaxActiveParticle;
+    int64_t NumActiveParticle;
     int *ActiveParticle;
 } ActiveParticles;
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -312,7 +312,7 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, size_t * d
         if(end > tw->WorkSetSize)
             end = tw->WorkSetSize;
         /* Reduce the chunk size towards the end of the walk*/
-        if(((size_t) tw->WorkSetSize  < end + chnksz * tw->NThread) && chnksz >= 2)
+        if((tw->WorkSetSize  < end + chnksz * tw->NThread) && chnksz >= 2)
             chnksz /= 2;
         int k;
         for(k = chnk; k < end; k++) {
@@ -470,7 +470,7 @@ ev_primary(TreeWalk * tw)
         lastSucceeded = real_ev(export, tw, &dataindexoffset[tid], &nexports[tid], &currentIndex);
     }
 
-    size_t i;
+    int64_t i;
     tw->Nexport = 0;
 
     /* Compactify the export queue*/
@@ -613,7 +613,7 @@ treewalk_run(TreeWalk * tw, int * active_set, size_t size)
     ev_begin(tw, active_set, size);
 
     if(tw->preprocess) {
-        int i;
+        int64_t i;
         #pragma omp parallel for
         for(i = 0; i < tw->WorkSetSize; i ++) {
             const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;
@@ -661,7 +661,7 @@ treewalk_run(TreeWalk * tw, int * active_set, size_t size)
     tstart = second();
 
     if(tw->postprocess) {
-        int i;
+        int64_t i;
         #pragma omp parallel for
         for(i = 0; i < tw->WorkSetSize; i ++) {
             const int p_i = tw->WorkSet ? tw->WorkSet[i] : i;

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -122,7 +122,7 @@ static TreeWalk * GDB_current_ev = NULL;
 static void
 ev_init_thread(const struct TreeWalkThreadLocals export, TreeWalk * const tw, LocalTreeWalk * lv)
 {
-    const int thread_id = omp_get_thread_num();
+    const size_t thread_id = omp_get_thread_num();
     const int NTask = tw->NTask;
     int j;
     lv->tw = tw;
@@ -164,7 +164,8 @@ ev_free_threadlocals(struct TreeWalkThreadLocals export)
 static void
 ev_begin(TreeWalk * tw, int * active_set, const size_t size)
 {
-    const int NumThreads = omp_get_max_threads();
+    /* Needs to be 64-bit so that the multiplication in Ngblist malloc doesn't overflow*/
+    const size_t NumThreads = omp_get_max_threads();
     MPI_Comm_size(MPI_COMM_WORLD, &tw->NTask);
     tw->NThread = NumThreads;
     /* The last argument is may_have_garbage: in practice the only

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -289,7 +289,7 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, size_t * d
     TreeWalkQueryBase * input = alloca(tw->query_type_elsize);
     TreeWalkResultBase * output = alloca(tw->result_type_elsize);
 
-    int lastSucceeded = tw->WorkSetStart - 1;
+    int64_t lastSucceeded = tw->WorkSetStart - 1;
     /* We must schedule monotonically so that if the export buffer fills up
      * it is guaranteed that earlier particles are already done.
      * However, we schedule dynamically so that we have reduced imbalance.
@@ -345,7 +345,7 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, size_t * d
         }
         /* If we filled up, we need to remove the partially evaluated last particle from the export list and leave this loop.*/
         if(lv->Nexport >= lv->BunchSize) {
-            message(1, "Tree export buffer full with %d particles. start %d lastsucceeded: %d.\n", lv->Nexport, tw->WorkSetStart, lastSucceeded);
+            message(1, "Tree export buffer full with %ld particles. start %ld lastsucceeded: %ld.\n", lv->Nexport, tw->WorkSetStart, lastSucceeded);
             tw->BufferFullFlag = 1;
             /* Touch up the DataIndexTable, so that partial particle exports are discarded.
              * Since this queue is per-thread, it is ordered.*/
@@ -353,7 +353,7 @@ static int real_ev(struct TreeWalkThreadLocals export, TreeWalk * tw, size_t * d
             const int lastreal = tw->WorkSet ? tw->WorkSet[k] : k;
             /* Index stores tw->target, which is the current particle.*/
             if(lv->NThisParticleExport > 0 && DataIndexTable[lv->DataIndexOffset + lv->Nexport].Index != lastreal)
-                endrun(5, "Something screwed up in export queue: nexp %d (local %d) last %d != index %d\n", lv->Nexport,
+                endrun(5, "Something screwed up in export queue: nexp %ld (local %d) last %d != index %d\n", lv->Nexport,
                        lv->NThisParticleExport, lastreal, DataIndexTable[lv->DataIndexOffset + lv->Nexport].Index);
             /* Leave this chunking loop.*/
             break;

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -104,7 +104,7 @@ struct TreeWalk {
     TreeWalkProcessFunction postprocess; /* postprocess finalizes quantities for each particle, e.g. divide the normalization */
     TreeWalkProcessFunction preprocess; /* Preprocess initializes quantities for each particle */
     int NTask; /*Number of MPI tasks*/
-    size_t NThread; /*Number of OpenMP threads*/
+    int64_t NThread; /*Number of OpenMP threads*/
 
     /* Unlike in Gadget-3, when exporting we now always send tree branches.*/
     char * dataget;
@@ -150,11 +150,11 @@ struct TreeWalk {
 
     /* Index into WorkSet to start iteration.
      * Will be !=0 if the export buffer fills up*/
-    int WorkSetStart;
+    int64_t WorkSetStart;
     /* The list of particles to work on. May be NULL, in which case all particles are used.*/
     int * WorkSet;
     /* Size of the workset list*/
-    int WorkSetSize;
+    int64_t WorkSetSize;
     /*Did we use the active_set array as the WorkSet?*/
     int work_set_stolen_from_active;
 

--- a/libgadget/utils/memory.c
+++ b/libgadget/utils/memory.c
@@ -287,24 +287,24 @@ allocator_print(Allocator * alloc)
                 alloc->name,
                 alloc->use_malloc?"(libc managed)":"(self managed)"
                 );
-    message(1, " Total: %010td bytes\n", alloc->size);
+    message(1, " Total: %010td kbytes\n", alloc->size/1024);
     message(1, " Free: %010td Used: %010td Top: %010td Bottom: %010td \n",
-            allocator_get_free_size(alloc),
-            allocator_get_used_size(alloc, ALLOC_DIR_BOTH),
-            allocator_get_used_size(alloc, ALLOC_DIR_TOP),
-            allocator_get_used_size(alloc, ALLOC_DIR_BOT)
+            allocator_get_free_size(alloc)/1024,
+            allocator_get_used_size(alloc, ALLOC_DIR_BOTH)/1024,
+            allocator_get_used_size(alloc, ALLOC_DIR_TOP)/1024,
+            allocator_get_used_size(alloc, ALLOC_DIR_BOT)/1024
             );
     AllocatorIter iter[1];
-    message(1, " %-20s | %c | %-10s %-10s | %s\n", "Name", 'd', "Requested", "Allocated", "Annotation");
+    message(1, " %-20s | %c | %-12s %-12s | %s\n", "Name", 'd', "Requested", "Allocated", "Annotation");
     message(1, "-------------------------------------------------------\n");
     for(allocator_iter_start(iter, alloc);
         !allocator_iter_ended(iter);
         allocator_iter_next(iter))
     {
-        message(1, " %-20s | %c | %010td %010td | %s\n",
+        message(1, " %-20s | %c | %012td %012td | %s\n",
                  iter->name,
                  "T?B"[iter->dir + 1],
-                 iter->request_size, iter->size, iter->annotation);
+                 iter->request_size/1024, iter->size/1024, iter->annotation);
     }
 }
 

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -58,6 +58,16 @@ double timediff(double t0, double t1);
 double second(void);
 size_t sizemax(size_t a, size_t b);
 
+static inline int64_t atomic_fetch_and_add_64(int64_t * ptr, int64_t value) {
+    int64_t k;
+#pragma omp atomic capture
+    {
+      k = (*ptr);
+      (*ptr)+=value;
+    }
+    return k;
+}
+
 static inline int atomic_fetch_and_add(int * ptr, int value) {
     int k;
 #pragma omp atomic capture


### PR DESCRIPTION
This PR fixes a crash when the Frontera nodes are fullly loaded and we use 28 threads. 3525ab4 is the actual bugfix. The others are pre-emptive extension of counter variables to int64_t in the hope of preventing future bugs.