### PR TITLE
Do multiple density iterations at once

### DIFF
--- a/libgadget/fof.c
+++ b/libgadget/fof.c
@@ -1120,6 +1120,9 @@ fof_secondary_ngbiter(TreeWalkQueryFOF * I,
         O->MinID = HaloLabel[other].MinID;
         O->MinIDTask = HaloLabel[other].MinIDTask;
     }
+    /* No need to search nodes at a greater distance
+     * now that we have a neighbour.*/
+    iter->base.Hsml = iter->base.r;
 }
 
 static void
@@ -1155,7 +1158,7 @@ static void fof_label_secondary(ForceTree * tree)
 
     TreeWalk tw[1] = {{0}};
     tw->ev_label = "FOF_FIND_NEAREST";
-    tw->visit = (TreeWalkVisitFunction) knn_visit;
+    tw->visit = treewalk_visit_nolist_ngbiter;
     tw->ngbiter = (TreeWalkNgbIterFunction) fof_secondary_ngbiter;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterFOF);
     tw->haswork = fof_secondary_haswork;

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -829,7 +829,7 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
 
     /* Increase Hsml to a larger value, using numerical extrapolation from the current value. We can be fairly aggressive
      * here because overly large treewalks stop once they have too many neighbours.*/
-    if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-1] < desnumngb - MetalParams.MaxNgbDeviation) {
+    if(Right[pi] > 0.99 * tw->tree->BoxSize) {
         /* Extrapolate using volume, ie locally constant density*/
         double dngbdv = (STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-1] - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-2]) / (pow(evalhsml[maxcmpt-1],3) - pow(evalhsml[maxcmpt-2],3));
         /* Increase hsml by a maximum factor to avoid madness. We can be fairly aggressive about this factor.*/
@@ -844,6 +844,18 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
     }
     if(hsml > Right[pi])
         hsml = Right[pi];
+
+    /* Decrease Hsml to a smaller value, using numerical extrapolation from the current value.*/
+    if(Left[pi] == 0) {
+        /* Extrapolate using volume, ie locally constant density*/
+        double dngbdv = (STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][1] - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][0]) / (pow(evalhsml[1],3) - pow(evalhsml[0],3));
+        /* Increase hsml by a maximum factor to avoid madness. We can be fairly aggressive about this factor.*/
+        if(dngbdv > 0) {
+            double dngb = desnumngb - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][0];
+            double newvolume = pow(hsml,3) + dngb / dngbdv;
+            hsml = pow(newvolume, 1./3);
+        }
+    }
 
     P[i].Hsml = hsml;
 

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -829,7 +829,8 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
     if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-1] < desnumngb - MetalParams.MaxNgbDeviation) {
         /* Extrapolate using volume, ie locally constant density*/
         double dngbdv = (STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-1] - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-2]) / (pow(evalhsml[maxcmpt-1],3) - pow(evalhsml[maxcmpt-2],3));
-        double newhsml = 3* hsml;
+        /* Increase hsml by a maximum factor to avoid madness. We can be fairly aggressive about this factor.*/
+        double newhsml = 4 * hsml;
         if(dngbdv > 0) {
             double dngb = (desnumngb - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][maxcmpt-1]);
             double newvolume = pow(hsml,3) + dngb / dngbdv;

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -855,6 +855,9 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
     if(Left[pi] == 0) {
         /* Extrapolate using volume, ie locally constant density*/
         double dngbdv = (STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][1] - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][0]) / (pow(evalhsml[1],3) - pow(evalhsml[0],3));
+        /* Derivative is not defined for minimum, so use 0.*/
+        if(maxcmpt == 1)
+            dngbdv = STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][0] / pow(evalhsml[1],3);
         /* Increase hsml by a maximum factor to avoid madness. We can be fairly aggressive about this factor.*/
         if(dngbdv > 0) {
             double dngb = desnumngb - STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][0];

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -935,6 +935,7 @@ stellar_density(const ActiveParticles * act, MyFloat * StarVolumeSPH, MyFloat * 
 
     tw->ev_label = "STELLAR_DENSITY";
     tw->visit = treewalk_visit_nolist_ngbiter;
+    tw->NoNgblist = 1;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterStellarDensity);
     tw->ngbiter = (TreeWalkNgbIterFunction) stellar_density_ngbiter;
     tw->haswork = stellar_density_haswork;

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -757,14 +757,17 @@ static inline double
 effhsml(int place, int i, TreeWalk * tw)
 {
     int pi = P[place].PI;
-    const double left = STELLAR_DENSITY_GET_PRIV(tw)->Left[pi];
-    const double right = STELLAR_DENSITY_GET_PRIV(tw)->Right[pi];
+    double left = STELLAR_DENSITY_GET_PRIV(tw)->Left[pi];
+    double right = STELLAR_DENSITY_GET_PRIV(tw)->Right[pi];
+    /* Use slightly past the current Hsml as the right most boundary*/
+    if(right > 0.99*tw->tree->BoxSize)
+        right = P[place].Hsml * ((1.+NHSML)/NHSML);
+    /* Use 1/2 of current Hsml for left. The asymmetry is because it is free
+     * to compute extra densities for h < Hsml, but not for h > Hsml.*/
+    if(left == 0)
+        left = 0.5 * P[place].Hsml;
     /* From left + 1/N  to right - 1/N*/
-    if(right < 0.99*tw->tree->BoxSize && left > 0)
-        return (1.*i+1)/(1.*NHSML+1) * (right - left) + left;
-    /* The asymmetry is because it is free to compute extra densities for h < Hsml, but not for h > Hsml.
-     *So we increase Right in check_neighbours.*/
-    return (i+1.)/(1.*NHSML) * (P[place].Hsml - left) + left;
+    return (1.*i+1)/(1.*NHSML+1) * (right - left) + left;
 }
 
 static void

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -815,10 +815,13 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
         }
     }
     for(j = 0; j < maxcmpt; j++) {
-        if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][j] < desnumngb - MetalParams.MaxNgbDeviation)
+        /* Need rightmost left and leftmost right*/
+        if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][j] < desnumngb)
             Left[pi] = evalhsml[j];
-        if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][j] > desnumngb + MetalParams.MaxNgbDeviation)
+        if(STELLAR_DENSITY_GET_PRIV(tw)->NumNgb[pi][j] > desnumngb) {
             Right[pi] = evalhsml[j];
+            break;
+        }
     }
 
     double hsml = evalhsml[close];

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -708,7 +708,7 @@ metal_return_haswork(int i, TreeWalk * tw)
 }
 
 /* Number of densities to evaluate simultaneously*/
-#define NHSML 5
+#define NHSML 10
 
 typedef struct {
     TreeWalkNgbIterBase base;

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -765,7 +765,7 @@ effhsml(int place, int i, TreeWalk * tw)
     /* Use 1/2 of current Hsml for left. The asymmetry is because it is free
      * to compute extra densities for h < Hsml, but not for h > Hsml.*/
     if(left == 0)
-        left = 0.5 * P[place].Hsml;
+        left = 0.1 * P[place].Hsml;
     /* From left + 1/N  to right - 1/N, evenly spaced in volume,
      * since NumNgb ~ h^3.*/
     double rvol = pow(right, 3);

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -766,8 +766,11 @@ effhsml(int place, int i, TreeWalk * tw)
      * to compute extra densities for h < Hsml, but not for h > Hsml.*/
     if(left == 0)
         left = 0.5 * P[place].Hsml;
-    /* From left + 1/N  to right - 1/N*/
-    return (1.*i+1)/(1.*NHSML+1) * (right - left) + left;
+    /* From left + 1/N  to right - 1/N, evenly spaced in volume,
+     * since NumNgb ~ h^3.*/
+    double rvol = pow(right, 3);
+    double lvol = pow(left, 3);
+    return pow((1.*i+1)/(1.*NHSML+1) * (rvol - lvol) + lvol, 1./3);
 }
 
 static void

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -859,6 +859,8 @@ void stellar_density_check_neighbours (int i, TreeWalk * tw)
             hsml = pow(newvolume, 1./3);
         }
     }
+    if(hsml < Left[pi])
+        hsml = Left[pi];
 
     P[i].Hsml = hsml;
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1119,13 +1119,15 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
     return numcand;
 }
 
-
 /*****
- * This is visit code that finds the nearest neighbour particle in the tree from
- * searchcenter up to hsml. It calls ngbiter every time a candidate is found, and thus culls the tree
- * when a node can contain no particle closer than the current nearest neighbour.
+ * Variant of ngbiter that doesn't use the Ngblist.
+ * The ngblist is generally preferred for memory locality reasons and
+ * to avoid particles being partially evaluated
+ * twice if the buffer fills up. Use this variant if the evaluation
+ * wants to change the search radius, such as for knn algorithms
+ * or some density code. Don't use it if the treewalk modifies other particles.
  * */
-int knn_visit(TreeWalkQueryBase * I,
+int treewalk_visit_nolist_ngbiter(TreeWalkQueryBase * I,
             TreeWalkResultBase * O,
             LocalTreeWalk * lv)
 {
@@ -1202,9 +1204,6 @@ int knn_visit(TreeWalkQueryBase * I,
                     iter->r2 = r2;
                     iter->other = other;
                     iter->r = sqrt(r2);
-                    /* No need to search nodes at a greater distance
-                     * now that we have a neighbour.*/
-                    iter->Hsml = iter->r;
                     lv->tw->ngbiter(I, O, iter, lv);
                 }
                 /* Move sideways*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -137,7 +137,8 @@ ev_init_thread(const struct TreeWalkThreadLocals export, TreeWalk * const tw, Lo
     if(localbunch > tw->BunchSize - thread_id * localbunch)
         lv->BunchSize = tw->BunchSize - thread_id * localbunch;
 
-    lv->ngblist = tw->Ngblist + thread_id * PartManager->NumPart;
+    if(tw->Ngblist)
+        lv->ngblist = tw->Ngblist + thread_id * PartManager->NumPart;
     for(j = 0; j < NTask; j++)
         lv->exportflag[j] = -1;
 }
@@ -183,7 +184,10 @@ ev_begin(TreeWalk * tw, int * active_set, const size_t size)
     /* Start first iteration at the beginning*/
     tw->WorkSetStart = 0;
 
-    tw->Ngblist = (int*) mymalloc("Ngblist", PartManager->NumPart * NumThreads * sizeof(int));
+    if(!tw->NoNgblist)
+        tw->Ngblist = (int*) mymalloc("Ngblist", PartManager->NumPart * NumThreads * sizeof(int));
+    else
+        tw->Ngblist = NULL;
 
     report_memory_usage(tw->ev_label);
 
@@ -230,7 +234,8 @@ static void ev_finish(TreeWalk * tw)
 {
     myfree(DataNodeList);
     myfree(DataIndexTable);
-    myfree(tw->Ngblist);
+    if(tw->Ngblist)
+        myfree(tw->Ngblist);
     if(!tw->work_set_stolen_from_active)
         myfree(tw->WorkSet);
 

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -152,7 +152,6 @@ struct TreeWalk {
     size_t BunchSize;
     /* List of neighbour candidates.*/
     int *Ngblist;
-
     /* Index into WorkSet to start iteration.
      * Will be !=0 if the export buffer fills up*/
     int64_t WorkSetStart;
@@ -186,7 +185,15 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
 int treewalk_export_particle(LocalTreeWalk * lv, int no);
 #define TREEWALK_REDUCE(A, B) (A) = (mode==TREEWALK_PRIMARY)?(B):((A) + (B))
 
-int knn_visit(TreeWalkQueryBase * I, TreeWalkResultBase * O, LocalTreeWalk * lv);
+/*****
+ * Variant of ngbiter that doesn't use the Ngblist.
+ * The ngblist is generally preferred for memory locality reasons and
+ * to avoid particles being partially evaluated
+ * twice if the buffer fills up. Use this variant if the evaluation
+ * wants to change the search radius, such as for knn algorithms
+ * or some density code. Don't use it if the treewalk modifies other particles.
+ * */
+int treewalk_visit_nolist_ngbiter(TreeWalkQueryBase * I, TreeWalkResultBase * O, LocalTreeWalk * lv);
 
 #define MAXITER 400
 

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -152,6 +152,8 @@ struct TreeWalk {
     size_t BunchSize;
     /* List of neighbour candidates.*/
     int *Ngblist;
+    /* Flag not allocating nighbour list*/
+    int NoNgblist;
     /* Index into WorkSet to start iteration.
      * Will be !=0 if the export buffer fills up*/
     int64_t WorkSetStart;


### PR DESCRIPTION
This is the latest attempt to improve the balance of the stellar density (metal return) code. If this works we could perhaps use it for the gas density as well. The idea is that to use that computing the neighbour number, NumNgb, for any smoothing length h < H (where H is the current particle Hsml) is essentially free, because the treewalk is dominated by the memory latency involved in fetching the nodes and particles. So we can compute NumNgb(h_i) for multiple h_i values in parallel and use this information to efficiently bound the desired SPH smoothing length. This dramatically reduces the maximum number of density iterations, from about 10 to 3. This should also improve the balance as the final iterations usually have very few particles active.

A side effect is that we can stop a treewalk and reduce H if h_i > N from a partial treewalk, because NumNgb is monotonic during the walk. This should avoid the very slow treewalks we sometimes see when one particle has acquired an overly large h value.

Open questions:
- What is the optimal number of simultaneous evaluations?
- I removed the Dhsmldensity (which finds dNumNgb(h)/dh by kernel differentiation) in cd3f82e as it didn't really seem to do anything in my little hydro example test. Is this conclusion correct in a bigger box?
- Is the current choice of the h_i array optimal? At the moment the first iteration uses the largest h_i > h, and the others <= h. Later iterations linearly space h_i between Left and Right, but it might be better to weight this spacing by the NumNgb value so that, eg, if NumNgb(Left) - DesNumNgb = -5 and NumNgb(Right) - DesNumNgb = 30 we have finer spacing near Left than Right. 
- (Once we merge this) What does this look like if implemented for the gas density code and the SFR_WIND code?

and of course more testing is needed!

Currently I tested on the hydro example only. There was a speedup of about 20% in the stellar density code, but none of the pathological behaviour seen in bigger runs shows up on my single-node workstation, so I would hope improvements are larger in the bigger boxes.