### PR TITLE
Combineddrift

### DIFF
--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -139,6 +139,9 @@ all: libgadget.a libgadget-utils.a
 .objs/test_cooling_rates: tests/test_cooling_rates.c .objs/cooling_rates.o .objs/cooling_uvfluc.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
 
+.objs/test_exchange: tests/test_exchange.c .objs/exchange.o ../tests/stub.c ../tests/cmocka.c libgadget.a libgadget-utils.a
+	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
+
 .objs/test_density: tests/test_density.c .objs/density.o libgadget.a ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
 

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -213,7 +213,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
     myfree(OldTopLeaves);
     myfree(OldTopNodes);
 
-    if(domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, 10000, ddecomp->DomainComm))
+    if(domain_exchange(domain_layoutfunc, ddecomp, 0, NULL, PartManager, SlotsManager, 10000, ddecomp->DomainComm))
         endrun(1929,"Could not exchange particles\n");
 
     /*Do a garbage collection so that the slots are ordered
@@ -231,7 +231,7 @@ void domain_decompose_full(DomainDecomp * ddecomp)
 
 /* This is a cut-down version of the domain decomposition that leaves the
  * domain grid intact, but exchanges the particles and rebuilds the tree */
-void domain_maintain(DomainDecomp * ddecomp)
+void domain_maintain(DomainDecomp * ddecomp, struct DriftData * drift)
 {
     message(0, "Attempting a domain exchange\n");
 
@@ -240,7 +240,7 @@ void domain_maintain(DomainDecomp * ddecomp)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, PartManager, SlotsManager, 10000, ddecomp->DomainComm)) {
+    if(0 != domain_exchange(domain_layoutfunc, ddecomp, 0, drift, PartManager, SlotsManager, 10000, ddecomp->DomainComm)) {
         domain_decompose_full(ddecomp);
         return;
     }

--- a/libgadget/domain.h
+++ b/libgadget/domain.h
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include "utils/peano.h"
 #include "utils/paramset.h"
+#include "drift.h"
 
 /*These variables are used externally in forcetree.c.
  * DomainTask is also used in treewalk and NTopLeaves is used in gravpm.c*/
@@ -66,7 +67,7 @@ void set_domain_par(DomainParams dp);
 /* Do a full domain decomposition, which splits the particles into even clumps*/
 void domain_decompose_full(DomainDecomp * ddecomp);
 /* Exchange particles which have moved into the new domains, not re-doing the split unless we have to*/
-void domain_maintain(DomainDecomp * ddecomp);
+void domain_maintain(DomainDecomp * ddecomp, struct DriftData * drift);
 
 /** This function determines the TopLeaves entry for the given key.*/
 static inline int

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -12,8 +12,6 @@
 #include "partmanager.h"
 #include "utils.h"
 
-static void real_drift_particle(int i, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3]);
-
 /* Drifts an individual particle to time ti1, by a drift factor ddrift.
  * The final argument is a random shift vector applied uniformly to all particles before periodic wrapping.
  * The box is periodic, so this does not affect real physics, but it avoids correlated errors
@@ -22,7 +20,7 @@ static void real_drift_particle(int i, inttime_t dti, const double ddrift, const
  * receives a shift vector removing the previous random shift and adding a new one.
  * This function also updates the velocity and updates the density according to an adiabatic factor.
  */
-static void real_drift_particle(int i, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3])
+void real_drift_particle(int i, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3])
 {
     int j;
     if(P[i].IsGarbage || P[i].Swallowed) {

--- a/libgadget/drift.h
+++ b/libgadget/drift.h
@@ -6,4 +6,15 @@
 /* Updates all particles to the current drift time*/
 void drift_all_particles(inttime_t ti0, inttime_t ti1, const double BoxSize, Cosmology * CP, const double random_shift[3]);
 
+void real_drift_particle(int i, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3]);
+
+struct DriftData
+{
+    int do_drift;
+    inttime_t ti0;
+    inttime_t ti1;
+    const double BoxSize;
+    Cosmology * CP;
+};
+
 #endif

--- a/libgadget/drift.h
+++ b/libgadget/drift.h
@@ -10,10 +10,9 @@ void real_drift_particle(int i, inttime_t dti, const double ddrift, const double
 
 struct DriftData
 {
-    int do_drift;
     inttime_t ti0;
     inttime_t ti1;
-    const double BoxSize;
+    double BoxSize;
     Cosmology * CP;
 };
 

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -5,6 +5,8 @@
 #include "slotsmanager.h"
 #include "partmanager.h"
 #include "walltime.h"
+#include "drift.h"
+#include "timefac.h"
 
 #include "utils.h"
 #include "utils/mpsort.h"
@@ -50,7 +52,7 @@ typedef struct {
 static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, MPI_Comm Comm);
 static void domain_build_plan(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman);
 static size_t domain_find_iter_space(ExchangePlan * plan, const struct part_manager_type * pman, const struct slots_manager_type * sman);
-static void domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman, MPI_Comm Comm);
+static void domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct DriftData * drift, struct part_manager_type * pman, MPI_Comm Comm);
 
 /* This function builds the count/displ arrays from
  * the rows stored in the entry struct of the plan.
@@ -98,7 +100,7 @@ domain_free_exchangeplan(ExchangePlan * plan)
 }
 
 /*Plan and execute a domain exchange, also performing a garbage collection if requested*/
-int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm) {
+int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, int do_gc, struct DriftData * drift, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm) {
     int64_t sumtogo;
     int failure = 0;
 
@@ -120,7 +122,7 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
             failure = 1;
             break;
         }
-        domain_build_exchange_list(layoutfunc, layout_userdata, &plan, pman, Comm);
+        domain_build_exchange_list(layoutfunc, layout_userdata, &plan, (iter > 0 ? NULL : drift), pman, Comm);
 
         /*Exit early if nothing to do*/
         if(!MPIU_Any(plan.nexchange > 0, Comm))
@@ -157,7 +159,8 @@ int domain_exchange(ExchangeLayoutFunc layoutfunc, const void * layout_userdata,
      * and we only get one iteration. */
     if(!failure && maxiter > 1) {
         ExchangePlan plan9 = domain_init_exchangeplan(Comm);
-        domain_build_exchange_list(layoutfunc, layout_userdata, &plan9, pman, Comm);
+        /* Do not drift again*/
+        domain_build_exchange_list(layoutfunc, layout_userdata, &plan9, NULL, pman, Comm);
         if(plan9.nexchange > 0)
             endrun(5, "Still have %ld particles in exchange list\n", plan9.nexchange);
         myfree(plan9.ExchangeList);
@@ -369,7 +372,7 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
  * All particles are processed every time, space is not considered.
  * The exchange list needs to be rebuilt every time gc is run. */
 static void
-domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct part_manager_type * pman, MPI_Comm Comm)
+domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_userdata, ExchangePlan * plan, struct DriftData * drift, struct part_manager_type * pman, MPI_Comm Comm)
 {
     int i;
     size_t numthreads = omp_get_max_threads();
@@ -387,11 +390,22 @@ domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_us
     int ThisTask;
     MPI_Comm_rank(Comm, &ThisTask);
 
+    /* Can't update the random shift without re-decomposing domain*/
+    const double rel_random_shift[3] = {0};
+    /* Find drift factor*/
+    double ddrift = 0;
+    if(drift)
+        ddrift = get_exact_drift_factor(drift->CP, drift->ti0, drift->ti1);
+
     /* flag the particles that need to be exported */
     size_t schedsz = plan->nexchange/numthreads+1;
     #pragma omp parallel for schedule(static, schedsz) reduction(+: ngarbage)
     for(i=0; i < pman->NumPart; i++)
     {
+        if(drift) {
+            real_drift_particle(i, drift->ti1-drift->ti0, ddrift, drift->BoxSize, rel_random_shift);
+            P[i].Ti_drift = drift->ti1;
+        }
         if(pman->Base[i].IsGarbage) {
             ngarbage++;
             continue;

--- a/libgadget/exchange.h
+++ b/libgadget/exchange.h
@@ -3,10 +3,11 @@
 
 #include "partmanager.h"
 #include "slotsmanager.h"
+#include "drift.h"
 
 typedef int (*ExchangeLayoutFunc) (int p, const void * userdata);
 
-int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm);
+int domain_exchange(ExchangeLayoutFunc, const void * layout_userdata, int do_gc, struct DriftData * drift, struct part_manager_type * pman, struct slots_manager_type * sman, int maxiter, MPI_Comm Comm);
 void domain_test_id_uniqueness(struct part_manager_type * pman);
 
 #endif

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -288,7 +288,7 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
 
     walltime_measure("/FOF/IO/Distribute");
     /* sort SPH and Others independently */
-    if(domain_exchange(fof_sorted_layout, targettask, 1, halo_pman, halo_sman, 1, Comm)) {
+    if(domain_exchange(fof_sorted_layout, targettask, 1, NULL, halo_pman, halo_sman, 1, Comm)) {
         message(1930, "Failed to exchange and write particles for the FOF. This is non-fatal, continuing\n");
         myfree(targettask);
         return 1;

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -221,7 +221,7 @@ run(int RestartSnapNum)
             /* currently we drift all particles every step */
             /* If it is not a PM step, do a shorter version
              * of the ddecomp decomp which just exchanges particles.*/
-            domain_maintain(ddecomp);
+            domain_maintain(ddecomp, NULL);
         }
 
         ActiveParticles Act = {0};

--- a/libgadget/tests/test_exchange.c
+++ b/libgadget/tests/test_exchange.c
@@ -101,7 +101,7 @@ test_exchange(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager,10000, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, NULL, PartManager, SlotsManager,10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -125,7 +125,7 @@ test_exchange_zero_slots(void **state)
 
     int i;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, NULL, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -148,10 +148,10 @@ test_exchange_with_garbage(void **state)
     setup_particles(newSlots);
     int i;
 
-    slots_mark_garbage(0, PartManager, SlotsManager); /* watch out! this propogates the garbage flag to children */
+    slots_mark_garbage(0, PartManager, SlotsManager); /* watch out! this propagates the garbage flag to children */
     TotNumPart -= NTask;
 
-    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func, NULL, 1, NULL, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 
@@ -187,7 +187,7 @@ test_exchange_uneven(void **state)
     int i;
 
     /* this will trigger a slot growth on slot type 0 due to the inbalance */
-    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
+    int fail = domain_exchange(&test_exchange_layout_func_uneven, NULL, 1, NULL, PartManager, SlotsManager, 10000, MPI_COMM_WORLD);
 
     assert_all_true(!fail);
 


### PR DESCRIPTION
This combines drifting with domain exchanging. Since in practice both are loops over all particles and dominated by the memory latency, doing both at once is basically the same cost as the longest one. Zero change to output, some moderate speed-up on a small simulation.