### PR TITLE
Driftdensity

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -514,6 +514,10 @@ density_postprocess(int i, TreeWalk * tw)
     *DhsmlDens *= P[i].Hsml / (NUMDIMS * density);
     *DhsmlDens = 1 / (1 + *DhsmlDens);
 
+    /* Uses DhsmlDensityFactor and changes Hsml, hence the location.*/
+    if(DENSITY_GET_PRIV(tw)->update_hsml)
+        density_check_neighbours(i, tw);
+
     if(P[i].Type == 0)
     {
         int PI = P[i].PI;
@@ -535,10 +539,6 @@ density_postprocess(int i, TreeWalk * tw)
 
         SPHP(i).DivVel /= SPHP(i).Density;
     }
-
-    /* This is slightly more complicated so we put it in a different function */
-    if(DENSITY_GET_PRIV(tw)->update_hsml)
-        density_check_neighbours(i, tw);
 }
 
 void density_check_neighbours (int i, TreeWalk * tw)

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -538,6 +538,7 @@ density_postprocess(int i, TreeWalk * tw)
         SPHP(i).CurlVel = sqrt(Rot[0] * Rot[0] + Rot[1] * Rot[1] + Rot[2] * Rot[2]) / SPHP(i).Density;
 
         SPHP(i).DivVel /= SPHP(i).Density;
+        P[i].DtHsml = (1.0 / NUMDIMS) * SPHP(i).DivVel * P[i].Hsml;
     }
 }
 

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -70,21 +70,12 @@ void real_drift_particle(struct particle_data * pp, struct slots_manager_type * 
         /* Only does something when Pressure-entropy is enabled*/
         SPH[pi].EgyWtDensity *= densdriftfac;
 
-        //      pp->Hsml *= exp(0.333333333333 * SPHP(i).DivVel * ddrift);
-        //---This was added
-        double fac = cbrt(densdriftfac);
-        if(fac < 1./1.25)
-            fac = 1./1.25;
-
-        inttime_t ti_step = dti_from_timebin(pp->TimeBin);
-
-        /* During deep timestep hierarchies the
-         * expansion factor may get out of control,
-         * so don't let it do that.*/
-        if(ti_step <= 8*(dti))
-            pp->Hsml /= fac;
-        /* Cap the Hsml: if DivVel is large for a particle with a long timestep
-         * (most likely a wind particle) Hsml can very rarely run away*/
+        /* DtHsml is 1/3 DivVel * Hsml evaluated at the last active timestep for this particle.
+         * This predicts Hsml during the current timestep in the way used in Gadget-4, more accurate
+         * than the Gadget-2 prediction which could run away in deep timesteps. */
+        pp->Hsml += pp->DtHsml * ddrift;
+        /* Cap the Hsml just in case: if DivVel is large for a particle with a long timestep
+         * at one point Hsml could rarely run away.*/
         const double Maxhsml = BoxSize /2.;
         if(pp->Hsml > Maxhsml)
             pp->Hsml = Maxhsml;

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -65,6 +65,9 @@ void real_drift_particle(struct particle_data * pp, struct slots_manager_type * 
          * This predicts Hsml during the current timestep in the way used in Gadget-4, more accurate
          * than the Gadget-2 prediction which could run away in deep timesteps. */
         pp->Hsml += pp->DtHsml * ddrift;
+        if(pp->Hsml <= 0)
+            endrun(5, "Part id %ld has bad Hsml %g with DtHsml %g vel %g %g %g\n",
+                   pp->ID, pp->Hsml, pp->DtHsml, pp->Vel[0], pp->Vel[1], pp->Vel[2]);
         /* Cap the Hsml just in case: if DivVel is large for a particle with a long timestep
          * at one point Hsml could rarely run away.*/
         const double Maxhsml = BoxSize /2.;

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -61,15 +61,6 @@ void real_drift_particle(struct particle_data * pp, struct slots_manager_type * 
     }
     else if(pp->Type == 0)
     {
-        struct sph_particle_data * SPH = (struct sph_particle_data *) sman->info[0].ptr;
-        int pi = pp->PI;
-        /* This accounts for adiabatic density changes,
-         * and is a good predictor for most of the gas.*/
-        double densdriftfac = exp(-SPH[pi].DivVel * ddrift);
-        SPH[pi].Density *= densdriftfac;
-        /* Only does something when Pressure-entropy is enabled*/
-        SPH[pi].EgyWtDensity *= densdriftfac;
-
         /* DtHsml is 1/3 DivVel * Hsml evaluated at the last active timestep for this particle.
          * This predicts Hsml during the current timestep in the way used in Gadget-4, more accurate
          * than the Gadget-2 prediction which could run away in deep timesteps. */

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -19,7 +19,7 @@
  * receives a shift vector removing the previous random shift and adding a new one.
  * This function also updates the velocity and updates the density according to an adiabatic factor.
  */
-void real_drift_particle(struct particle_data * pp, struct slots_manager_type * sman, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3])
+void real_drift_particle(struct particle_data * pp, struct slots_manager_type * sman, const double ddrift, const double BoxSize, const double random_shift[3])
 {
     int j;
     if(pp->IsGarbage || pp->Swallowed) {
@@ -103,7 +103,7 @@ void drift_all_particles(inttime_t ti0, inttime_t ti1, const double BoxSize, Cos
         if(PartManager->Base[i].Ti_drift != ti0)
             endrun(10, "Drift time mismatch: (ids = %ld %ld) %d != %d\n",PartManager->Base[0].ID, PartManager->Base[i].ID, ti0,  PartManager->Base[i].Ti_drift);
 #endif
-        real_drift_particle(&PartManager->Base[i], SlotsManager, ti1-ti0, ddrift, BoxSize, random_shift);
+        real_drift_particle(&PartManager->Base[i], SlotsManager, ddrift, BoxSize, random_shift);
         PartManager->Base[i].Ti_drift = ti1;
     }
 

--- a/libgadget/drift.h
+++ b/libgadget/drift.h
@@ -8,7 +8,7 @@
 /* Updates all particles to the current drift time*/
 void drift_all_particles(inttime_t ti0, inttime_t ti1, const double BoxSize, Cosmology * CP, const double random_shift[3]);
 
-void real_drift_particle(struct particle_data * pp, struct slots_manager_type * sman, inttime_t dti, const double ddrift, const double BoxSize, const double random_shift[3]);
+void real_drift_particle(struct particle_data * pp, struct slots_manager_type * sman, const double ddrift, const double BoxSize, const double random_shift[3]);
 
 struct DriftData
 {

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -403,7 +403,7 @@ domain_build_exchange_list(ExchangeLayoutFunc layoutfunc, const void * layout_us
     for(i=0; i < pman->NumPart; i++)
     {
         if(drift) {
-            real_drift_particle(&pman->Base[i], sman, drift->ti1-drift->ti0, ddrift, drift->BoxSize, rel_random_shift);
+            real_drift_particle(&pman->Base[i], sman, ddrift, drift->BoxSize, rel_random_shift);
             pman->Base[i].Ti_drift = drift->ti1;
         }
         if(pman->Base[i].IsGarbage) {

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -85,6 +85,7 @@ struct HydraPriv {
     double FgravkickB;
     double gravkicks[TIMEBINS+1];
     double hydrokicks[TIMEBINS+1];
+    double drifts[TIMEBINS+1];
 };
 
 #define HYDRA_GET_PRIV(tw) ((struct HydraPriv*) ((tw)->priv))
@@ -171,6 +172,7 @@ hydro_force(const ActiveParticles * act, int WindOn, const double hubble, const 
     HYDRA_GET_PRIV(tw)->SPH_predicted = SPH_predicted;
     HYDRA_GET_PRIV(tw)->PressurePred = (double *) mymalloc("PressurePred", SlotsManager->info[0].size * sizeof(double));
     memset(HYDRA_GET_PRIV(tw)->PressurePred, 0, SlotsManager->info[0].size * sizeof(double));
+
     /* Compute pressure for active particles*/
     if(act->ActiveParticle) {
         #pragma omp parallel for
@@ -206,6 +208,7 @@ hydro_force(const ActiveParticles * act, int WindOn, const double hubble, const 
     priv->FgravkickB = get_exact_gravkick_factor(CP, times.PM_kick, times.Ti_Current);
     memset(priv->gravkicks, 0, sizeof(priv->gravkicks[0])*(TIMEBINS+1));
     memset(priv->hydrokicks, 0, sizeof(priv->hydrokicks[0])*(TIMEBINS+1));
+    memset(priv->drifts, 0, sizeof(priv->drifts[0])*(TIMEBINS+1));
     /* Compute the factors to move a current kick times velocity to the drift time velocity.
      * We need to do the computation for all timebins up to the maximum because even inactive
      * particles may have interactions. */
@@ -214,8 +217,11 @@ hydro_force(const ActiveParticles * act, int WindOn, const double hubble, const 
     {
         priv->gravkicks[i] = get_exact_gravkick_factor(CP, times.Ti_kick[i], times.Ti_Current);
         priv->hydrokicks[i] = get_exact_hydrokick_factor(CP, times.Ti_kick[i], times.Ti_Current);
+        /* For density: last active drift time is Ti_kick - 1/2 timestep as the kick time is half a timestep ahead.
+         * For active particles no density drift is needed.*/
+        if(!is_timebin_active(i, times.Ti_Current))
+            priv->drifts[i] = get_exact_drift_factor(CP, times.Ti_kick[i] - dti_from_timebin(i)/2, times.Ti_Current);
     }
-
 
     treewalk_run(tw, act->ActiveParticle, act->NumActiveParticle);
 
@@ -282,6 +288,17 @@ hydro_reduce(int place, TreeWalkResultHydro * result, enum TreeWalkReduceMode mo
 
 }
 
+/* Find the density predicted forward to the current drift time.
+ * The Density in the SPHP struct is evaluated at the last time
+ * the particle was active. Good for both EgyWtDensity and Density,
+ * cube of the change in Hsml in drift.c. */
+double
+SPH_DensityPred(MyFloat Density, MyFloat DivVel, double dtdrift)
+{
+    /* Note minus sign!*/
+    return Density - DivVel * Density * dtdrift;
+}
+
 /*! This function is the 'core' of the SPH force computation. A target
  *  particle is specified which may either be local, or reside in the
  *  communication buffer.
@@ -341,6 +358,8 @@ hydro_ngbiter(
     if(rsq <= 0 || !(rsq < iter->kernel_i.HH || rsq < kernel_j.HH))
         return;
 
+    struct HydraPriv * priv = HYDRA_GET_PRIV(lv->tw);
+
     double EntVarPred;
     #pragma omp atomic read
     EntVarPred = HYDRA_GET_PRIV(lv->tw)->SPH_predicted->EntVarPred[P[other].PI];
@@ -351,7 +370,6 @@ hydro_ngbiter(
      * Zero can be the special value since there should never be zero entropy.*/
     if(EntVarPred == 0) {
         MyFloat VelPred[3];
-        struct HydraPriv * priv = HYDRA_GET_PRIV(lv->tw);
         int bin = P[other].TimeBin;
         double a3inv = pow(priv->atime, -3);
         double dloga = dloga_from_dti(priv->times->Ti_Current - priv->times->Ti_kick[bin], priv->times->Ti_Current);
@@ -374,10 +392,15 @@ hydro_ngbiter(
     if(Pressure_j == 0) {
         Pressure_j = PressurePred(P[other].PI, EntVarPred);
         #pragma omp atomic write
-        HYDRA_GET_PRIV(lv->tw)->PressurePred[P[other].PI] = Pressure_j;
+        priv->PressurePred[P[other].PI] = Pressure_j;
     }
 
-    const double eomdensity = SPH_EOMDensity(&SPHP(other));
+    /* Predict densities. Note that for active timebins the density is up to date so SPH_DensityPred is just returns the current densities.
+     * This improves on the technique used in Gadget-2 by being a linear prediction that does not become pathological in deep timebins.*/
+    int bin = P[other].TimeBin;
+    const double density_j = SPH_DensityPred(SPHP(other).Density, SPHP(other).DivVel, priv->drifts[bin]);
+    const double eomdensity = SPH_DensityPred(SPH_EOMDensity(&SPHP(other)), SPHP(other).DivVel, priv->drifts[bin]);;
+
     double p_over_rho2_j = Pressure_j / (eomdensity * eomdensity);
     double soundspeed_j = sqrt(GAMMA * Pressure_j / eomdensity);
 
@@ -401,7 +424,7 @@ hydro_ngbiter(
     {
         /*See Gadget-2 paper: eq. 13*/
         const double mu_ij = HYDRA_GET_PRIV(lv->tw)->fac_mu * vdotr2 / r;	/* note: this is negative! */
-        const double rho_ij = 0.5 * (I->Density + SPHP(other).Density);
+        const double rho_ij = 0.5 * (I->Density + density_j);
         double vsig = iter->soundspeed_i + soundspeed_j;
 
         vsig -= 3 * mu_ij;
@@ -409,8 +432,7 @@ hydro_ngbiter(
         if(vsig > O->MaxSignalVel)
             O->MaxSignalVel = vsig;
 
-        /* Note this uses the CurlVel of an inactive particle, which may not be
-            * at the present drift time*/
+        /* Note this uses the CurlVel of an inactive particle, which is not at the present drift time*/
         const double f2 = fabs(SPHP(other).DivVel) / (fabs(SPHP(other).DivVel) +
                 SPHP(other).CurlVel + 0.0001 * soundspeed_j / HYDRA_GET_PRIV(lv->tw)->fac_mu / P[other].Hsml);
 
@@ -447,7 +469,7 @@ hydro_ngbiter(
         /* enable grad-h corrections only if contrastlimit is non negative */
         if(HydroParams.DensityContrastLimit >= 0) {
             rr1 = I->EgyRho / I->Density;
-            rr2 = SPHP(other).EgyWtDensity / SPHP(other).Density;
+            rr2 = eomdensity / density_j;
             if(HydroParams.DensityContrastLimit > 0) {
                 /* apply the limit if it is enabled > 0*/
                 rr1 = DMIN(rr1, HydroParams.DensityContrastLimit);

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -217,7 +217,7 @@ hydro_force(const ActiveParticles * act, int WindOn, const double hubble, const 
         /* For density: last active drift time is Ti_kick - 1/2 timestep as the kick time is half a timestep ahead.
          * For active particles no density drift is needed.*/
         if(!is_timebin_active(i, times.Ti_Current))
-            priv->drifts[i] = get_exact_drift_factor(CP, times.Ti_kick[i] - dti_from_timebin(i)/2, times.Ti_Current);
+            priv->drifts[i] = get_exact_drift_factor(CP, times.Ti_lastactivedrift[i], times.Ti_Current);
     }
 
     treewalk_run(tw, act->ActiveParticle, act->NumActiveParticle);

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -44,6 +44,7 @@ struct particle_data
 
     MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree+gravpm is called. */
 
+    MyFloat DtHsml; /* Change in Hsml over a timestep, for interpolating active particles*/
     MyFloat Hsml;
 
     /* Union these two because they are transients: they are hard to move

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -44,7 +44,11 @@ struct particle_data
 
     MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree+gravpm is called. */
 
-    MyFloat DtHsml; /* Change in Hsml over a timestep, for interpolating active particles*/
+    /* DtHsml is 1/3 DivVel * Hsml evaluated at the last active timestep for this particle.
+     * This predicts Hsml during the current timestep in the way used in Gadget-4, more accurate
+     * than the Gadget-2 prediction which could run away in deep timesteps. Used also
+     * to limit timesteps by density change. */
+    MyFloat DtHsml;
     MyFloat Hsml;
 
     /* Union these two because they are transients: they are hard to move

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -228,6 +228,8 @@ run(int RestartSnapNum)
             drift.ti1 = times.Ti_Current;
             domain_maintain(ddecomp, &drift);
         }
+        update_lastactive_drift(&times);
+
 
         ActiveParticles Act = {0};
         rebuild_activelist(&Act, &times, NumCurrentTiStep);

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -275,6 +275,12 @@ find_timesteps(const ActiveParticles * act, DriftKickTimes * times)
     MPI_Allreduce(MPI_IN_PLACE, &mTimeBin, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
     MPI_Allreduce(MPI_IN_PLACE, &maxTimeBin, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
 
+    MPI_Allreduce(MPI_IN_PLACE, &ntiaccel, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &nticourant, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &ntihsml, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &ntiaccrete, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &ntineighbour, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
+
     /* Ensure that the PM timestep is not longer than the longest tree timestep;
      * this prevents particles in the longest timestep being active and moving into a higher bin
      * between PM timesteps, thus skipping the PM step entirely.*/

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -134,8 +134,10 @@ DriftKickTimes init_driftkicktime(inttime_t Ti_Current)
     DriftKickTimes times = {0};
     times.Ti_Current = Ti_Current;
     int i;
-    for(i = 0; i <= TIMEBINS; i++)
+    for(i = 0; i <= TIMEBINS; i++) {
         times.Ti_kick[i] = times.Ti_Current;
+        times.Ti_lastactivedrift[i] = times.Ti_Current;
+    }
     /* this makes sure the first step is a PM step. */
     times.PM_length = 0;
     times.PM_kick = times.Ti_Current;
@@ -310,6 +312,20 @@ find_timesteps(const ActiveParticles * act, DriftKickTimes * times)
     times->mintimebin = mTimeBin;
     times->maxtimebin = maxTimeBin;
     return;
+}
+
+/* Update the last active drift times for all bins*/
+void
+update_lastactive_drift(DriftKickTimes * times)
+{
+    int bin;
+    #pragma omp parallel for
+    for(bin = 0; bin <= TIMEBINS; bin++)
+    {
+        /* Update active timestep even if no particles in it*/
+        if(is_timebin_active(bin, times->Ti_Current))
+            times->Ti_lastactivedrift[bin] = times->Ti_Current;
+    }
 }
 
 /* Apply half a kick, for the second half of the timestep.*/

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -21,6 +21,8 @@ typedef struct
     int maxtimebin;
     /* Kick times per bin*/
     inttime_t Ti_kick[TIMEBINS+1];
+    /* Drift time when this timebin was last active*/
+    inttime_t Ti_lastactivedrift[TIMEBINS+1];
     /* Current drift time, which is universal.*/
     inttime_t Ti_Current;
     /* PM Timesteps*/
@@ -48,6 +50,9 @@ int is_timebin_active(int i, inttime_t current);
 inttime_t find_next_kick(inttime_t Ti_Current, int minTimeBin);
 
 inttime_t init_timebins(double TimeInit);
+
+/* Update the table of active bin drift times */
+void update_lastactive_drift(DriftKickTimes * times);
 
 DriftKickTimes init_driftkicktime(inttime_t Ti_Current);
 


### PR DESCRIPTION
This PR improves the estimation of h and rho for inactive particles to the drifting formula used in Gadget-4. 

We currently use the formula from Gadget-2, which is pathologically wrong for really deep timesteps because the exp() runs away. For this reason the formula is disabled in most places and we use the Density at the last active time for the particle. This is the same equation implemented, only a more accurate solution to it. It only affects the hydro (although it would affect other symmetric tree walks if we had any) and should improve force estimation moderately.