### PR TITLE
Run treewalk_build in treewalk_do_hsml_loop before treewalk_run

### DIFF
--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -616,6 +616,8 @@ void density_check_neighbours (int i, TreeWalk * tw)
         /* More work needed: add this particle to the redo queue*/
         tw->NPRedo[tid][tw->NPLeft[tid]] = i;
         tw->NPLeft[tid] ++;
+        if(tw->NPLeft[tid] > tw->Redo_thread_alloc)
+            endrun(5, "Particle %d on thread %d exceeded allocated size of redo queue %ld\n", tw->NPLeft[tid], tid, tw->Redo_thread_alloc);
     }
     else {
         /* We might have got here by serendipity, without bounding.*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1283,6 +1283,7 @@ treewalk_do_hsml_loop(TreeWalk * tw, int * queue, int64_t queuesize, int update_
                 ReDoQueue = (int *) mymalloc("ReDoQueue", size * sizeof(int) * NumThreads);
                 alloc_high = 0;
             }
+            tw->Redo_thread_alloc = size;
             gadget_setup_thread_arrays(ReDoQueue, tw->NPRedo, tw->NPLeft, size, NumThreads);
         }
         treewalk_run(tw, CurQueue, size);

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -166,6 +166,7 @@ struct TreeWalk {
     /* Redo counters and queues*/
     size_t *NPLeft;
     int **NPRedo;
+    size_t Redo_thread_alloc;
     /* Max and min arrays for each iteration of the count*/
     double * maxnumngb;
     double * minnumngb;


### PR DESCRIPTION
This ensures that the ReDoQueue only needs be as large as the workset,
which is for density 1/2 of the total particles.

Memory optimization