### PR TITLE
Exclude wind from BH density

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -752,8 +752,8 @@ blackhole_dynfric_postprocess(int n, TreeWalk * tw){
         }
     }
 }
-    /*******************************************************************/
 
+/*******************************************************************/
 static int
 blackhole_dynfric_haswork(int n, TreeWalk * tw){
     /*Black hole not being swallowed*/

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -16,6 +16,7 @@
 #include "timestep.h"
 #include "utils.h"
 #include "gravity.h"
+#include "winds.h"
 
 static struct density_params DensityParams;
 
@@ -412,6 +413,11 @@ density_ngbiter(
 
     if(r2 < iter->kernel.HH)
     {
+        /* For the BH we wish to exclude wind particles from the density,
+         * because they are excluded from the accretion treewalk.*/
+        if(I->Type == 5 && winds_is_particle_decoupled(other))
+            return;
+
         const double u = r * iter->kernel.Hinv;
         const double wk = density_kernel_wk(&iter->kernel, u);
         O->Ngb += wk * iter->kernel_volume;

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -114,7 +114,10 @@ setup_sync_points(double TimeIC, double TimeMax, double no_snapshot_until_time, 
     SyncPoints[1].a = TimeMax;
     SyncPoints[1].loga = log(TimeMax);
     SyncPoints[1].write_snapshot = 1;
-    SyncPoints[1].write_fof = 0;
+    if(SnapshotWithFOF)
+        SyncPoints[1].write_fof = 1;
+    else
+        SyncPoints[1].write_fof = 0;
     NSyncPoints = 2;
 
     /* we do an insertion sort here. A heap is faster but who cares the speed for this? */

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -417,10 +417,9 @@ sfr_wind_weight_postprocess(const int i, TreeWalk * tw)
     double numngb = WINDP(i, Windd).Ngb[close];
 
     int tid = omp_get_thread_num();
-    if(numngb < (NUMDMNGB - MAXDMDEVIATION) || numngb > (NUMDMNGB + MAXDMDEVIATION)){
-        /*If DMRadius converged, let it go*/
-        if(WINDP(i, Windd).Right - WINDP(i, Windd).Left < 1e-2)
-            return;
+    /*  If we have 40 neighbours, or if DMRadius is narrow, set vdisp. Otherwise add to redo queue */
+    if((numngb < (NUMDMNGB - MAXDMDEVIATION) || numngb > (NUMDMNGB + MAXDMDEVIATION)) &&
+        (WINDP(i, Windd).Right - WINDP(i, Windd).Left > 1e-2)) {
         /* More work needed: add this particle to the redo queue*/
         tw->NPRedo[tid][tw->NPLeft[tid]] = i;
         tw->NPLeft[tid] ++;


### PR DESCRIPTION
Exclude wind particles from the BH density, to match the accretion treewalk, where they are excluded.