### PR TITLE
Fofexchangefix2

### DIFF
--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -283,6 +283,9 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
     _transpose_plan_entries(plan->toGet, recvcounts, -1, plan->NTask);
     _transpose_plan_entries(plan->toGetOffset, recvdispls, -1, plan->NTask);
 
+    /* Ensure the mallocs are finished on all tasks before we start sending the data*/
+    MPI_Barrier(Comm);
+
     /* recv at the end */
     MPI_Alltoallv_sparse(partBuf, sendcounts, senddispls, MPI_TYPE_PARTICLE,
                  pman->Base + pman->NumPart, recvcounts, recvdispls, MPI_TYPE_PARTICLE,

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -285,7 +285,9 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
 
     /* Ensure the mallocs are finished on all tasks before we start sending the data*/
     MPI_Barrier(Comm);
-
+#ifdef DEBUG
+    message(0, "Starting particle data exchange\n");
+#endif
     /* recv at the end */
     MPI_Alltoallv_sparse(partBuf, sendcounts, senddispls, MPI_TYPE_PARTICLE,
                  pman->Base + pman->NumPart, recvcounts, recvdispls, MPI_TYPE_PARTICLE,
@@ -303,6 +305,10 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
         _transpose_plan_entries(plan->toGet, recvcounts, ptype, plan->NTask);
         _transpose_plan_entries(plan->toGetOffset, recvdispls, ptype, plan->NTask);
 
+#ifdef DEBUG
+        message(0, "Starting exchange for slot %d\n", ptype);
+#endif
+
         /* recv at the end */
         MPI_Alltoallv_sparse(slotBuf[ptype], sendcounts, senddispls, MPI_TYPE_SLOT[ptype],
                      ptr + N_slots * elsize,
@@ -310,6 +316,9 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
                      Comm);
     }
 
+#ifdef DEBUG
+        message(0, "Done with AlltoAllv\n");
+#endif
     int src;
     for(src = 0; src < plan->NTask; src++) {
         /* unpack each source rank */

--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -259,8 +259,10 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
     }
 
     int64_t atleast[6]={0};
-    /* Count how many particles we have*/
-    //#pragma omp parallel for reduction(+: NpigLocal)
+    /* Count how many particles we have: array reductions are an openmp 4.5 feature.*/
+#if (defined _OPENMP) && (_OPENMP >= 201511)
+    #pragma omp parallel for reduction(+: NpigLocal, atleast)
+#endif
     for(i = 0; i < PartManager->NumPart; i ++) {
         if(P[i].GrNr >= 0) {
             NpigLocal++;

--- a/libgadget/partmanager.h
+++ b/libgadget/partmanager.h
@@ -9,8 +9,6 @@
  */
 struct particle_data
 {
-    inttime_t Ti_drift;       /*!< current time of the particle position. The same for all particles. */
-
     double Pos[3];   /*!< particle position at its current time */
     float Mass;     /*!< particle mass */
 
@@ -35,6 +33,8 @@ struct particle_data
 
     int PI; /* particle property index; used by BH, SPH and STAR.
                         points to the corresponding structure in (SPH|BH|STAR)P array.*/
+    inttime_t Ti_drift;       /*!< current time of the particle position. The same for all particles. */
+
     MyIDType ID;
 
     MyFloat Vel[3];   /* particle velocity at its current time */
@@ -48,7 +48,14 @@ struct particle_data
      * This predicts Hsml during the current timestep in the way used in Gadget-4, more accurate
      * than the Gadget-2 prediction which could run away in deep timesteps. Used also
      * to limit timesteps by density change. */
-    MyFloat DtHsml;
+    union {
+        MyFloat DtHsml;
+        /* This is the destination task during the fof particle exchange.
+         * It is never used outside of that code, and the
+         * particles are copied into a new PartManager before setting it,
+         * so it is safe to union with DtHsml.*/
+        int TargetTask;
+    };
     MyFloat Hsml;
 
     /* Union these two because they are transients: they are hard to move

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -96,8 +96,6 @@ int begrun(int RestartFlag, int RestartSnapNum)
 
     MPIU_write_pids(pidfile);
     myfree(pidfile);
-
-    enable_core_dumps_and_fpu_exceptions();
 #endif
 
     init_forcetree_params(All.FastParticleType);

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -28,16 +28,14 @@
  *
  * */
 
-#ifdef DEBUG
+#if 0
 #include <fenv.h>
 void enable_core_dumps_and_fpu_exceptions(void)
 {
-  struct rlimit rlim;
-  extern int feenableexcept(int __excepts);
-
   /* enable floating point exceptions */
 
-  /*
+  /* extern int feenableexcept(int __excepts);
+
      feenableexcept(FE_DIVBYZERO | FE_INVALID);
    */
 
@@ -49,6 +47,7 @@ void enable_core_dumps_and_fpu_exceptions(void)
    * Don't do this because it may be there for a reason:
    * the cluster does not like us to dump 2PB of core! */
   /* getrlimit(RLIMIT_CORE, &rlim);
+  struct rlimit rlim;
   rlim.rlim_cur = RLIM_INFINITY;
   setrlimit(RLIMIT_CORE, &rlim);*/
 }

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -376,7 +376,6 @@ int MPI_Alltoallv_sparse(void *sendbuf, int *sendcnts, int *sdispls,
     MPI_Request *requests = mymalloc("requests", NTask * 2 * sizeof(MPI_Request));
     n_requests = 0;
 
-
     for(ngrp = 0; ngrp < (1 << PTask); ngrp++)
     {
         int target = ThisTask ^ ngrp;


### PR DESCRIPTION
The first fix to allow multiple iterations during fof particle exchange was too slow. This fix is faster and allows the exchange code to handle resumability, instead of the fof code, at the cost of a slight hack in the particle data structure.

Also some debugging and robustness changes to the exchange code in an attempt to work out why large exchanges sometimes fail.