### PR TITLE
Fix flash ionization at end of HeII reionization.

### DIFF
--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -655,11 +655,5 @@ during_helium_reionization(double redshift)
     if(redshift < 1./He_zz[Nreionhist-1] - 1)
         return 0;
 
-    double desired_ion_frac = gsl_interp_eval(HeIII_intp, He_zz, XHeIII, 1/(1+redshift), NULL);
-    /* If the desired ionization fraction is above a threshold (by default 0.95)
-     * ionize all particles*/
-    if(desired_ion_frac > QSOLightupParams.heIIIreion_finish_frac)
-        return 0;
-
     return 1;
 }


### PR DESCRIPTION
The check for HeII reionization happening was in
during_helium_reionization and included a check for the redshift being
low enough to flash-ionize. But that is still helium reionization! As
the code was not during helium reionization, this meant that the flash
ionization never happened.

A side consequence is that the long mean free path heating was being added 
even after HeII reionization completed for some particles.