### PR TITLE
Fixtempconverge

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1258,7 +1258,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
             //#pragma omp atomic write
             P[other].BHHeated = 1;
         }
-        const double enttou = pow(SPH_EOMDensity(&SPHP(other)) * BH_GET_PRIV(lv->tw)->a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+        const double enttou = pow(SPHP(other).Density * BH_GET_PRIV(lv->tw)->a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
         double entold, entnew;
         double * entptr = &(SPHP(other).Entropy);
         #pragma omp atomic read

--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -397,7 +397,7 @@ ionize_single_particle(int other, double a3inv, double uu_in_cgs)
     double deltau = qso_inst_heating * nheperg;
 
     /* Conversion factor between internal energy and entropy.*/
-    double entropytou = pow(SPH_EOMDensity(&SPHP(other)) * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+    double entropytou = pow(SPHP(other).Density * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     /* Convert to entropy in internal units*/
     /* Only one thread may get here*/
     SPHP(other).Entropy += deltau / uu_in_cgs / entropytou;

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -51,7 +51,9 @@ int DensityIndependentSphOn(void)
     return HydroParams.DensityIndependentSphOn;
 }
 
-MyFloat SPH_EOMDensity(const struct sph_particle_data * const pi)
+/* Function to get the center of mass density and HSML correction factor for an SPH particle with index i.
+ * Encodes the main difference between pressure-entropy SPH and regular SPH.*/
+static MyFloat SPH_EOMDensity(const struct sph_particle_data * const pi)
 {
     if(HydroParams.DensityIndependentSphOn)
         return pi->EgyWtDensity;

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -502,7 +502,7 @@ hydro_postprocess(int i, TreeWalk * tw)
     if(P[i].Type == 0)
     {
         /* Translate energy change rate into entropy change rate */
-        SPHP(i).DtEntropy *= GAMMA_MINUS1 / (HYDRA_GET_PRIV(tw)->hubble_a2 * pow(SPH_EOMDensity(&SPHP(i)), GAMMA_MINUS1));
+        SPHP(i).DtEntropy *= GAMMA_MINUS1 / (HYDRA_GET_PRIV(tw)->hubble_a2 * pow(SPHP(i).Density, GAMMA_MINUS1));
 
         /* if we have winds, we decouple particles briefly if delaytime>0 */
         if(HYDRA_GET_PRIV(tw)->WindOn && winds_is_particle_decoupled(i))

--- a/libgadget/hydra.h
+++ b/libgadget/hydra.h
@@ -7,10 +7,6 @@
 #include "density.h"
 #include "utils/paramset.h"
 
-/* Function to get the center of mass density and HSML correction factor for an SPH particle with index i.
- * Encodes the main difference between pressure-entropy SPH and regular SPH.*/
-MyFloat SPH_EOMDensity(const struct sph_particle_data * const pi);
-
 /*Function to compute hydro accelerations and adiabatic entropy change*/
 void hydro_force(const ActiveParticles * act, int WindOn, const double hubble, const double atime, struct sph_pred_data * SPH_predicted, double MinEgySpec, const DriftKickTimes times,  Cosmology * CP, const ForceTree * const tree);
 

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -937,7 +937,7 @@ static void GTInternalEnergy(int i, float * out, void * baseptr, void * smanptr)
     int PI = ((struct particle_data *) baseptr)[i].PI;
     struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
-    *out = sl[PI].Entropy / GAMMA_MINUS1 * pow(SPH_EOMDensity(&sl[PI]) * All.cf.a3inv, GAMMA_MINUS1);
+    *out = sl[PI].Entropy / GAMMA_MINUS1 * pow(sl[PI].Density * All.cf.a3inv, GAMMA_MINUS1);
 }
 
 static void STInternalEnergy(int i, float * out, void * baseptr, void * smanptr) {
@@ -945,7 +945,7 @@ static void STInternalEnergy(int i, float * out, void * baseptr, void * smanptr)
     int PI = ((struct particle_data *) baseptr)[i].PI;
     struct slot_info * info = &(((struct slots_manager_type *) smanptr)->info[0]);
     struct sph_particle_data * sl = (struct sph_particle_data *) info->ptr;
-    sl[PI].Entropy  = GAMMA_MINUS1 * u / pow(SPH_EOMDensity(&sl[PI]) * All.cf.a3inv , GAMMA_MINUS1);
+    sl[PI].Entropy  = GAMMA_MINUS1 * u / pow(sl[PI].Density * All.cf.a3inv , GAMMA_MINUS1);
 }
 
 /* Can't use the macros because cannot take address of a bitfield*/

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -432,7 +432,7 @@ cooling_direct(int i, const double a3inv, const double hubble, const struct UVBG
 
     double ne = SPHP(i).Ne;	/* electron abundance (gives ionization state and mean molecular weight) */
 
-    const double enttou = pow(SPH_EOMDensity(&SPHP(i)) * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+    const double enttou = pow(SPHP(i).Density * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
 
     /* Current internal energy including adiabatic change*/
     double uold = SPHP(i).Entropy * enttou;
@@ -592,7 +592,7 @@ static void
 cooling_relaxed(int i, double dtime, const double a3inv, struct sfr_eeqos_data sfr_data, const struct UVBG * const GlobalUVBG)
 {
     const double egyeff = sfr_params.EgySpecCold * sfr_data.cloudfrac + (1 - sfr_data.cloudfrac) * sfr_data.egyhot;
-    const double Density = SPH_EOMDensity(&SPHP(i));
+    const double Density = SPHP(i).Density;
     const double densityfac = pow(Density * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double egycurrent = SPHP(i).Entropy * densityfac;
     double trelax = sfr_data.trelax;
@@ -631,7 +631,7 @@ quicklyastarformation(int i, const double a3inv)
     if(SPHP(i).Density <= sfr_params.OverDensThresh)
         return 0;
 
-    const double enttou = pow(SPH_EOMDensity(&SPHP(i)) * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+    const double enttou = pow(SPHP(i).Density * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
     double unew = SPHP(i).Entropy * enttou;
 
     const double u_to_temp_fac = (4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))) * PROTONMASS / BOLTZMANN * GAMMA_MINUS1 * All.UnitEnergy_in_cgs / All.UnitMass_in_g;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -487,7 +487,7 @@ sfreff_on_eeqos(const struct sph_particle_data * sph, const double a3inv)
         double redshift = pow(a3inv, 1./3.)-1;
         struct UVBG uvbg = get_global_UVBG(redshift);
         double egyeff = get_egyeff(redshift, sph->Density, &uvbg);
-        const double enttou = pow(sph->EgyWtDensity * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+        const double enttou = pow(sph->Density * a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
         double unew = sph->Entropy * enttou;
         /* 0.5 dex = 10^0.5 = 3.2 */
         if(unew >= egyeff * 3.2)
@@ -509,8 +509,6 @@ double get_neutral_fraction_sfreff(double redshift, struct particle_data * partd
     if(!All.StarformationOn || sfr_params.QuickLymanAlphaProbability > 0 || !sfreff_on_eeqos(sphdata, All.cf.a3inv)) {
         /*This gets the neutral fraction for standard gas*/
         double eomdensity = sphdata->Density;
-        if(DensityIndependentSphOn())
-            eomdensity  = sphdata->EgyWtDensity;
         double InternalEnergy = sphdata->Entropy / GAMMA_MINUS1 * pow(eomdensity * All.cf.a3inv, GAMMA_MINUS1);
         nh0 = GetNeutralFraction(InternalEnergy, physdens, &uvbg, sphdata->Ne);
     }
@@ -540,8 +538,6 @@ double get_helium_neutral_fraction_sfreff(int ion, double redshift, struct parti
     if(!All.StarformationOn || sfr_params.QuickLymanAlphaProbability > 0 || !sfreff_on_eeqos(sphdata, All.cf.a3inv)) {
         /*This gets the neutral fraction for standard gas*/
         double eomdensity = sphdata->Density;
-        if(DensityIndependentSphOn())
-            eomdensity  = sphdata->EgyWtDensity;
         double InternalEnergy = sphdata->Entropy / GAMMA_MINUS1 * pow(eomdensity * All.cf.a3inv, GAMMA_MINUS1);
         helium = GetHeliumIonFraction(ion, InternalEnergy, physdens, &uvbg, sphdata->Ne);
     }

--- a/libgadget/stats.c
+++ b/libgadget/stats.c
@@ -76,10 +76,10 @@ struct state_of_system compute_global_quantities_of_system(const double Time,  s
         {
             struct UVBG uvbg = get_local_UVBG(redshift, &GlobalUVBG, P[i].Pos, PartManager->CurrentParticleOffset);
             entr = SPHP(i).Entropy;
-            egyspec = entr / (GAMMA_MINUS1) * pow(SPH_EOMDensity(&SPHP(i)) / a3, GAMMA_MINUS1);
+            egyspec = entr / (GAMMA_MINUS1) * pow(SPHP(i).Density / a3, GAMMA_MINUS1);
             sys.EnergyIntComp[0] += P[i].Mass * egyspec;
             double ne = SPHP(i).Ne;
-            sys.TemperatureComp[0] += P[i].Mass * get_temp(SPH_EOMDensity(&SPHP(i)), egyspec, (1 - HYDROGEN_MASSFRAC), &uvbg, &ne);
+            sys.TemperatureComp[0] += P[i].Mass * get_temp(SPHP(i).Density, egyspec, (1 - HYDROGEN_MASSFRAC), &uvbg, &ne);
         }
 
         for(j = 0; j < 3; j++)

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -575,14 +575,13 @@ get_timestep_ti(const int p, const inttime_t dti_max, const inttime_t Ti_Current
     if(dti <= 1 || dti > (inttime_t) TIMEBASE)
     {
         if(P[p].Type == 0)
-            message(1, "Bad timestep (%x)! titype %d. ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g) hydro-frc=(%g|%g|%g) dens=%g hsml=%g dh = %g egyrho=%g Entropy=%g, dtEntropy=%g maxsignal=%g\n",
+            message(1, "Bad timestep (%x)! titype %d. ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g) hydro-frc=(%g|%g|%g) dens=%g hsml=%g dh = %g Entropy=%g, dtEntropy=%g maxsignal=%g\n",
                 dti, *titype, P[p].ID, P[p].Type, dloga, dti_max,
                 P[p].Pos[0], P[p].Pos[1], P[p].Pos[2],
                 P[p].GravAccel[0], P[p].GravAccel[1], P[p].GravAccel[2],
                 P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2],
                 SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2],
-                SPHP(p).Density, P[p].Hsml, P[p].DtHsml, SPH_EOMDensity(&SPHP(p)),
-                SPHP(p).Entropy, SPHP(p).DtEntropy, SPHP(p).MaxSignalVel);
+                SPHP(p).Density, P[p].Hsml, P[p].DtHsml, SPHP(p).Entropy, SPHP(p).DtEntropy, SPHP(p).MaxSignalVel);
         else
             message(1, "Bad timestep (%x)! titype %d. ID=%lu Type=%d dloga=%g dtmax=%x xyz=(%g|%g|%g) tree=(%g|%g|%g) PM=(%g|%g|%g)\n",
                 dti, *titype, P[p].ID, P[p].Type, dloga, dti_max,

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -447,7 +447,7 @@ do_the_short_range_kick(int i, double dt_entr, double Fgravkick, double Fhydroki
             SPHP(i).Entropy += SPHP(i).DtEntropy * dt_entr;
 
         /* Limit entropy in simulations with cooling disabled*/
-        const double enttou = pow(SPH_EOMDensity(&SPHP(i)) * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
+        const double enttou = pow(SPHP(i).Density * All.cf.a3inv, GAMMA_MINUS1) / GAMMA_MINUS1;
         if(SPHP(i).Entropy < All.MinEgySpec/enttou)
             SPHP(i).Entropy = All.MinEgySpec / enttou;
     }

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -599,7 +599,7 @@ wind_do_kick(int other, double vel, double therm, double atime)
             P[other].Vel[j] += vel * dir[j];
         }
         /* StarTherm is internal energy per unit mass. Need to convert to entropy*/
-        const double enttou = pow(SPH_EOMDensity(&SPHP(other)) / pow(atime, 3), GAMMA_MINUS1) / GAMMA_MINUS1;
+        const double enttou = pow(SPHP(other).Density / pow(atime, 3), GAMMA_MINUS1) / GAMMA_MINUS1;
         SPHP(other).Entropy += therm/enttou;
         if(winds_ever_decouple()) {
             double delay = wind_params.WindFreeTravelLength / (vel / atime);


### PR DESCRIPTION
Change various uses of the energy weighted density as a conversion factor between entropy and internal energy to use the regular density, which is the more correct conservative quantity. This may be affecting the adiabatic cooling at late times.