### PR TITLE
Fix hang with adaptive softenings

### DIFF
--- a/libgadget/gravshort-tree.c
+++ b/libgadget/gravshort-tree.c
@@ -327,22 +327,21 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
             }
 
             /* This node accelerates the particle directly, and is not opened.*/
-            if(!shall_we_open_node(nop->len, nop->mom.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2))
+            int open_node = shall_we_open_node(nop->len, nop->mom.mass, r2, nop->center, inpos, BoxSize, aold, TreeUseBH, BHOpeningAngle2);
+            if(TreeParams.AdaptiveSoftening == 1 && (input->Soft < nop->mom.hmax))
+            {
+                /* Always open the node if it has a larger softening than the particle,
+                 * and the particle is inside its softening radius.
+                 * This condition only ever applies for adaptive softenings. It may or may not make sense. */
+                if(r2 < nop->mom.hmax * nop->mom.hmax)
+                    open_node = 1;
+            }
+
+            if(!open_node)
             {
                 double h = input->Soft;
-                if(TreeParams.AdaptiveSoftening == 1 && (input->Soft < nop->mom.hmax))
-                {
-                    /* Always open the node if it has a larger softening than the particle,
-                     * and the particle is inside its softening radius.
-                     * This condition only ever applies for adaptive softenings. It may or may not make sense. */
+                if(TreeParams.AdaptiveSoftening)
                     h = DMAX(input->Soft, nop->mom.hmax);
-                    if(r2 < h * h)
-                    {
-                        no = nop->s.suns[0];
-                        continue;
-                    }
-                }
-
                 /* ok, node can be used */
                 no = nop->sibling;
                 /* Compute the acceleration and apply it to the output structure*/


### PR DESCRIPTION
Prior to this commit, adaptive softenings would blindly walk the tree to
the first child of the node if the opening condition was met. This
was bad if the node opened was a leaf node. The refactor fixes this
condition.

Fixes: #562