### PR TITLE
workaround anaconda mpicc/gcc incompatibility.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,7 @@ jobs:
     - name: Setup Conda Environment
       uses: conda-incubator/setup-miniconda@v2.0.1
       with:
+        miniconda-version: latest
         activate-environment: test
         environment-file: maintainer/conda-env.yaml
         channels: bccp

--- a/maintainer/conda-env.yaml
+++ b/maintainer/conda-env.yaml
@@ -12,5 +12,5 @@ dependencies:
   - configobj
   # Below are for building MP-Gadget
   - mpich
-  - gcc_linux-64
+  - gcc_linux-64=9.3.0   # Pin to latest version compatible with mpich 3.3.2: https://github.com/AnacondaRecipes/mpich-feedstock/issues/5
   - gsl


### PR DESCRIPTION
Pin gcc to 9.3.0, last good version.
Refer to https://github.com/AnacondaRecipes/mpich-feedstock/issues/5