### PR TITLE
Two tweaks to the wind model:

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -293,7 +293,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "WindEfficiency", OPTIONAL, 2.0, "Fraction of the stellar mass that goes into a wind. Needs sh03 or vs08 wind models.");
     param_declare_double(ps, "WindEnergyFraction", OPTIONAL, 1.0, "Fraction of the available energy that goes into winds.");
 
-    /* The following two are for OFJT10*/
+    /* The following three are for OFJT10*/
+    param_declare_int(ps, "WindVDispType", OPTIONAL, 0, "Type of particle to use for the velocity dispersion of the winds.");
     param_declare_double(ps, "WindSigma0", OPTIONAL, 353, "Reference halo circular velocity at which to evaluate wind speed. Needs ofjt10 wind model.");
     param_declare_double(ps, "WindSpeedFactor", OPTIONAL, 3.7, "Factor connecting wind speed to halo circular velocity. ofjt10 wind model.");
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -548,7 +548,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
 
             /**** radiative cooling and star formation *****/
             if(All.CoolingOn)
-                cooling_and_starformation(&Act, atime, get_dloga_for_bin(times.mintimebin, times.Ti_Current), &Tree, &All.CP, GradRho, fds.FdSfr);
+                cooling_and_starformation(&Act, atime, &times, get_dloga_for_bin(times.mintimebin, times.Ti_Current), &Tree, &All.CP, GradRho, fds.FdSfr);
 
         }
         /* We don't need this timestep's tree anymore.*/
@@ -678,7 +678,7 @@ runfof(const int RestartSnapNum, const inttime_t Ti_Current, const struct header
             slots_free_sph_pred_data(&sph_predicted);
         }
         ForceTree Tree = {0};
-        cooling_and_starformation(&Act, header->TimeSnapshot, 0, &Tree, &All.CP, GradRho, NULL);
+        cooling_and_starformation(&Act, header->TimeSnapshot, NULL, 0, &Tree, &All.CP, GradRho, NULL);
         if(GradRho)
             myfree(GradRho);
     }

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -164,7 +164,7 @@ void set_sfr_params(ParameterSet * ps)
 
 /* cooling and star formation routine.*/
 void
-cooling_and_starformation(ActiveParticles * act, double Time, double dloga, ForceTree * tree, const Cosmology *CP, MyFloat * GradRho, FILE * FdSfr)
+cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTimes * const times, double dloga, ForceTree * tree, Cosmology *CP, MyFloat * GradRho, FILE * FdSfr)
 {
     const int nthreads = omp_get_max_threads();
     /*This is a queue for the new stars and their parents, so we can reallocate the slots after the main cooling loop.*/
@@ -272,7 +272,7 @@ cooling_and_starformation(ActiveParticles * act, double Time, double dloga, Forc
     /* Do subgrid winds*/
     if(sfr_params.WindOn && winds_are_subgrid()) {
         NumMaybeWind = gadget_compact_thread_arrays(MaybeWind, thrqueuewind, nqthrwind, nthreads);
-        winds_subgrid(MaybeWind, NumMaybeWind, Time, hubble, tree, StellarMass);
+        winds_subgrid(MaybeWind, NumMaybeWind, Time, CP, times, hubble, tree, StellarMass);
         myfree(MaybeWind);
         myfree(StellarMass);
         ta_free(thrqueuewind);
@@ -368,7 +368,7 @@ cooling_and_starformation(ActiveParticles * act, double Time, double dloga, Forc
 
     /* Now apply the wind model using the list of new stars.*/
     if(sfr_params.WindOn && !winds_are_subgrid())
-        winds_and_feedback(NewStars, NumNewStar, Time, hubble, tree);
+        winds_and_feedback(NewStars, NumNewStar, Time, CP, times, hubble, tree);
 
     myfree(NewStars);
 }

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -27,7 +27,7 @@ void set_sfr_params(ParameterSet * ps);
 
 void init_cooling_and_star_formation(int CoolingOn, int StarformationOn, Cosmology * CP, const double avg_baryon_mass, const double BoxSize, const struct UnitSystem units);
 /*Do the cooling and the star formation. The tree is required for the winds only.*/
-void cooling_and_starformation(ActiveParticles * act, double Time, double dloga, ForceTree * tree, const Cosmology * CP, MyFloat * GradRho, FILE * FdSfr);
+void cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTimes * const times, double dloga, ForceTree * tree, Cosmology *CP, MyFloat * GradRho, FILE * FdSfr);
 
 /*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
  * This calls the cooling routines for the current internal energy when off the equation of state, but

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -3,6 +3,7 @@
 
 #include "forcetree.h"
 #include "utils/paramset.h"
+#include "timestep.h"
 
 /*
  * Enumeration of the supported wind models.
@@ -28,13 +29,13 @@ void init_winds(double FactorSN, double EgySpecSN, double PhysDensThresh, double
 void winds_evolve(int i, double a3inv, double hubble);
 
 /*do the treewalk for the wind model*/
-void winds_and_feedback(int * NewStars, int NumNewStars, const double Time, const double hubble, ForceTree * tree);
+void winds_and_feedback(int * NewStars, int NumNewStars, const double Time, Cosmology * CP, const DriftKickTimes * const times, const double hubble, ForceTree * tree);
 
 /*Make a wind particle at the site of recent star formation.*/
 int winds_make_after_sf(int i, double sm, double vdisp, double atime);
 
 /* Make winds for the subgrid model, after computing the velocity dispersion. */
-void winds_subgrid(int * MaybeWind, int NumMaybeWind, const double Time, const double hubble, ForceTree * tree, MyFloat * StellarMasses);
+void winds_subgrid(int * MaybeWind, int NumMaybeWind, const double Time, Cosmology * CP, const DriftKickTimes * const times, const double hubble, ForceTree * tree, MyFloat * StellarMasses);
 
 /* Tests whether winds spawn from gas or stars*/
 int winds_are_subgrid(void);


### PR DESCRIPTION
1. Use the predicted velocity for the wind velocity dispersion. The current velocity may be evaluated at different times as
the other particle is inactive, and so we are not comparing two objects at the same kick time.
2. Make the type of particle whose velocity dispersion is used configurable.

This is on top of master but I need it for the hierarchical gravity mode: in that mode the kick times of inactive particles are somewhat different on short timesteps, thus increasing the difference between particle velocities and so wind velocity launch. Using predicted velocities is the physically correct thing to do (even without hierarchical gravity) and I would like to know how much difference it makes.

I also made the type of particle used configurable: it would be worth checking if WindVDispType == 0 works about the same as WindVDispType == 1. If so the hierarchical model can be made more efficient and avoid building the full tree entirely on most timesteps. 