### PR TITLE
Fix spurious rare export buffer full crash:

### DIFF
--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -363,8 +363,8 @@ static int real_ev(struct TreeWalkThreadLocals local_exports, TreeWalk * tw, siz
                 lv->Nexport-= lv->NThisParticleExport;
                 const int lastreal = tw->WorkSet ? tw->WorkSet[k] : k;
                 /* Index stores tw->target, which is the current particle.*/
-                if(lv->NThisParticleExport > 0 && DataIndexTable[lv->DataIndexOffset + lv->Nexport].Index != lastreal)
-                    endrun(5, "Something screwed up in export queue: nexp %ld (local %d) last %d != index %d\n", lv->Nexport,
+                if(lv->NThisParticleExport > 0 && DataIndexTable[lv->DataIndexOffset + lv->Nexport].Index > lastreal)
+                    endrun(5, "Something screwed up in export queue: nexp %ld (local %d) last %d < index %d\n", lv->Nexport,
                         lv->NThisParticleExport, lastreal, DataIndexTable[lv->DataIndexOffset + lv->Nexport].Index);
                 /* Leave this chunking loop.*/
             }


### PR DESCRIPTION
The error is:
[ 059851.77 ] ERROR: Task 673: Something screwed up in export queue: nexp 1272278 (local 2) last 79115500 != index 79115499

This happens when lastreal (the last element in the workqueue
which was evaluated) is larger than the last element in the export
buffer. But that is actually fine: there can be particles with no
exports. Weaken the condition to allow for this.