### PR TITLE
Fofsaveparticlememreduce

### DIFF
--- a/libgadget/fofpetaio.c
+++ b/libgadget/fofpetaio.c
@@ -271,8 +271,7 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
                 atleast[type]++;
         }
     }
-    double FOFPartAllocFactor = (double) PartManager->MaxPart / PartManager->NumPart;
-    halo_pman->MaxPart = NpigLocal * FOFPartAllocFactor;
+    halo_pman->MaxPart = NpigLocal * 1.02;
     struct particle_data * halopart = (struct particle_data *) mymalloc("HaloParticle", sizeof(struct particle_data) * halo_pman->MaxPart);
     halo_pman->Base = halopart;
     halo_pman->NumPart = NpigLocal;
@@ -280,8 +279,10 @@ fof_distribute_particles(struct part_manager_type * halo_pman, struct slots_mana
     memcpy(halo_pman->CurrentParticleOffset, PartManager->CurrentParticleOffset, 3 * sizeof(PartManager->CurrentParticleOffset[0]));
 
     /* We leave extra space in the hope that we can avoid compacting slots in the fof exchange*/
-    for(i = 0; i < 6; i ++)
-        atleast[i]*= FOFPartAllocFactor;
+    const double FOFPartAllocFactor = (double) PartManager->MaxPart / PartManager->NumPart;
+    atleast[0] *= 1.02;
+    atleast[4]*= FOFPartAllocFactor;
+    atleast[5]*= FOFPartAllocFactor;
 
     slots_reserve(0, atleast, halo_sman);
 


### PR DESCRIPTION
Reduce peak memory usage while saving FOF particles. Some slightly sneaky things are being done here, but they seem to work.