### PR TITLE
Separatevdisp

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1665,6 +1665,7 @@ void blackhole_make_one(int index, const double atime) {
     }
     /* Initialize KineticFdbkEnergy, keep zero if BlackHoleKineticOn is not turned on */
     BHP(child).KineticFdbkEnergy = 0;
+    BHP(child).VDisp = 0;
 }
 
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1102,9 +1102,6 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             O->BH_MinPotPos[d] = I->base.Pos[d];
         }
         iter->base.mask = GASMASK + STARMASK + BHMASK;
-        /* Add DM if needed*/
-        if(blackhole_params.BlackHoleKineticOn == 1)
-            iter->base.mask += DMMASK;
         iter->base.Hsml = I->Hsml;
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1779,7 +1779,7 @@ blackhole_veldisp(const ActiveParticles * act, Cosmology * CP, ForceTree * tree,
     struct BHVelDispPriv priv[1] = {0};
 
     TreeWalk tw_veldisp[1] = {{0}};
-    tw_veldisp->ev_label = "BH_VELDISP";
+    tw_veldisp->ev_label = "BH_VDISP";
     tw_veldisp->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw_veldisp->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBHVelDisp);
     tw_veldisp->ngbiter = (TreeWalkNgbIterFunction) blackhole_veldisp_ngbiter;
@@ -1806,7 +1806,7 @@ blackhole_veldisp(const ActiveParticles * act, Cosmology * CP, ForceTree * tree,
     /* This allocates memory*/
     treewalk_run(tw_veldisp, act->ActiveParticle, act->NumActiveParticle);
 
-    walltime_measure("/BH/VelDisp");
+    walltime_measure("/BH/VDisp");
 
     myfree(priv->V1sumDM);
     myfree(priv->V2sumDM);

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -182,8 +182,6 @@ struct BHPriv {
 
     /* temporary computed for kinetic feedback energy threshold*/
     MyFloat * NumDM;
-    MyFloat (*V1sumDM)[3];
-    MyFloat * V2sumDM;
     MyFloat * MgasEnc;
     /* mark the state of AGN kinetic feedback, 1 accumulate, 2 release */
     int * KEflag;
@@ -246,8 +244,9 @@ struct __attribute__((__packed__)) BHinfo{
 
     double KineticFdbkEnergy;
     double NumDM;
+    /* Kept for backwards compatibility, not written to*/
     double V1sumDM[3];
-    double V2sumDM;
+    double VDisp;
     double MgasEnc;
     int KEflag;
 
@@ -499,10 +498,7 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
 
         info->KineticFdbkEnergy = BHP(p_i).KineticFdbkEnergy;
         info->NumDM = priv->NumDM[PI];
-        info->V1sumDM[0] = priv->V1sumDM[PI][0];
-        info->V1sumDM[1] = priv->V1sumDM[PI][1];
-        info->V1sumDM[2] = priv->V1sumDM[PI][2];
-        info->V2sumDM = priv->V2sumDM[PI];
+        info->VDisp = BHP(p_i).VDisp;
         info->MgasEnc = priv->MgasEnc[PI];
         info->KEflag = priv->KEflag[PI];
 
@@ -674,8 +670,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
 
     /* For AGN kinetic feedback */
     priv->NumDM = mymalloc("NumDM", SlotsManager->info[5].size * sizeof(MyFloat));
-    priv->V2sumDM = mymalloc("V2sumDM", SlotsManager->info[5].size * sizeof(MyFloat));
-    priv->V1sumDM = (MyFloat (*) [3]) mymalloc("V1sumDM", 3* SlotsManager->info[5].size * sizeof(priv->V1sumDM[0]));
     priv->MgasEnc = mymalloc("MgasEnc", SlotsManager->info[5].size * sizeof(MyFloat));
     /* mark the state of AGN kinetic feedback */
     priv->KEflag = mymalloc("KEflag", SlotsManager->info[5].size * sizeof(int));
@@ -720,8 +714,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     /*****************************************************************/
     myfree(priv->KEflag);
     myfree(priv->MgasEnc);
-    myfree(priv->V1sumDM);
-    myfree(priv->V2sumDM);
     myfree(priv->NumDM);
 
     myfree(priv->BH_SurroundingGasVel);
@@ -1526,10 +1518,8 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
     TREEWALK_REDUCE(BH_GET_PRIV(tw)->BH_Entropy[PI], remote->SmoothedEntropy);
     for (k = 0; k < 3; k++){
         TREEWALK_REDUCE(BH_GET_PRIV(tw)->BH_SurroundingGasVel[PI][k], remote->GasVel[k]);
-        TREEWALK_REDUCE(BH_GET_PRIV(tw)->V1sumDM[PI][k], remote->V1sumDM[k]);
     }
     TREEWALK_REDUCE(BH_GET_PRIV(tw)->NumDM[PI], remote->NumDM);
-    TREEWALK_REDUCE(BH_GET_PRIV(tw)->V2sumDM[PI], remote->V2sumDM);
     TREEWALK_REDUCE(BH_GET_PRIV(tw)->MgasEnc[PI], remote->MgasEnc);
 }
 

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -4,6 +4,7 @@
 #include "timestep.h"
 #include "forcetree.h"
 #include "physconst.h"
+#include "density.h"
 
 enum BlackHoleFeedbackMethod {
      BH_FEEDBACK_TOPHAT   = 0x2,
@@ -27,7 +28,7 @@ void blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceT
 void blackhole_make_one(int index, const double atime);
 
 /* Compute the DM velocity dispersion for black holes*/
-void blackhole_veldisp(const ActiveParticles * act, Cosmology * CP, ForceTree * tree, double * gravkicks, double FgravkickB);
+void blackhole_veldisp(const ActiveParticles * act, Cosmology * CP, ForceTree * tree, struct kick_factor_data * kf);
 
 /* Decide whether black hole repositioning is enabled. */
 int BHGetRepositionEnabled(void);

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -26,6 +26,9 @@ void blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceT
 /* Make a black hole from the particle at index. */
 void blackhole_make_one(int index, const double atime);
 
+/* Compute the DM velocity dispersion for black holes*/
+void blackhole_veldisp(const ActiveParticles * act, Cosmology * CP, ForceTree * tree, double * gravkicks, double FgravkickB);
+
 /* Decide whether black hole repositioning is enabled. */
 int BHGetRepositionEnabled(void);
 #endif

--- a/libgadget/density.h
+++ b/libgadget/density.h
@@ -5,6 +5,7 @@
 #include "timestep.h"
 #include "densitykernel.h"
 #include "utils/paramset.h"
+#include "timebinmgr.h"
 
 struct density_params
 {
@@ -26,6 +27,15 @@ struct sph_pred_data
 {
     /*!< Predicted entropy at current particle drift time for SPH computation*/
     MyFloat * EntVarPred;
+};
+
+/* Structure storing the pre-computed kick factors which
+ * used for making the predicted velocities.*/
+struct kick_factor_data
+{
+    double FgravkickB;
+    double gravkicks[TIMEBINS+1];
+    double hydrokicks[TIMEBINS+1];
 };
 
 /*Set the parameters of the density module*/
@@ -51,9 +61,11 @@ void slots_free_sph_pred_data(struct sph_pred_data * sph_pred);
 
 /* Predicted quantity computation used in hydro*/
 MyFloat SPH_EntVarPred(const int i, const DriftKickTimes * times);
-void SPH_VelPred(int i, MyFloat * VelPred, const double FgravkickB, double * gravkick, double * hydrokick);
+void SPH_VelPred(int i, MyFloat * VelPred, const struct kick_factor_data * kf);
 /* Predicted velocity for dark matter, ignoring the hydro component.*/
-void DM_VelPred(int i, MyFloat * VelPred, const double FgravkickB, double * gravkick);
+void DM_VelPred(int i, MyFloat * VelPred, const struct kick_factor_data * kf);
+/* Initialise the grav and hydrokick arrays for the current kick times.*/
+void init_kick_factor_data(struct kick_factor_data * kf, const DriftKickTimes * const times, Cosmology * CP);
 
 /* Set the initial smoothing length for gas and BH. Used on first timestep in init()*/
 void set_init_hsml(ForceTree * tree, DomainDecomp * ddecomp, const double MeanGasSeparation);

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -1027,6 +1027,9 @@ SIMPLE_GETTER_PI(GTDtEntropy, DtEntropy, float, 1, struct sph_particle_data)
 SIMPLE_GETTER_PI(GTDhsmlEgyDensityFactor, DhsmlEgyDensityFactor, float, 1, struct sph_particle_data)
 SIMPLE_GETTER_PI(GTDivVel, DivVel, float, 1, struct sph_particle_data)
 SIMPLE_GETTER_PI(GTCurlVel, CurlVel, float, 1, struct sph_particle_data)
+SIMPLE_GETTER_PI(GTVelDisp, VDisp, float, 1, struct sph_particle_data)
+SIMPLE_GETTER_PI(GTBHVelDisp, VDisp, float, 1, struct bh_particle_data)
+SIMPLE_GETTER_PI(GTStarVelDisp, VDisp, float, 1, struct star_particle_data)
 
 void register_debug_io_blocks(struct IOTable * IOTable)
 {
@@ -1046,6 +1049,10 @@ void register_debug_io_blocks(struct IOTable * IOTable)
     IO_REG_WRONLY(DhsmlEgyDensityFactor,       "f4", 1, 0, IOTable);
     IO_REG_WRONLY(DivVel,       "f4", 1, 0, IOTable);
     IO_REG_WRONLY(CurlVel,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(VelDisp,       "f4", 1, 0, IOTable);
+    IO_REG_WRONLY(BHVelDisp,       "f4", 1, 5, IOTable);
+    IO_REG_WRONLY(StarVelDisp,       "f4", 1, 4, IOTable);
+
     /*Sort IO blocks so similar types are together; then ordered by the sequence they are declared. */
     qsort_openmp(IOTable->ent, IOTable->used, sizeof(struct IOTableEntry), order_by_type);
 }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -628,7 +628,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
 
             /**** radiative cooling and star formation *****/
             if(All.CoolingOn)
-                cooling_and_starformation(&Act, atime, &times, get_dloga_for_bin(times.mintimebin, times.Ti_Current), &Tree, GravAccel, ddecomp, &All.CP, GradRho_mag, fds.FdSfr);
+                cooling_and_starformation(&Act, atime, get_dloga_for_bin(times.mintimebin, times.Ti_Current), &Tree, GravAccel, ddecomp, &All.CP, GradRho_mag, fds.FdSfr);
         }
         /* We don't need this timestep's tree anymore.*/
         force_tree_free(&Tree);
@@ -773,7 +773,7 @@ runfof(const int RestartSnapNum, const inttime_t Ti_Current, const struct header
         }
         ForceTree Tree = {0};
         struct grav_accel_store gg = {0};
-        cooling_and_starformation(&Act, header->TimeSnapshot, NULL, 0, &Tree, gg, ddecomp, &All.CP, GradRho, NULL);
+        cooling_and_starformation(&Act, header->TimeSnapshot, 0, &Tree, gg, ddecomp, &All.CP, GradRho, NULL);
         if(GradRho)
             myfree(GradRho);
     }

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -35,6 +35,7 @@
 #include "uvbg.h"
 #include "neutrinos_lra.h"
 #include "stats.h"
+#include "winds.h"
 
 static struct ClockTable Clocks;
 
@@ -611,6 +612,8 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
                 fof_finish(&fof);
             }
 
+            if(is_PM && (All.BlackHoleOn || All.CoolingOn))
+                winds_find_vel_disp(atime, hubble_function(&All.CP, atime), ddecomp);
             /* Note that the tree here may be freed, if we are not a gravity-active timestep,
              * or if we are a PM step.*/
             /* If we didn't build a tree for gravity, we need to build one in BH or in winds.

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -612,7 +612,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
                 fof_finish(&fof);
             }
 
-//             if(is_PM && (All.BlackHoleOn || All.CoolingOn))
+            if(is_PM && All.CoolingOn)
                 winds_find_vel_disp(&Act, atime, hubble_function(&All.CP, atime), &All.CP, &times, ddecomp);
             /* Note that the tree here may be freed, if we are not a gravity-active timestep,
              * or if we are a PM step.*/

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -613,7 +613,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
             }
 
 //             if(is_PM && (All.BlackHoleOn || All.CoolingOn))
-                winds_find_vel_disp(&Act, atime, hubble_function(&All.CP, atime), ddecomp);
+                winds_find_vel_disp(&Act, atime, hubble_function(&All.CP, atime), &All.CP, &times, ddecomp);
             /* Note that the tree here may be freed, if we are not a gravity-active timestep,
              * or if we are a PM step.*/
             /* If we didn't build a tree for gravity, we need to build one in BH or in winds.

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -612,8 +612,8 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
                 fof_finish(&fof);
             }
 
-            if(is_PM && (All.BlackHoleOn || All.CoolingOn))
-                winds_find_vel_disp(atime, hubble_function(&All.CP, atime), ddecomp);
+//             if(is_PM && (All.BlackHoleOn || All.CoolingOn))
+                winds_find_vel_disp(&Act, atime, hubble_function(&All.CP, atime), ddecomp);
             /* Note that the tree here may be freed, if we are not a gravity-active timestep,
              * or if we are a PM step.*/
             /* If we didn't build a tree for gravity, we need to build one in BH or in winds.

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -488,6 +488,21 @@ cooling_direct(int i, const double redshift, const double a3inv, const double hu
     SPHP(i).Sfr = 0;
 }
 
+/* Returns the density threshold for star formation in comoving units*/
+double
+sfr_density_threshold(const double atime)
+{
+    double thresh;
+    if(sfr_params.QuickLymanAlphaProbability > 0)
+        thresh = sfr_params.OverDensThresh;
+    else {
+        thresh = sfr_params.PhysDensThresh * (atime * atime * atime);
+        if(thresh < sfr_params.OverDensThresh)
+            thresh = sfr_params.OverDensThresh;
+    }
+    return thresh;
+}
+
 /* returns 1 if the particle is on the effective equation of state,
  * cooling via the relaxation equation and maybe forming stars.
  * 0 if the particle does not form stars, instead cooling normally.*/

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -286,7 +286,7 @@ cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTim
     /* Do subgrid winds*/
     if(sfr_params.WindOn && winds_are_subgrid()) {
         NumMaybeWind = gadget_compact_thread_arrays(MaybeWind, thrqueuewind, nqthrwind, nthreads);
-        winds_subgrid(MaybeWind, NumMaybeWind, Time, CP, times, hubble, tree, ddecomp, StellarMass);
+        winds_subgrid(MaybeWind, NumMaybeWind, Time, StellarMass);
         myfree(MaybeWind);
         myfree(StellarMass);
         ta_free(thrqueuewind);
@@ -387,7 +387,7 @@ cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTim
 
     /* Now apply the wind model using the list of new stars.*/
     if(sfr_params.WindOn && !winds_are_subgrid())
-        winds_and_feedback(NewStars, NumNewStar, Time, CP, times, hubble, tree, ddecomp);
+        winds_and_feedback(NewStars, NumNewStar, Time, tree, ddecomp);
     myfree(NewStars);
 }
 
@@ -600,6 +600,7 @@ static int make_particle_star(int child, int parent, int placement, double Time)
     STARP(child).LastEnrichmentMyr = 0;
     STARP(child).TotalMassReturned = 0;
     STARP(child).BirthDensity = oldslot.Density;
+    STARP(child).VDisp = oldslot.VDisp;
     /*Copy metallicity*/
     STARP(child).Metallicity = oldslot.Metallicity;
     int j;

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -177,7 +177,7 @@ void set_sfr_params(ParameterSet * ps)
 
 /* cooling and star formation routine.*/
 void
-cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTimes * const times, double dloga, ForceTree * tree, struct grav_accel_store GravAccel, DomainDecomp * ddecomp, Cosmology *CP, MyFloat * GradRho, FILE * FdSfr)
+cooling_and_starformation(ActiveParticles * act, double Time, double dloga, ForceTree * tree, struct grav_accel_store GravAccel, DomainDecomp * ddecomp, Cosmology *CP, MyFloat * GradRho, FILE * FdSfr)
 {
     const int nthreads = omp_get_max_threads();
     /*This is a queue for the new stars and their parents, so we can reallocate the slots after the main cooling loop.*/

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -51,4 +51,7 @@ int sfreff_on_eeqos(const struct sph_particle_data * sph, const double a3inv);
 /* Get the Minimum temperature in internal energy*/
 double get_MinEgySpec(void);
 
+/* Returns the density threshold for star formation in comoving units*/
+double sfr_density_threshold(const double atime);
+
 #endif

--- a/libgadget/sfr_eff.h
+++ b/libgadget/sfr_eff.h
@@ -27,7 +27,7 @@ void set_sfr_params(ParameterSet * ps);
 
 void init_cooling_and_star_formation(int CoolingOn, int StarformationOn, Cosmology * CP, const double avg_baryon_mass, const double BoxSize, const struct UnitSystem units);
 /*Do the cooling and the star formation. The tree is required for the winds only.*/
-void cooling_and_starformation(ActiveParticles * act, double Time, const DriftKickTimes * const times, double dloga, ForceTree * tree, struct grav_accel_store GravAccel, DomainDecomp * ddecomp, Cosmology * CP, MyFloat * GradRho, FILE * FdSfr);
+void cooling_and_starformation(ActiveParticles * act, double Time, double dloga, ForceTree * tree, struct grav_accel_store GravAccel, DomainDecomp * ddecomp, Cosmology * CP, MyFloat * GradRho, FILE * FdSfr);
 
 /*Get the neutral fraction of a particle correctly, even when on the star-forming equation of state.
  * This calls the cooling routines for the current internal energy when off the equation of state, but

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -55,6 +55,7 @@ struct bh_particle_data {
     int encounter; /* mark the event when BH encounters another BH */
     double Mtrack; /*Swallow gas particle when BHP.Mass accretes from SeedBHMass to SeedDynMass for mass conservation */
     double Mseed; /*Log the seed mass of BH, would be useful in case of the powerlaw seeding*/
+    MyFloat VDisp; /* 1D DM Velocity dispersion, for the kinetic winds*/
 };
 
 #define NMETALS 9
@@ -73,6 +74,7 @@ struct star_particle_data
     float Metals[NMETALS];      /* Metal mass of each species in star particle*/
 
     MyFloat EscapeFraction; /* Escape fraction stored for reionisation calculation */
+    MyFloat VDisp; /* 1D DM Velocity dispersion on creation for the winds*/
 };
 
 /* the following structure holds data that is stored for each SPH particle in addition to the collisionless
@@ -112,6 +114,7 @@ struct sph_particle_data
     MyFloat local_J21; /* local J21 ionising background calculated from the excursion set */
     MyFloat zreion; /* redshift when a particle is first ionised */
     MyFloat EscapeFraction; /* Escape fraction for SFR -> J21 calculation */
+    MyFloat VDisp; /* 1D DM Velocity dispersion, for the winds*/
 };
 
 extern struct slots_manager_type {

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -757,8 +757,6 @@ wind_vdisp_postprocess(const int i, TreeWalk * tw)
         if(vdisp > 0) {
             if(P[i].Type == 0)
                 SPHP(i).VDisp = sqrt(vdisp / 3);
-            else if (P[i].Type == 5)
-                BHP(i).VDisp = sqrt(vdisp / 3);
         }
     }
 

--- a/libgadget/winds.c
+++ b/libgadget/winds.c
@@ -288,6 +288,7 @@ winds_subgrid(int * MaybeWind, int NumMaybeWind, const double Time, MyFloat * St
         return;
 
     int n;
+    #pragma omp parallel for
     for(n = 0; n < NumMaybeWind; n++)
     {
         int i = MaybeWind ? MaybeWind[n] : n;

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -51,6 +51,6 @@ int winds_ever_decouple(void);
 
 /* Find the 1D DM velocity dispersion of all gas particles by running a density loop.
  * Stores it in VDisp in the slots structure.*/
-void winds_find_vel_disp(const ActiveParticles * act, const double Time, const double hubble, DomainDecomp * ddecomp);
+void winds_find_vel_disp(const ActiveParticles * act, const double Time, const double hubble, Cosmology * CP, DriftKickTimes * times, DomainDecomp * ddecomp);
 
 #endif

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -49,7 +49,9 @@ void winds_decoupled_hydro(int i, double atime);
 /* Returns 1 if the winds ever decouple, 0 otherwise*/
 int winds_ever_decouple(void);
 
-/* Find the 1D DM velocity dispersion of all gas particles by running a density loop.
+/* Find the 1D DM velocity dispersion of all nearly star-forming gas and black hole particles.
+ * Gas is done by running a density loop for find Vdisp of nearest 40 DM particles.
+ * BH is done by finding VDisp of all DM particles inside the SPH kernel.
  * Stores it in VDisp in the slots structure.*/
 void winds_find_vel_disp(const ActiveParticles * act, const double Time, const double hubble, Cosmology * CP, DriftKickTimes * times, DomainDecomp * ddecomp);
 

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -48,4 +48,9 @@ void winds_decoupled_hydro(int i, double atime);
 
 /* Returns 1 if the winds ever decouple, 0 otherwise*/
 int winds_ever_decouple(void);
+
+/* Find the 1D DM velocity dispersion of all gas particles by running a density loop.
+ * Stores it in VDisp in the slots structure.*/
+void winds_find_vel_disp(const double Time, const double hubble, DomainDecomp * ddecomp);
+
 #endif

--- a/libgadget/winds.h
+++ b/libgadget/winds.h
@@ -29,13 +29,13 @@ void init_winds(double FactorSN, double EgySpecSN, double PhysDensThresh, double
 void winds_evolve(int i, double a3inv, double hubble);
 
 /*do the treewalk for the wind model*/
-void winds_and_feedback(int * NewStars, int NumNewStars, const double Time, Cosmology * CP, const DriftKickTimes * const times, const double hubble, ForceTree * tree, DomainDecomp * ddecomp);
+void winds_and_feedback(int * NewStars, int NumNewStars, const double Time, ForceTree * tree, DomainDecomp * ddecomp);
 
 /*Make a wind particle at the site of recent star formation.*/
 int winds_make_after_sf(int i, double sm, double vdisp, double atime);
 
 /* Make winds for the subgrid model, after computing the velocity dispersion. */
-void winds_subgrid(int * MaybeWind, int NumMaybeWind, const double Time, Cosmology * CP, const DriftKickTimes * const times, const double hubble, ForceTree * tree, DomainDecomp * ddecomp, MyFloat * StellarMasses);
+void winds_subgrid(int * MaybeWind, int NumMaybeWind, const double Time, MyFloat * StellarMasses);
 
 /* Tests whether winds spawn from gas or stars*/
 int winds_are_subgrid(void);
@@ -51,6 +51,6 @@ int winds_ever_decouple(void);
 
 /* Find the 1D DM velocity dispersion of all gas particles by running a density loop.
  * Stores it in VDisp in the slots structure.*/
-void winds_find_vel_disp(const double Time, const double hubble, DomainDecomp * ddecomp);
+void winds_find_vel_disp(const ActiveParticles * act, const double Time, const double hubble, DomainDecomp * ddecomp);
 
 #endif


### PR DESCRIPTION
Separate the velocity dispersion calculation from the rest of the winds and only run it on PM steps. This produces about the same result in a small simulation (and is what Illustris did) but it means we do not have to build a tree with DM particles for winds on short timesteps.