### PR TITLE
Remove 64-bit debug variable unless DEBUG is on

### DIFF
--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -1139,7 +1139,6 @@ void blackhole_make_one(int index, const double atime) {
      * between the gas and BH mass. */
     child = slots_convert(child, 5, -1, PartManager, SlotsManager);
 
-    BHP(child).base.ID = P[child].ID;
     /* The accretion mass should always be the seed black hole mass,
      * irrespective of the gravitational mass of the particle.*/
     if(blackhole_params.MaxSeedBlackHoleMass > 0)

--- a/libgadget/exchange.c
+++ b/libgadget/exchange.c
@@ -342,10 +342,12 @@ static int domain_exchange_once(ExchangePlan * plan, int do_gc, struct part_mana
 
             if(!sman->info[ptype].enabled) continue;
 
+#ifdef DEBUG
             int PI = pman->Base[i].PI;
             if(BASESLOT_PI(PI, ptype, sman)->ID != pman->Base[i].ID) {
                 endrun(1, "Exchange: P[%d].ID = %ld (type %d) != SLOT ID = %ld. garbage: %d ReverseLink: %d\n",i,pman->Base[i].ID, pman->Base[i].Type, BASESLOT_PI(PI, ptype, sman)->ID, pman->Base[i].IsGarbage, BASESLOT_PI(PI, ptype, sman)->ReverseLink);
             }
+#endif
         }
         for(ptype = 0; ptype < 6; ptype ++) {
             if(newPI[ptype] !=

--- a/libgadget/slotsmanager.c
+++ b/libgadget/slotsmanager.c
@@ -33,7 +33,9 @@ slots_connect_new_slot(int i, int pi, int type, struct part_manager_type * pman,
      * if it is uninitialised.*/
     memset(BASESLOT_PI(pi, type, sman), 101, sman->info[type].elsize);
     /* book keeping ID: debug only */
+#ifdef DEBUG
     BASESLOT_PI(pi, type, sman)->ID = pman->Base[i].ID;
+#endif
     /*Update the particle's pointer*/
     pman->Base[i].PI = pi;
 }
@@ -656,6 +658,8 @@ slots_setup_id(const struct part_manager_type * pman, struct slots_manager_type 
             endrun(1, "Particle %d, type %d has PI index %d beyond max slot size %d.\n", i, pman->Base[i].Type, sind, info.size);
         struct particle_data_ext * sdata = (struct particle_data_ext * )(info.ptr + info.elsize * (size_t) sind);
         sdata->ReverseLink = i;
+#ifdef DEBUG
         sdata->ID = pman->Base[i].ID;
+#endif
     }
 }

--- a/libgadget/slotsmanager.h
+++ b/libgadget/slotsmanager.h
@@ -21,7 +21,9 @@ struct particle_data_ext {
     /* Used at GC for reverse link to P.
      * Garbage slots have this impossibly large. */
     int ReverseLink;
+#ifdef DEBUG
     MyIDType ID; /* for data consistency check, same as particle ID */
+#endif
 };
 
 /* Data stored for each black hole in addition to collisionless data*/


### PR DESCRIPTION
@yueyingn What do you think of this? It makes every sph_particle_data and every star_particle_data 64-bits smaller, but it removes a check in the exchange code that has caught bugs before (although I think not bugs in production). Living dangerously but likely reduces memory use noticeably.