### PR TITLE
fix bhinfo collect error when df off

### DIFF
--- a/libgadget/bhinfo.c
+++ b/libgadget/bhinfo.c
@@ -115,7 +115,6 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
         info->BH_SurroundingVel[0] = dynpriv->BH_SurroundingVel[PI][0];
         info->BH_SurroundingVel[1] = dynpriv->BH_SurroundingVel[PI][1];
         info->BH_SurroundingVel[2] = dynpriv->BH_SurroundingVel[PI][2];
-
         /****************************************************************************/
         info->BH_accreted_BHMass = priv->BH_accreted_BHMass[PI];
         info->BH_accreted_Mass = priv->BH_accreted_Mass[PI];


### PR DESCRIPTION
When bhdyfric_method=0, the dynpriv struct is not allocated and yet used when collecting bhinfo, resulting in an error. This fix allocates dynpriv even when dynfric is off and set all variables in the structure to zero. Should not affect the run when the bhdyfric is turned on.