### PR TITLE
Separatetree

### DIFF
--- a/examples/dynfric/paramfile.gadget
+++ b/examples/dynfric/paramfile.gadget
@@ -3,13 +3,9 @@ InitCondFile = ICS/IC
 OutputDir = output
 TreeCoolFile = ../TREECOOL_fg_june11
 OutputList = 0.1,0.1111111, 0.125, 0.142857, 0.16666, 0.181818,0.2,0.222222, 0.25, 0.285714, 0.3333333,0.4
-#OutputList =  0.2, 0.222222, 0.25, 0.285714, 0.333333 
-#OutputList = 0.333333,0.4
-Nmesh = 1100
 # CPU time -limit
-	
-#TimeLimitCPU = 43000 #= 8 hours
-TimeLimitCPU = 230000
+
+TimeLimitCPU = 28000
 
 # Code options
 #  Characteristics of run
@@ -31,45 +27,22 @@ MassiveNuLinRespOn = 0
 WindOn = 1
 MetalCoolFile = ../cooling_metal_UVB
 
-# Accuracy of time integration
-MaxSizeTimestep = 0.1
-MinSizeTimestep = 0.00
-
 SnapshotWithFOF = 1
-FOFHaloLinkingLength = 0.2
-FOFHaloMinLength = 32
 
 #  Further parameters of SPH
 DensityKernelType = quintic
 
-DensityContrastLimit = 100   # max contrast for hydro force calculation
-DensityResolutionEta = 1.0  # for Cubic spline 1.0 = 33
-MaxNumNgbDeviation = 2
-ArtBulkViscConst = 0.75
-InitGasTemp = 580.0        # always ignored if set to 0 
-MinGasTemp = 5.0
-
-
-# Softening lengths
-
-MinGasHsmlFractional = 0.01
-
 #----------------------BH Stuff-------------------------
 BlackHoleFeedbackFactor = 0.05
-BlackHoleFeedbackRadius = 0.
-BlackHoleFeedbackRadiusMaxPhys = 0.
 BlackHoleFeedbackMethod = spline | mass
 SeedBlackHoleMass = 5.0e-5
-BlackHoleAccretionFactor = 100.0
-BlackHoleNgbFactor = 2.0
-BlackHoleEddingtonFactor = 3.0
 MetalReturnOn = 1
 MinFoFMassForNewSeed = 1
 TimeBetweenSeedingSearch = 1.03
 
 WriteBlackHoleDetails = 1
 BH_DynFrictionMethod = 2  # no DM/Star
-BH_DRAG = 1  # No drag
+BH_DRAG = 1  # drag
 BH_DFBoostFactor = 1
 SeedBHDynMass = 2e-3
 BH_DFbmax = 10.
@@ -82,9 +55,6 @@ CritPhysDensity = 0       #  critical physical density for star formation in
 CritOverDensity = 57.7   #  overdensity threshold value
 
 WindModel = ofjt10,decouple
-WindEfficiency = 2.0
-WindEnergyFraction = 1.0
-WindSigma0 = 353.0 #km/s
 WindSpeedFactor = 3.7
 
 WindFreeTravelLength = 20

--- a/examples/dynfric/paramfile.genic
+++ b/examples/dynfric/paramfile.genic
@@ -18,14 +18,9 @@ DifferentTransferFunctions = 1
 FileWithInputSpectrum = ../class_pk_99.dat  # filename of tabulated input spectrum (if used)
 FileWithTransferFunction = ../class_tk_99.dat  # filename of transfer functions for different species
 
-                                    # Note: This can be chosen different from UnitLength_in_cm
 # Only used by the CLASS script.
 PrimordialAmp = 2.215e-9
 # May be used to tilt the primordial index. Only used if WhichSpectum != 2
 PrimordialIndex  = 0.96
 
 Seed = 738    #  seed for IC-generator
-
-UnitLength_in_cm = 3.085678e21   # defines length unit of output (in cm/h)
-UnitMass_in_g = 1.989e43      # defines mass unit of output (in g/cm)
-UnitVelocity_in_cm_per_s = 1e5 # defines velocity unit of output (in cm/sec)            

--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -52,7 +52,7 @@ BlackHoleNgbFactor = 2.0
 BlackHoleEddingtonFactor = 3.0
 
 MinFoFMassForNewSeed = 1
-TimeBetweenSeedingSearch 1.03
+TimeBetweenSeedingSearch = 1.03
 WriteBlackHoleDetails = 1
 
 #----------------------SFR Stuff-------------------------

--- a/gadget/main.c
+++ b/gadget/main.c
@@ -16,6 +16,7 @@
 #include <libgadget/run.h>
 #include <libgadget/checkpoint.h>
 #include <libgadget/config.h>
+#include <libgadget/forcetree.c>
 
 #include <libgadget/utils.h>
 
@@ -54,6 +55,7 @@ int main(int argc, char **argv)
     message(0, "Size of blackhole structure       %td  [bytes]\n",sizeof(struct bh_particle_data));
     message(0, "Size of sph particle structure   %td  [bytes]\n",sizeof(struct sph_particle_data));
     message(0, "Size of star particle structure   %td  [bytes]\n",sizeof(struct star_particle_data));
+    message(0, "Size of force tree node structure %td [bytes]\n", sizeof(struct NODE));
 
     if(argc < 2)
     {

--- a/libgadget/bhdynfric.h
+++ b/libgadget/bhdynfric.h
@@ -19,8 +19,8 @@ struct BHDynFricPriv {
 };
 
 /* Do the dynamic friction treewalk if BH_DynFrictionMethod > 0.
- * Tree needs stars and gas.*/
-void blackhole_dynfric(int * ActiveBlackHoles, int64_t NumActiveBlackHoles, ForceTree * tree, struct BHDynFricPriv * priv);
+ * Builds a private tree with the types needed for dynamic friction (mostly stars and DM).*/
+void blackhole_dynfric(int * ActiveBlackHoles, int64_t NumActiveBlackHoles, DomainDecomp * ddecomp, struct BHDynFricPriv * priv);
 void set_blackhole_dynfric_params(ParameterSet * ps);
 void blackhole_dynpriv_free(struct BHDynFricPriv * dynpriv);
 /* Get the particle types used in dynfric*/

--- a/libgadget/bhdynfric.h
+++ b/libgadget/bhdynfric.h
@@ -16,6 +16,8 @@ struct BHDynFricPriv {
     double atime;
     Cosmology * CP;
     struct kick_factor_data * kf;
+    /* For diagnostics*/
+    MyFloat * MinPot;
 };
 
 /* Do the dynamic friction treewalk if BH_DynFrictionMethod > 0.
@@ -25,5 +27,12 @@ void set_blackhole_dynfric_params(ParameterSet * ps);
 void blackhole_dynpriv_free(struct BHDynFricPriv * dynpriv);
 /* Get the particle types used in dynfric*/
 int blackhole_dynfric_treemask(void);
+
+/* Stand-alone function to find the black hole local potential minimum, when using the repositioning model. Uses its own treebuild.
+ * The local potential minimum is also found by the dynamic friction treewalk.*/
+void blackhole_findminpot(int * ActiveBlackHoles, const int64_t NumActiveBlackHoles, DomainDecomp * ddecomp);
+
+/* Decide whether black hole repositioning is enabled. */
+int BHGetRepositionEnabled(void);
 
 #endif

--- a/libgadget/bhinfo.c
+++ b/libgadget/bhinfo.c
@@ -94,9 +94,6 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
         info->minTimeBin = BHP(p_i).minTimeBin;
         info->encounter = BHP(p_i).encounter;
 
-        if(priv->MinPot) {
-            info->MinPot = priv->MinPot[PI];
-        }
         info->BH_Entropy = priv->BH_Entropy[PI];
         int k;
         for(k=0; k < 3; k++) {
@@ -113,6 +110,7 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
         /****************************************************************************/
         /* Output some DF info for debugging */
         if(dynpriv && dynpriv->BH_SurroundingDensity) {
+            info->MinPot = dynpriv->MinPot[PI];
             info->BH_SurroundingDensity = dynpriv->BH_SurroundingDensity[PI];
             info->BH_SurroundingRmsVel = dynpriv->BH_SurroundingRmsVel[PI];
             info->BH_SurroundingParticles = dynpriv->BH_SurroundingParticles[PI];

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -570,7 +570,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         if(r2 < iter->kernel.HH) {
             double u = r * iter->kernel.Hinv;
             double wk = density_kernel_wk(&iter->kernel, u);
-            float mass_j = P[other].Mass;
+            double mass_j = P[other].Mass;
 
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
             MyFloat VelPred[3];

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -474,7 +474,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     if(iter->base.other == -1) {
         O->BH_minTimeBin = TIMEBINS;
         O->encounter = 0;
-        iter->base.mask = GASMASK + STARMASK + BHMASK;
+        iter->base.mask = GASMASK + BHMASK;
         iter->base.Hsml = I->Hsml;
         /* Symmetric for the BH mergers*/
         iter->base.symmetric = NGB_TREEFIND_SYMMETRIC;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -32,7 +32,6 @@ struct BlackholeParams
     double BlackHoleFeedbackFactor;	/*!< Fraction of the black luminosity feed into thermal feedback */
     enum BlackHoleFeedbackMethod BlackHoleFeedbackMethod;	/*!< method of the feedback*/
     double BlackHoleEddingtonFactor;	/*! Factor above Eddington */
-    int BlackHoleRepositionEnabled; /* If true, enable repositioning the BH to the potential minimum*/
 
     int BlackHoleKineticOn; /*If 1, perform AGN kinetic feedback when the Eddington accretion rate is low */
     double BHKE_EddingtonThrFactor; /*Threshold of the Eddington rate for the kinetic feedback*/
@@ -55,12 +54,6 @@ struct BlackholeParams
     /************************************************************************/
 } blackhole_params;
 
-int
-BHGetRepositionEnabled(void)
-{
-    return blackhole_params.BlackHoleRepositionEnabled;
-}
-
 typedef struct {
     TreeWalkQueryBase base;
     MyFloat Density;
@@ -75,9 +68,6 @@ typedef struct {
 
 typedef struct {
     TreeWalkResultBase base;
-    MyFloat BH_MinPotPos[3];
-    MyFloat BH_MinPotVel[3];
-    MyFloat BH_MinPot;
     int BH_minTimeBin;
     int encounter;
     MyFloat FeedbackWeightSum;
@@ -111,7 +101,6 @@ void set_blackhole_params(ParameterSet * ps)
         blackhole_params.BlackHoleFeedbackFactor = param_get_double(ps, "BlackHoleFeedbackFactor");
 
         blackhole_params.BlackHoleFeedbackMethod = (enum BlackHoleFeedbackMethod) param_get_enum(ps, "BlackHoleFeedbackMethod");
-        blackhole_params.BlackHoleRepositionEnabled = param_get_int(ps, "BlackHoleRepositionEnabled");
 
         blackhole_params.BlackHoleKineticOn = param_get_int(ps,"BlackHoleKineticOn");
         blackhole_params.BHKE_EddingtonThrFactor = param_get_double(ps, "BHKE_EddingtonThrFactor");
@@ -148,10 +137,6 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
 static void
 blackhole_accretion_copy(int place, TreeWalkQueryBHAccretion * I, TreeWalk * tw);
 
-/* Initializes the minimum potentials*/
-static void
-blackhole_accretion_preprocess(int n, TreeWalk * tw);
-
 static void
 blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         TreeWalkResultBHAccretion * O,
@@ -163,8 +148,6 @@ static void
 blackhole_feedback(int * ActiveBlackHoles, int64_t NumActiveBlackHoles, ForceTree * tree, struct BHPriv * priv);
 
 /*************************************************************************************/
-
-#define BHPOTVALUEINIT 1.0e29
 
 static double blackhole_soundspeed(double entropy, double rho, const double atime) {
     /* rho is comoving !*/
@@ -251,9 +234,8 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     }
 
     /* Types used in treewalks:
-     * accretion uses: all types but ONLY for repositioning potential minimum. Otherwise
-     * accretion uses: gas + black holes if dynamic friction is enabled.
-     * feedback uses: gas + black holes.
+     * accretion uses: gas + black holes (to flag mergers).
+     * feedback uses: gas + black holes (to flag mergers).
      */
     if(tree->tree_allocated_flag && (tree->mask & ALLMASK) != ALLMASK)
         force_tree_free(tree);
@@ -261,10 +243,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     {
         message(0, "Building tree in blackhole\n");
         int treemask = GASMASK | BHMASK;
-        /* If we are repositioning, need all types*/
-        if(blackhole_params.BlackHoleRepositionEnabled)
-            treemask = ALLMASK;
-
         force_tree_rebuild_mask(tree, ddecomp, treemask, NULL);
         /* We need hmax for the symmetric BH walk*/
         force_tree_calc_moments(tree, ddecomp);
@@ -304,9 +282,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     /* Computed in accretion, used in feedback*/
     priv->BH_FeedbackWeightSum = (MyFloat *) mymalloc("BH_FeedbackWeightSum", SlotsManager->info[5].size * sizeof(MyFloat));
 
-    /* These are initialized in preprocess and used to reposition the BH in postprocess*/
-    priv->MinPot = (MyFloat *) mymalloc("BH_MinPot", SlotsManager->info[5].size * sizeof(MyFloat));
-
     /* Local to this treewalk*/
     priv->BH_Entropy = (MyFloat *) mymalloc("BH_Entropy", SlotsManager->info[5].size * sizeof(MyFloat));
     priv->BH_SurroundingGasVel = (MyFloat (*) [3]) mymalloc("BH_SurroundVel", 3* SlotsManager->info[5].size * sizeof(priv->BH_SurroundingGasVel[0]));
@@ -328,7 +303,7 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     tw_accretion->ngbiter = (TreeWalkNgbIterFunction) blackhole_accretion_ngbiter;
     tw_accretion->haswork = NULL;
     tw_accretion->postprocess = (TreeWalkProcessFunction) blackhole_accretion_postprocess;
-    tw_accretion->preprocess = (TreeWalkProcessFunction) blackhole_accretion_preprocess;
+    tw_accretion->preprocess = NULL;
     tw_accretion->fill = (TreeWalkFillQueryFunction) blackhole_accretion_copy;
     tw_accretion->reduce = (TreeWalkReduceResultFunction) blackhole_accretion_reduce;
     tw_accretion->query_type_elsize = sizeof(TreeWalkQueryBHAccretion);
@@ -384,7 +359,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
 
     myfree(priv->BH_SurroundingGasVel);
     myfree(priv->BH_Entropy);
-    myfree(priv->MinPot);
 
     myfree(priv->BH_FeedbackWeightSum);
     myfree(priv->BH_SwallowID);
@@ -497,22 +471,6 @@ blackhole_accretion_postprocess(int i, TreeWalk * tw)
 }
 
 static void
-blackhole_accretion_preprocess(int n, TreeWalk * tw)
-{
-    int j;
-    /* Note that the potential is only updated when it is from all particles.
-     * In particular this means that it is not updated for hierarchical gravity
-     * when the number of active particles is less than the total number of particles
-     * (because then the tree does not contain all forces). */
-    BH_GET_PRIV(tw)->MinPot[P[n].PI] = P[n].Potential;
-
-    for(j = 0; j < 3; j++) {
-        BHP(n).MinPotPos[j] = P[n].Pos[j];
-    }
-
-}
-
-static void
 blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         TreeWalkResultBHAccretion * O,
         TreeWalkNgbIterBHAccretion * iter,
@@ -522,13 +480,6 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     if(iter->base.other == -1) {
         O->BH_minTimeBin = TIMEBINS;
         O->encounter = 0;
-
-        O->BH_MinPot = BHPOTVALUEINIT;
-
-        int d;
-        for(d = 0; d < 3; d++) {
-            O->BH_MinPotPos[d] = I->base.Pos[d];
-        }
         iter->base.mask = GASMASK + STARMASK + BHMASK;
         iter->base.Hsml = I->Hsml;
         /* Symmetric for the BH mergers*/
@@ -554,20 +505,6 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
      /* BH does not accrete wind */
     if(winds_is_particle_decoupled(other)) return;
 
-    /* Find the black hole potential minimum. */
-    if(r2 < iter->accretion_kernel.HH)
-    {
-        if(P[other].Potential < O->BH_MinPot)
-        {
-            int d;
-            O->BH_MinPot = P[other].Potential;
-            for(d = 0; d < 3; d++) {
-                O->BH_MinPotPos[d] = P[other].Pos[d];
-                O->BH_MinPotVel[d] = P[other].Vel[d];
-            }
-        }
-    }
-
     /* Accretion / merger doesn't do self interaction */
     if(P[other].ID == I->ID) return;
 
@@ -580,12 +517,12 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
 
         int flag = 0; // the flag for BH merge
 
-        if(blackhole_params.BlackHoleRepositionEnabled == 1) // directly merge if reposition is enabled
+        if(BHGetRepositionEnabled() == 1) // directly merge if reposition is enabled
             flag = 1;
         if(blackhole_params.MergeGravBound == 0)
             flag = 1;
         /* apply Grav Bound check only when Reposition is disabled, otherwise BHs would be repositioned to the same location but not merge */
-        if(blackhole_params.MergeGravBound == 1 && blackhole_params.BlackHoleRepositionEnabled == 0){
+        if(blackhole_params.MergeGravBound == 1 && BHGetRepositionEnabled() == 0){
 
             double dx[3];
             double dv[3];
@@ -726,19 +663,8 @@ static void
 blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum TreeWalkReduceMode mode, TreeWalk * tw)
 {
     int k;
-    MyFloat * MinPot = BH_GET_PRIV(tw)->MinPot;
 
     int PI = P[place].PI;
-    if(MinPot[PI] > remote->BH_MinPot)
-    {
-        BHP(place).JumpToMinPot = blackhole_params.BlackHoleRepositionEnabled;
-        MinPot[PI] = remote->BH_MinPot;
-        for(k = 0; k < 3; k++) {
-            /* Movement occurs in drift.c */
-            BHP(place).MinPotPos[k] = remote->BH_MinPotPos[k];
-            BHP(place).MinPotVel[k] = remote->BH_MinPotVel[k];
-        }
-    }
 
     /* Set encounter to true if it is true on any remote*/
     if (mode == 0 || BHP(place).encounter < remote->encounter) {

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -237,7 +237,7 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
      * accretion uses: gas + black holes (to flag mergers).
      * feedback uses: gas + black holes (to flag mergers).
      */
-    if(tree->tree_allocated_flag && (tree->mask & ALLMASK) != ALLMASK)
+    if(tree->tree_allocated_flag && (tree->mask & (GASMASK | BHMASK)) != (GASMASK | BHMASK))
         force_tree_free(tree);
     if(!tree->tree_allocated_flag)
     {

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -251,19 +251,23 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     }
 
     /* Types used in treewalks:
-     * dynamical friction uses: stars, DM if BH_DynFrictionMethod > 1 gas if BH_DynFrictionMethod  == 3.
-     * accretion uses: all types but ONLY for repositioning potential minimum. Otherwise gas + black holes. gas + stars + BH is probably fine.
-     * gas + BH probably not enough if gas is sparse in halo.
+     * accretion uses: all types but ONLY for repositioning potential minimum. Otherwise
+     * accretion uses: gas + black holes if dynamic friction is enabled.
      * feedback uses: gas + black holes.
-     * The DM in dynamic friction and accretion doesn't really do anything, so could perhaps be removed from the treebuild later.
-     * However, we would still need a tree with gas + DM in the wind code.
      */
+    if(tree->tree_allocated_flag && (tree->mask & ALLMASK) != ALLMASK)
+        force_tree_free(tree);
     if(!tree->tree_allocated_flag)
     {
         message(0, "Building tree in blackhole\n");
-        int treemask = blackhole_dynfric_treemask();
-        treemask += GASMASK | BHMASK;
+        int treemask = GASMASK | BHMASK;
+        /* If we are repositioning, need all types*/
+        if(blackhole_params.BlackHoleRepositionEnabled)
+            treemask = ALLMASK;
+
         force_tree_rebuild_mask(tree, ddecomp, treemask, NULL);
+        /* We need hmax for the symmetric BH walk*/
+        force_tree_calc_moments(tree, ddecomp);
         walltime_measure("/BH/Build");
     }
 
@@ -277,7 +281,7 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     dynpriv->atime = atime;
     dynpriv->CP = CP;
     dynpriv->kf = &kf;
-    blackhole_dynfric(ActiveBlackHoles, NumActiveBlackHoles, tree, dynpriv);
+    blackhole_dynfric(ActiveBlackHoles, NumActiveBlackHoles, ddecomp, dynpriv);
     walltime_measure("/BH/DynFric");
 
     struct BHPriv priv[1] = {0};
@@ -297,8 +301,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     priv->BH_SwallowID = (MyIDType *) mymalloc("BH_SwallowID", SlotsManager->info[5].size * sizeof(MyIDType));
     memset(priv->BH_SwallowID, 0, SlotsManager->info[5].size * sizeof(MyIDType));
 
-    /* We need hmax for the symmetric BH walk*/
-    force_tree_calc_moments(tree, ddecomp);
     /* Computed in accretion, used in feedback*/
     priv->BH_FeedbackWeightSum = (MyFloat *) mymalloc("BH_FeedbackWeightSum", SlotsManager->info[5].size * sizeof(MyFloat));
 

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -12,7 +12,6 @@ struct BHPriv {
     /* Similar for IDs of BH mergers*/
     MyIDType * BH_SwallowID;
     /* These are temporaries used in the accretion treewalk*/
-    MyFloat * MinPot;
     MyFloat * BH_Entropy;
     MyFloat (*BH_SurroundingGasVel)[3];
 
@@ -65,6 +64,4 @@ void blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceT
 /* Make a black hole from the particle at index. */
 void blackhole_make_one(int index, const double atime);
 
-/* Decide whether black hole repositioning is enabled. */
-int BHGetRepositionEnabled(void);
 #endif

--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -523,7 +523,7 @@ ionize_all_part(int qso_ind, int * qso_cand, struct QSOPriv priv, ForceTree * tr
  * Keeps adding new quasars until need_more_quasars() returns 0.
  */
 static void
-turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
+turn_on_quasars(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
 {
     int ncand = 0;
     int * qso_cand = NULL;
@@ -573,8 +573,6 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
         return;
     }
     message(0, "HeII: Built quasar candidate list from %d quasars\n", ncand_tot);
-    ForceTree gasTree = {0};
-    force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, NULL);
     walltime_measure("/HeIII/Build");
     for(iteration = 0; curionfrac < desired_ion_frac; iteration++){
         /* Get a new quasar*/
@@ -588,7 +586,7 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
             break;
         }
 
-        int64_t n_ionized = ionize_all_part(new_qso, qso_cand, priv, &gasTree);
+        int64_t n_ionized = ionize_all_part(new_qso, qso_cand, priv, gasTree);
         int64_t tot_qso_ionized = 0;
         /* Check that the ionization fraction changed*/
         MPI_Allreduce(&n_ionized, &tot_qso_ionized, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
@@ -630,7 +628,6 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
             ncand--;
         }
     }
-    force_tree_free(&gasTree);
     if(qso_cand) {
         myfree(qso_cand);
     }
@@ -644,7 +641,7 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
 
 /* Starts reionization by selecting the first halo and flagging all particles in the first HeIII bubble*/
 void
-do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
+do_heiii_reionization(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
 {
     if(!QSOLightupParams.QSOLightupOn)
         return;
@@ -655,9 +652,12 @@ do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cos
     if(atime > He_zz[Nreionhist-1])
         return;
 
+    if(!gasTree->tree_allocated_flag || !(gasTree->mask & GASMASK))
+        endrun(5, "helium_reion called with bad tree allocated %d mask %d\n", gasTree->tree_allocated_flag, gasTree->mask);
+
     walltime_measure("/Misc");
     //message(0, "HeII: Reionization initiated.\n");
-    turn_on_quasars(atime, fof, ddecomp, CP, uu_in_cgs, FdHelium);
+    turn_on_quasars(atime, fof, gasTree, CP, uu_in_cgs, FdHelium);
 }
 
 int

--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -430,7 +430,7 @@ ionize_ngbiter(TreeWalkQueryQSOLightup * I,
 
     if(iter->other == -1) {
         /* Gas only ( 1 == 1 << 0, the bit for type 0)*/
-        iter->mask = 1;
+        iter->mask = GASMASK;
         /* Bubble size*/
         double bubble = gaussian_rng(QSOLightupParams.mean_bubble, sqrt(QSOLightupParams.var_bubble), I->ID);
         iter->Hsml = bubble;

--- a/libgadget/cooling_qso_lightup.h
+++ b/libgadget/cooling_qso_lightup.h
@@ -11,7 +11,7 @@ void set_qso_lightup_params(ParameterSet * ps);
 void init_qso_lightup(char * reion_hist_file);
 
 /* Starts reionization by selecting the first halo and flagging all particles in the first HeIII bubble*/
-void do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium);
+void do_heiii_reionization(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium);
 
 /* Get the long mean free path photon heating that applies to not-yet-ionized particles*/
 double get_long_mean_free_path_heating(double redshift);

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -430,7 +430,7 @@ density_ngbiter(
         iter->kernel_volume = density_kernel_volume(&iter->kernel);
 
         iter->base.Hsml = h;
-        iter->base.mask = 1; /* gas only */
+        iter->base.mask = GASMASK; /* gas only */
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
         return;
     }

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <gsl/gsl_math.h>
 #include "drift.h"
-#include "blackhole.h"
+#include "bhdynfric.h"
 #include "walltime.h"
 #include "timefac.h"
 #include "timestep.h"

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -312,7 +312,6 @@ static void init_internal_node(struct NODE *nfreep, struct NODE *parent, int sub
     for(j = 0; j < NMAXCHILD; j++)
         nfreep->s.suns[j] = -1;
     nfreep->s.noccupied = 0;
-    nfreep->s.Types = 0;
     memset(&(nfreep->mom.cofm),0,3*sizeof(MyFloat));
     nfreep->mom.mass = 0;
     nfreep->mom.hmax = 0;
@@ -353,7 +352,6 @@ modify_internal_node(int parent, int subnode, int p_toplace, const ForceTree tb,
         tb.Father[p_toplace] = parent;
     tb.Nodes[parent].s.suns[subnode] = p_toplace;
     /* Encode the type in the Types array*/
-    tb.Nodes[parent].s.Types += P[p_toplace].Type << (3*subnode);
     if(!HybridNuGrav || P[p_toplace].Type != ForceTreeParams.FastParticleType)
         add_particle_moment_to_node(&tb.Nodes[parent], &P[p_toplace]);
     return 0;
@@ -663,7 +661,6 @@ force_tree_create_nodes(ForceTree * tree, const ActiveParticles * act, int mask,
             nfreep->center[i] = PartManager->BoxSize/2.;
         for(i = 0; i < NMAXCHILD; i++)
             nfreep->s.suns[i] = -1;
-        nfreep->s.Types = 0;
         nfreep->s.noccupied = 0;
         nfreep->father = -1;
         nfreep->sibling = -1;
@@ -831,7 +828,6 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
 
                 int count = i + 2 * j + 4 * k;
 
-                Nodes[no].s.Types = 0;
                 Nodes[no].s.suns[count] = *nextfree;
                 /*We are an internal top level node as we now have a child top level.*/
                 Nodes[no].f.InternalTopLevel = 1;

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -41,15 +41,6 @@ struct NODE
     MyFloat center[3];		/*!< geometrical center of node */
 
     struct {
-        unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
-        unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
-        unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
-        unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
-                                    * (should be an enum, but not standard in C).*/
-        unsigned int unused : 3; /* Spare bits*/
-    } f;
-
-    struct {
         MyFloat cofm[3];		/*!< center of mass of node */
         MyFloat mass;		/*!< mass of node */
         MyFloat hmax;           /*!< maximum amount by which Pos + Hsml of all gas particles in the node exceeds len for this node. */
@@ -62,6 +53,14 @@ struct NODE
      * Any attempt to get it back by using a separate allocation means we lost the ability to resize
      * the Nodes array and that is always worse.*/
     struct NodeChild s;
+    struct {
+        unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
+        unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
+        unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
+        unsigned int ChildType :2; /* Specify the type of children this node has: particles, other nodes, or pseudo-particles.
+                                    * (should be an enum, but not standard in C).*/
+        unsigned int unused : 3; /* Spare bits*/
+    } f;
 };
 
 /*Structure containing the Node pointer, and various Tree metadata.*/

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -26,9 +26,6 @@
 
 struct NodeChild
 {
-    /* Stores the types of the child particles. Uses a bit field, 3 bits per particle.
-     */
-    unsigned int Types;
     /*!< pointers to daughter nodes or daughter particles. */
     int suns[NMAXCHILD];
     /* Number of daughter particles if node contains particles.

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -75,7 +75,7 @@ grav_short_pair_ngbiter(
 
     if(iter->base.other == -1) {
         iter->base.Hsml = GRAV_GET_PRIV(lv->tw)->Rcut;
-        iter->base.mask = 0xff; /* all particles */
+        iter->base.mask = ALLMASK; /* all particles */
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
         return;
     }

--- a/libgadget/hydra.c
+++ b/libgadget/hydra.c
@@ -326,7 +326,7 @@ hydro_ngbiter(
 {
     if(iter->base.other == -1) {
         iter->base.Hsml = I->Hsml;
-        iter->base.mask = 1;
+        iter->base.mask = GASMASK;
         iter->base.symmetric = NGB_TREEFIND_SYMMETRIC;
 
         if(HydroParams.DensityIndependentSphOn)

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -517,7 +517,7 @@ metal_return_priv_free(struct MetalReturnPriv * priv)
 
 /*! This function is the driver routine for the calculation of metal return. */
 void
-metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmology * CP, const double atime, const double AvgGasMass)
+metal_return(const ActiveParticles * act, ForceTree * gasTree, Cosmology * CP, const double atime, const double AvgGasMass)
 {
     /* Do nothing if no stars yet*/
     int64_t totstar;
@@ -545,14 +545,10 @@ metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmolog
         return;
     }
 
-    ForceTree gasTree = {0};
-    /* Just gas, no moments*/
-    force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, NULL);
-    walltime_measure("/SPH/Metals/Build");
-
-
+    if(!gasTree->tree_allocated_flag || !(gasTree->mask & GASMASK))
+        endrun(5, "metal_return called with bad tree allocated %d mask %d\n", gasTree->tree_allocated_flag, gasTree->mask);
     /* Compute total number of weights around each star for actively returning stars*/
-    stellar_density(act, priv->StarVolumeSPH, priv->MassReturn, &gasTree);
+    stellar_density(act, priv->StarVolumeSPH, priv->MassReturn, gasTree);
 
     /* Do the metal return*/
     TreeWalk tw[1] = {{0}};
@@ -568,14 +564,13 @@ metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmolog
     tw->query_type_elsize = sizeof(TreeWalkQueryMetals);
     tw->result_type_elsize = sizeof(TreeWalkResultMetals);
     tw->repeatdisallowed = 1;
-    tw->tree = &gasTree;
+    tw->tree = gasTree;
     tw->priv = priv;
 
     priv->spin = init_spinlocks(SlotsManager->info[0].size);
     treewalk_run(tw, act->ActiveParticle, act->NumActiveParticle);
     free_spinlocks(priv->spin);
 
-    force_tree_free(&gasTree);
     metal_return_priv_free(priv);
 
     /* collect some timing information */

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -651,7 +651,7 @@ metal_return_ngbiter(
 {
     if(iter->base.other == -1) {
         /* Only return metals to gas*/
-        iter->base.mask = 1;
+        iter->base.mask = GASMASK;
         iter->base.Hsml = I->Hsml;
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
         /* Initialise the mass lost by this star in this timestep*/
@@ -896,7 +896,7 @@ stellar_density_ngbiter(
             iter->kernel_volume[i] = density_kernel_volume(&iter->kernel[i]);
         }
         iter->base.Hsml = I->Hsml[NHSML-1];
-        iter->base.mask = 1; /* gas only */
+        iter->base.mask = GASMASK; /* gas only */
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
         O->maxcmpte = NHSML;
         return;

--- a/libgadget/metal_return.h
+++ b/libgadget/metal_return.h
@@ -39,7 +39,7 @@ struct MetalReturnPriv {
     struct SpinLocks * spin;
 };
 
-void metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmology * CP, const double atime, const double AvgGasMass);
+void metal_return(const ActiveParticles * act, ForceTree * gasTree, Cosmology * CP, const double atime, const double AvgGasMass);
 
 void set_metal_return_params(ParameterSet * ps);
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -587,10 +587,13 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
          */
         if(GasEnabled)
         {
+            if(!gasTree.tree_allocated_flag)
+                force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK | BHMASK, All.OutputDir);
+
             /* Do this before sfr and bh so the gas hsml always contains DesNumNgb neighbours.*/
             if(All.MetalReturnOn) {
                 double AvgGasMass = All.CP.OmegaBaryon * 3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.CP.GravInternal) * pow(PartManager->BoxSize, 3) / header->NTotalInit[0];
-                metal_return(&Act, ddecomp, &All.CP, atime, AvgGasMass);
+                metal_return(&Act, &gasTree, &All.CP, atime, AvgGasMass);
             }
 
             /* this will find new black hole seed halos.
@@ -611,7 +614,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
 
                 if(during_helium_reionization(1/atime - 1)) {
                     /* Helium reionization by switching on quasar bubbles*/
-                    do_heiii_reionization(atime, &fof, ddecomp, &All.CP, units.UnitInternalEnergy_in_cgs, fds.FdHelium);
+                    do_heiii_reionization(atime, &fof, &gasTree, &All.CP, units.UnitInternalEnergy_in_cgs, fds.FdHelium);
                 }
 #ifdef EXCUR_REION
                 //excursion set reionisation

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -1129,14 +1129,6 @@ ngb_treefind_threads(TreeWalkQueryBase * I,
             int i;
             int * suns = current->s.suns;
             for (i = 0; i < current->s.noccupied; i++) {
-                /* must be the correct type: compare the
-                 * current type for this subnode extracted
-                 * from the bitfield to the mask.*/
-                int type = (current->s.Types >> (3*i)) % 8;
-
-                if(!((1<<type) & iter->mask))
-                    continue;
-
                 lv->ngblist[numcand++] = suns[i];
             }
             /* Move sideways*/
@@ -1215,14 +1207,6 @@ int treewalk_visit_nolist_ngbiter(TreeWalkQueryBase * I,
                 int i;
                 int * suns = current->s.suns;
                 for (i = 0; i < current->s.noccupied; i++) {
-                    /* must be the correct type: compare the
-                    * current type for this subnode extracted
-                    * from the bitfield to the mask.*/
-                    int type = (current->s.Types >> (3*i)) % 8;
-
-                    if(!((1<<type) & iter->mask))
-                        continue;
-
                     /* Now evaluate a particle for the list*/
                     int other = suns[i];
                     /* Skip garbage*/

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -965,8 +965,8 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
     iter->other = -1;
     lv->tw->ngbiter(I, O, iter, lv);
     /* Check whether the tree contains the particles we are looking for*/
-    if((lv->tw->tree->mask & iter->mask) == 0)
-        endrun(5, "Tried to run treewalk for particle mask %d but tree mask is %d.\n", iter->mask, lv->tw->tree->mask);
+    if((lv->tw->tree->mask & iter->mask) != iter->mask)
+        endrun(5, "Treewalk for particles with mask %d but tree mask is only %d overlap %d.\n", iter->mask, lv->tw->tree->mask, lv->tw->tree->mask & iter->mask);
     /* If symmetric, make sure we did hmax first*/
     if(iter->symmetric == NGB_TREEFIND_SYMMETRIC && !lv->tw->tree->hmax_computed_flag)
         endrun(3, "%s tried to do a symmetric treewalk without computing hmax!\n", lv->tw->ev_label);
@@ -1471,5 +1471,5 @@ treewalk_print_stats(const TreeWalk * tw)
     MPI_Reduce(&tw->Nlist, &Nlist, 1, MPI_INT64, MPI_SUM, 0, MPI_COMM_WORLD);
     if(Nlist == 0)
         Nlist ++;
-    message(0, "%s Ngblist: min %ld max %ld avg %g average exports: %g\n", tw->ev_label, minNinteractions, maxNinteractions, (double) Ninteractions / Nlistprimary, (double) Nnodesinlist/Nlist);
+    message(0, "%s Ngblist: min %ld max %ld avg %g average exports: %g\n", tw->ev_label, minNinteractions, maxNinteractions, (double) Ninteractions / Nlistprimary, (double) Nnodesinlist / Nlist);
 }


### PR DESCRIPTION
This lets DF use a separate, star-only, tree. The minimum potential computation uses the same tree.

The idea here is that accretion and feedback now use a gas only tree, and so the treewalks are faster.