### PR TITLE
Fix SIGBUS

### DIFF
--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -770,6 +770,8 @@ force_tree_create_nodes(ForceTree * tree, const ActiveParticles * act, int mask,
                  * has a local set of treenodes copying the global topnodes, except tid 0
                  * which has the real topnodes.*/
                 const int topleaf = domain_get_topleaf(P[i].Key, ddecomp);
+                if(topleaf < StartLeaf || topleaf >= EndLeaf)
+                    endrun(5, "Bad topleaf %d start %d end %d key %ld type %d ID %ld\n", topleaf, StartLeaf, EndLeaf, P[i].Key, P[i].Type, P[i].ID);
                 //int treenode = ddecomp->TopLeaves[topleaf].treenode;
                 cur = local_topnodes[topleaf - StartLeaf];
             }
@@ -817,7 +819,8 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
     int i, j, k;
 
     /*We reached the leaf of the toptree*/
-    if(ddecomp->TopNodes[topnode].Daughter < 0)
+    const int curdaughter = ddecomp->TopNodes[topnode].Daughter;
+    if(curdaughter < 0)
         return;
 
     for(i = 0; i < 2; i++)
@@ -842,7 +845,9 @@ void force_create_node_for_topnode(int no, int topnode, struct NODE * Nodes, con
                 /*All nodes here are top level nodes*/
                 Nodes[*nextfree].f.TopLevel = 1;
 
-                const struct topnode_data curtopnode = ddecomp->TopNodes[ddecomp->TopNodes[topnode].Daughter + sub];
+                if(curdaughter + sub >= ddecomp->NTopNodes)
+                    endrun(5, "Invalid topnode: daughter %d sub %d > topnodes %d\n", curdaughter, sub, ddecomp->NTopNodes);
+                const struct topnode_data curtopnode = ddecomp->TopNodes[curdaughter + sub];
                 if(curtopnode.Daughter == -1) {
                     ddecomp->TopLeaves[curtopnode.Leaf].treenode = *nextfree;
                 }

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -18,7 +18,7 @@
 #define PSEUDO_NODE_TYPE 2
 
 /* Define to build a tree containing all types of particles*/
-#define ALLMASK (1<<30)-1
+#define ALLMASK (1<<6)-1
 #define GASMASK (1)
 #define DMMASK (2)
 #define STARMASK (1<<4)
@@ -159,8 +159,8 @@ int
 force_get_father(int no, const ForceTree * tt);
 
 /*Internal API, exposed for tests*/
-int
-force_tree_create_nodes(const ForceTree tb, const ActiveParticles * act, int mask, DomainDecomp * ddecomp, const int HybridNuGrav);
+void
+force_tree_create_nodes(ForceTree * tree, const ActiveParticles * act, int mask, DomainDecomp * ddecomp, const int HybridNuGrav);
 
 ForceTree
 force_treeallocate(const int64_t maxnodes, const int64_t maxpart, const DomainDecomp * ddecomp, const int alloc_father);

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -212,13 +212,12 @@ static void do_tree_test(const int numpart, ForceTree tb, DomainDecomp * ddecomp
     start = MPI_Wtime();
     ActiveParticles Act = init_empty_active_particles(numpart);
     tb.mask = ALLMASK;
-    int nodes = force_tree_create_nodes(tb, &Act, ALLMASK, ddecomp, 0);
-    tb.numnodes = nodes;
-    assert_true(nodes < maxnode);
+    force_tree_create_nodes(&tb, &Act, ALLMASK, ddecomp, 0);
+    assert_true(tb.numnodes < maxnode);
     end = MPI_Wtime();
     double ms = (end - start)*1000;
-    printf("Number of nodes used: %d. Built tree in %.3g ms\n", nodes,ms);
-    int nrealnode = check_tree(&tb, nodes, numpart);
+    printf("Number of nodes used: %d. Built tree in %.3g ms\n", tb.numnodes,ms);
+    int nrealnode = check_tree(&tb, tb.numnodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
     force_update_node_parallel(&tb, ddecomp);
@@ -296,8 +295,7 @@ static void do_tree_mask_hmax_update_test(const int numpart, ForceTree * tb, Dom
     start = MPI_Wtime();
     ActiveParticles Act = init_empty_active_particles(numpart);
     tb->mask = GASMASK;
-    int nodes = force_tree_create_nodes(*tb, &Act, GASMASK, ddecomp, 0);
-    tb->numnodes = nodes;
+    force_tree_create_nodes(tb, &Act, GASMASK, ddecomp, 0);
     end = MPI_Wtime();
     double ms = (end - start)*1000;
     printf("Built gas tree in %.3g ms\n", ms);


### PR DESCRIPTION
Some attempts to debug a bus error on Frontera with ASTRID.

Here is the error:
[ 098868.09 ] Forces computed.
[ 098868.09 ] Hydro timesteps: Accel: 0 Soundspeed: 119 DivVel: 0 Accrete: 0 Neighbour: 0
[ 098868.09 ] Min grav timebin: 12 mintimebin 5
[ 098868.33 ] domain decomposition... (presently allocated=27148.1 MB)
[ 098868.33 ] Allocated 1611.5 MByte for top-level domain structure
[ 098868.33 ] Attempting new domain decomposition policy: TopNodeAllocFactor=0.5, UseglobalSort=1, SubSampleDistance=16 UsePreSort=0
[ 098868.61 ] use of 2014.33 MB of temporary storage for domain decomposition... (presently allocated=30758.4 MB)
[ 098869.57 ] local topTree size before appending=523545
[ 098869.58 ] Final local topTree size = 527961 per segment = 4.60345.
[ 098869.59 ] NTopLeaves= 461966  NTopNodes=527961 (space for 52804566)
[ 098869.78 ] Expected segment cost 8.74772e+07
[ 098869.79 ] Created 4096 segments in 1 rounds. Max leaf cost: 0.0612884
[ 098869.79 ] Largest particle load particle=1.03496
[ 098869.97 ] Using 46838951936 bytes for exchange.
[ 098869.98 ] iter = 0 Total particles in flight: 498212293 Largest togo: 3080471, toget 3080471
[ 098893.15 ] Domain decomposition done.
[ 098893.28 ] Begin Step 30603, Time: 0.443985 (dd000), Redshift: 1.25233, Nf = 00001231003380, Systemstep: 1.0255e-07, Dloga: 2.30977e-07, status:
[ 098893.28 ] TotNumPart: 0358304821645 SPH 0165130727733 BH 0012431532 STAR 0026786662380
[ 098893.28 ] Occupied:            0            1            2            3            4            5 dt
[ 098893.28 ]    bin=16  141633104244  161727028840          0            0   6558850255       423993 0.000473041
[ 098893.28 ]    bin=15  11869152288   4240479352            0            0  11285168896      1519271 0.000236521
[ 098893.28 ]    bin=14   7699711276    367341302            0            0   6080646671      8387877 0.00011826
[ 098893.28 ]    bin=13   2793150969     39547200            0            0   2767727052      1578779 5.91302e-05
[ 098893.28 ]  X bin=12    845624917       603306            0            0     94269506       409951 2.95651e-05
[ 098893.28 ]  X bin=11    232825691            0            0            0            0        86108 1.47825e-05
[ 098893.28 ]  X bin=10     49406587            0            0            0            0        20057 7.39127e-06
[ 098893.28 ]  X bin= 9      6865233            0            0            0            0         4747 3.69563e-06
[ 098893.28 ]  X bin= 8       802892            0            0            0            0          701 1.84782e-06
[ 098893.28 ]  X bin= 7        79610            0            0            0            0           47 9.23909e-07
[ 098893.28 ]  X bin= 6         3907            0            0            0            0            1 4.61954e-07
[ 098893.28 ]  X bin= 5          119            0            0            0            0            0 2.30977e-07
[ 098893.28 ]                -----------------------------------
[ 098893.28 ] Total:      1135608956       603306            0            0     94269506       521612  Sum:    1231003380 Gravity:       95204625
[ 098893.28 ] Tree construction for types: 1.
Killed by Signal 7
Abort(7) on node 2468 (rank 2468 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, 7) - process 2468
TACC:  MPI job exited with code: 7
TACC:  Shutdown complete. Exiting.