### PR TITLE
Sepbhmerger

### DIFF
--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -26,7 +26,7 @@ INCL = densitykernel.h \
 	metal_return.h \
 	winds.h \
 	timefac.h \
-	blackhole.h bhdynfric.h bhinfo.h \
+	blackhole.h bhdynfric.h bhinfo.h bhmerger.h \
 	gravity.h \
 	cosmology.h \
 	drift.h     \
@@ -94,7 +94,7 @@ GADGET_OBJS =  \
 	 gdbtools.o hci.o\
 	 fof.o fofpetaio.o petaio.o \
 	 domain.o exchange.o slotsmanager.o partmanager.o \
-	 blackhole.o bhinfo.o bhdynfric.o \
+	 blackhole.o bhinfo.o bhdynfric.o bhmerger.o \
 	 timebinmgr.o \
 	 run.o drift.o stats.o \
 	 timestep.o init.o checkpoint.o \

--- a/libgadget/bhinfo.c
+++ b/libgadget/bhinfo.c
@@ -6,6 +6,7 @@
 #include "blackhole.h"
 #include "bhdynfric.h"
 #include "bhinfo.h"
+#include "bhmerger.h"
 
 /* Structure needs to be packed to ensure disc write is the same on all architectures and the record size is correct. */
 struct __attribute__((__packed__)) BHinfo{
@@ -63,7 +64,7 @@ struct __attribute__((__packed__)) BHinfo{
 
 
 void
-collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *priv, struct BHDynFricPriv * dynpriv, FILE * FdBlackholeDetails)
+collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *priv, struct BHDynFricPriv * dynpriv, AccretedVariables * accrete, FILE * FdBlackholeDetails)
 {
     int i;
 
@@ -99,7 +100,7 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
         for(k=0; k < 3; k++) {
             info->MinPotPos[k] = BHP(p_i).MinPotPos[k] - PartManager->CurrentParticleOffset[k];
             info->BH_SurroundingGasVel[k] = priv->BH_SurroundingGasVel[PI][k];
-            info->BH_accreted_momentum[k] = priv->BH_accreted_momentum[PI][k];
+            info->BH_accreted_momentum[k] = accrete->BH_accreted_momentum[PI][k];
             info->BH_DragAccel[k] = BHP(p_i).DragAccel[k];
             info->BH_FullTreeGravAccel[k] = P[p_i].FullTreeGravAccel[k];
             info->Pos[k] = P[p_i].Pos[k] - PartManager->CurrentParticleOffset[k];
@@ -120,8 +121,10 @@ collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *
         }
 
         /****************************************************************************/
-        info->BH_accreted_BHMass = priv->BH_accreted_BHMass[PI];
-        info->BH_accreted_Mass = priv->BH_accreted_Mass[PI];
+        if(accrete->BH_accreted_Mass) {
+            info->BH_accreted_BHMass = accrete->BH_accreted_BHMass[PI];
+            info->BH_accreted_Mass = accrete->BH_accreted_Mass[PI];
+        }
         info->BH_FeedbackWeightSum = priv->BH_FeedbackWeightSum[PI];
 
         info->SPH_SwallowID = priv->SPH_SwallowID[PI];

--- a/libgadget/bhinfo.h
+++ b/libgadget/bhinfo.h
@@ -3,9 +3,10 @@
 
 #include "bhdynfric.h"
 #include "blackhole.h"
+#include "bhmerger.h"
 
 /* Writes a packed binary structure of detailed black hole information to disc*/
-void collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *priv, struct BHDynFricPriv * dynpriv, FILE * FdBlackholeDetails);
+void collect_BH_info(int * ActiveBlackHoles, int NumActiveBlackHoles, struct BHPriv *priv, struct BHDynFricPriv * dynpriv, AccretedVariables * accrete, FILE * FdBlackholeDetails);
 
 void write_blackhole_txt(FILE * FdBlackHoles, const struct UnitSystem units, const double atime);
 

--- a/libgadget/bhmerger.c
+++ b/libgadget/bhmerger.c
@@ -24,6 +24,9 @@ struct BHMergerPriv {
     /* Used in the real merger treewalk to store masses
      * for the BH Details file, and avoid roundoff.*/
     AccretedVariables * accreted;
+    /* Count of number of mergers 'expected' (actual mergers may be less than this
+     * if one of the merger targets is merging).*/
+    int mergercount;
 };
 
 #define BH_GET_PRIV(tw) ((struct BHMergerPriv *) (tw->priv))
@@ -148,6 +151,9 @@ blackhole_merger_ngbiter(TreeWalkQueryBHMerger * I,
         /* Swap in the new id only if the old one hasn't changed:
             * in principle an extension, but supported on at least clang >= 9, gcc >= 5 and icc >= 18.*/
         } while(!__atomic_compare_exchange_n(&(BHP(other).SwallowID), &readid, newswallowid, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+
+        #pragma omp atomic update
+        BH_GET_PRIV(lv->tw)->mergercount++;
     }
 }
 
@@ -364,6 +370,7 @@ blackhole_mergers(int * ActiveBlackHoles, const int64_t NumActiveBlackHoles, Dom
     priv->kf = kf;
     priv->SeedBHDynMass = SeedBHDynMass;
     priv->MergeGravBound = MergeGravBound;
+    priv->mergercount = 0;
     /*************************************************************************/
     TreeWalk tw_merger[1] = {{0}};
 
@@ -401,6 +408,11 @@ blackhole_mergers(int * ActiveBlackHoles, const int64_t NumActiveBlackHoles, Dom
     tw_real_merger->priv = priv;
     tw_real_merger->repeatdisallowed = 1;
 
+    /* If no BHs are expecting a merger, we don't need to do anything here.*/
+    if(!MPIU_Any(priv->mergercount > 0, MPI_COMM_WORLD)) {
+        force_tree_free(tree);
+        return 0;
+    }
     /* Ionization counters*/
     priv[0].N_BH_swallowed = ta_malloc("n_BH_swallowed", int64_t, omp_get_max_threads());
     memset(priv[0].N_BH_swallowed, 0, sizeof(int64_t) * omp_get_max_threads());

--- a/libgadget/bhmerger.c
+++ b/libgadget/bhmerger.c
@@ -280,8 +280,8 @@ blackhole_real_merger_ngbiter(TreeWalkQueryBHRealMerger * I,
 static int
 blackhole_real_merger_haswork(int n, TreeWalk * tw)
 {
-    /*Black hole not being swallowed*/
-    return (P[n].Type == 5) && (!P[n].Swallowed) && (BHP(n).SwallowID == (MyIDType) -1);
+    /*Black hole not being swallowed but in an encounter (we don't know with who)*/
+    return (P[n].Type == 5) && (!P[n].Swallowed) && (BHP(n).SwallowID == (MyIDType) -1) && BHP(n).encounter;
 }
 
 static void

--- a/libgadget/bhmerger.c
+++ b/libgadget/bhmerger.c
@@ -1,0 +1,440 @@
+#include <mpi.h>
+#include <string.h>
+#include <math.h>
+#include <omp.h>
+
+#include "treewalk.h"
+#include "slotsmanager.h"
+#include "gravity.h"
+#include "walltime.h"
+#include "density.h"
+#include "bhmerger.h"
+
+/*! \file blackhole.c
+ *  \brief routines for gas accretion onto black holes, and black hole mergers
+ */
+struct BHMergerPriv {
+    /* Time factors*/
+    double atime;
+    /* Counters*/
+    int64_t * N_BH_swallowed;
+    struct kick_factor_data * kf;
+    double SeedBHDynMass; /* The initial dynamic mass of BH particle */
+    int MergeGravBound;
+    /* Used in the real merger treewalk to store masses
+     * for the BH Details file, and avoid roundoff.*/
+    AccretedVariables * accreted;
+};
+
+#define BH_GET_PRIV(tw) ((struct BHMergerPriv *) (tw->priv))
+
+typedef struct {
+    TreeWalkQueryBase base;
+    MyFloat Hsml;
+    MyFloat Vel[3];
+    MyFloat Accel[3];
+    MyIDType ID;
+} TreeWalkQueryBHMerger;
+
+typedef struct {
+    TreeWalkResultBase base;
+    int encounter;
+    int alignment; //Ensure 64-bit alignment
+} TreeWalkResultBHMerger;
+
+/* check if two BHs are gravitationally bounded, input dv, da, dx in code unit */
+/* same as Bellovary2011, Tremmel2017 */
+static int
+check_grav_bound(double dx[3], double dv[3], double da[3], const double atime)
+{
+    int j;
+    double KE = 0;
+    double PE = 0;
+
+    for(j = 0; j < 3; j++){
+        KE += 0.5 * pow(dv[j], 2);
+        PE += da[j] * dx[j];
+    }
+
+    KE /= (atime * atime); /* convert to proper velocity */
+    PE /= atime; /* convert to proper unit */
+
+    /* The gravitationally bound condition is PE + KE < 0.
+     * Still merge if it is marginally bound so that we merge
+     * particles at zero distance and velocity from each other.*/
+    return (PE + KE <= 0);
+}
+
+static void
+blackhole_merger_ngbiter(TreeWalkQueryBHMerger * I,
+        TreeWalkResultBHMerger * O,
+        TreeWalkNgbIterBase * iter,
+        LocalTreeWalk * lv)
+{
+
+    if(iter->other == -1) {
+        O->encounter = 0;
+        iter->mask = BHMASK;
+        /* Search within Hsml*/
+        iter->Hsml = I->Hsml;
+        /* Search hsml asymmetrically (should be symmetric).*/
+        iter->symmetric = NGB_TREEFIND_ASYMMETRIC;
+        return;
+    }
+
+    int other = iter->other;
+    double r = iter->r;
+
+    /* Accretion / merger doesn't do self interaction */
+    if(P[other].ID == I->ID)
+        return;
+
+    if(P[other].Type != 5)
+        return;
+
+    /* we have a black hole merger. Now we use 2 times GravitationalSoftening as merging criteria,
+     * previously we used the SPH smoothing length. Both need to be satisfied.*/
+    if(r >= (2*FORCE_SOFTENING(0,1)/2.8))
+        return;
+
+    O->encounter = 1; // mark the event when two BHs encounter each other
+
+    int flag = 0; // the flag for BH merge
+
+    /* apply Grav Bound check only when Reposition is disabled, otherwise BHs would be repositioned to the same location but not merge */
+    if(BH_GET_PRIV(lv->tw)->MergeGravBound == 1){
+        double dx[3];
+        double dv[3];
+        double da[3];
+        int d;
+        MyFloat VelPred[3];
+        DM_VelPred(other, VelPred, BH_GET_PRIV(lv->tw)->kf);
+        for(d = 0; d < 3; d++){
+            dx[d] = NEAREST(I->base.Pos[d] - P[other].Pos[d], PartManager->BoxSize);
+            dv[d] = I->Vel[d] - VelPred[d];
+            /* we include long range PM force, short range force from the last long timestep and DF */
+            da[d] = (I->Accel[d] - P[other].FullTreeGravAccel[d] - P[other].GravPM[d] - BHP(other).DFAccel[d]);
+        }
+        flag = check_grav_bound(dx,dv,da, BH_GET_PRIV(lv->tw)->atime);
+        /*if(flag == 0)
+            message(0, "dx %g %g %g dv %g %g %g da %g %g %g\n",dx[0], dx[1], dx[2], dv[0], dv[1], dv[2], da[0], da[1], da[2]);*/
+    }
+    else {
+        flag = 1;
+    }
+
+    /* do the merge */
+    if(flag == 1)
+    {
+        O->encounter = 0;
+        MyIDType readid, newswallowid;
+
+        #pragma omp atomic read
+        readid = (BHP(other).SwallowID);
+
+        /* Here we mark the black hole as "ready to be swallowed" using the SwallowID.
+            * The actual swallowing is done in the feedback treewalk by setting Swallowed = 1
+            * and merging the masses.*/
+        do {
+            /* Generate the new ID from the old*/
+            if(readid != (MyIDType) -1 && readid < I->ID ) {
+                /* Already marked, prefer to be swallowed by a bigger ID */
+                newswallowid = I->ID;
+            } else if(readid == (MyIDType) -1 && P[other].ID < I->ID) {
+                /* Unmarked, the BH with bigger ID swallows */
+                newswallowid = I->ID;
+            }
+            else
+                break;
+        /* Swap in the new id only if the old one hasn't changed:
+            * in principle an extension, but supported on at least clang >= 9, gcc >= 5 and icc >= 18.*/
+        } while(!__atomic_compare_exchange_n(&(BHP(other).SwallowID), &readid, newswallowid, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    }
+}
+
+static void
+blackhole_merger_reduce(int place, TreeWalkResultBHMerger * remote, enum TreeWalkReduceMode mode, TreeWalk * tw)
+{
+    /* Set encounter to true if it is true on any remote*/
+    if (mode == 0 || BHP(place).encounter < remote->encounter) {
+        BHP(place).encounter = remote->encounter;
+    }
+    /* But set it to false if we are merging*/
+    if(BHP(place).SwallowID != (MyIDType) -1)
+        BHP(place).encounter = 0;
+
+}
+
+static void
+blackhole_merger_copy(int place, TreeWalkQueryBHMerger * I, TreeWalk * tw)
+{
+    int k;
+    for(k = 0; k < 3; k++)
+    {
+        I->Vel[k] = P[place].Vel[k];
+        I->Accel[k] = P[place].FullTreeGravAccel[k] + P[place].GravPM[k] + BHP(place).DFAccel[k];
+    }
+    I->Hsml = P[place].Hsml;
+    I->ID = P[place].ID;
+}
+
+typedef struct {
+    TreeWalkQueryBase base;
+    MyFloat Hsml;
+    MyFloat Mtrack;
+    MyIDType ID;
+} TreeWalkQueryBHRealMerger;
+
+typedef struct {
+    TreeWalkResultBase base;
+    MyFloat Mass; /* the accreted Mdyn */
+    MyFloat AccretedMomentum[3];
+    MyFloat BH_Mass;
+    MyFloat acMtrack; /* the accreted Mtrack */
+    int BH_CountProgs;
+    int alignment; /* Ensure alignment*/
+} TreeWalkResultBHRealMerger;
+
+/**
+ * perform blackhole swallow / merger;
+ */
+static void
+blackhole_real_merger_ngbiter(TreeWalkQueryBHRealMerger * I,
+        TreeWalkResultBHRealMerger * O,
+        TreeWalkNgbIterBase * iter,
+        LocalTreeWalk * lv)
+{
+    if(iter->other == -1) {
+        iter->mask = BHMASK;
+        iter->Hsml = I->Hsml;
+        iter->symmetric = NGB_TREEFIND_SYMMETRIC;
+        return;
+    }
+
+    int other = iter->other;
+    /* Exclude self interaction */
+
+    if(P[other].ID == I->ID) return;
+
+     /* we have a black hole merger! */
+    if(P[other].Type == 5 && BHP(other).SwallowID != (MyIDType) -1)
+    {
+        if(BHP(other).SwallowID != I->ID) return;
+
+        /* Swallow the particle*/
+        /* A note on Swallowed vs SwallowID: black hole particles which have been completely swallowed
+         * (ie, their mass has been added to another particle) have Swallowed = 1.
+         * These particles are ignored in future tree walks. We set Swallowed here so that this process is atomic:
+         * the total mass in the tree is always conserved.
+         *
+         * We also set SwallowID != -1 in the accretion treewalk. This marks the black hole as ready to be swallowed
+         * by something. It is actually swallowed only by the nearby black hole with the largest ID. In rare cases
+         * it may happen that the swallower is itself swallowed before swallowing the marked black hole. However,
+         * in practice the new swallower should also take the marked black hole next timestep.
+         */
+        BHP(other).SwallowTime = BH_GET_PRIV(lv->tw)->atime;
+        P[other].Swallowed = 1;
+        O->BH_CountProgs += BHP(other).CountProgs;
+        O->BH_Mass += (BHP(other).Mass);
+
+        if (BH_GET_PRIV(lv->tw)->SeedBHDynMass>0 && I->Mtrack>0){
+        /* Make sure that the final dynamic mass (I->Mass + O->Mass) = MAX(SeedDynMass, total_gas_accreted),
+           I->Mtrack only need to be updated when I->Mtrack < SeedBHDynMass, */
+            if(I->Mtrack < BH_GET_PRIV(lv->tw)->SeedBHDynMass && BHP(other).Mtrack < BH_GET_PRIV(lv->tw)->SeedBHDynMass){
+            /* I->Mass = SeedBHDynMass, total_gas_accreted = I->Mtrack + BHP(other).Mtrack */
+                O->acMtrack += BHP(other).Mtrack;
+                double delta_m = I->Mtrack + BHP(other).Mtrack - BH_GET_PRIV(lv->tw)->SeedBHDynMass;
+                O->Mass += DMAX(0,delta_m);
+            }
+            if(I->Mtrack >= BH_GET_PRIV(lv->tw)->SeedBHDynMass && BHP(other).Mtrack < BH_GET_PRIV(lv->tw)->SeedBHDynMass){
+            /* I->Mass = gas_accreted, total_gas_accreted = I->Mass + BHP(other).Mtrack */
+                O->Mass += BHP(other).Mtrack;
+            }
+            if(I->Mtrack < BH_GET_PRIV(lv->tw)->SeedBHDynMass && BHP(other).Mtrack >= BH_GET_PRIV(lv->tw)->SeedBHDynMass){
+            /* I->Mass = SeedBHDynMass, P[other].Mass = gas_accreted,
+               total_gas_accreted = I->track + P[other].Mass */
+                O->acMtrack += BHP(other).Mtrack;
+                O->Mass += (P[other].Mass + I->Mtrack - BH_GET_PRIV(lv->tw)->SeedBHDynMass);
+            }
+            if(I->Mtrack >= BH_GET_PRIV(lv->tw)->SeedBHDynMass && BHP(other).Mtrack >= BH_GET_PRIV(lv->tw)->SeedBHDynMass){
+            /* trivial case, total_gas_accreted = I->Mass + P[other].Mass */
+                O->Mass += P[other].Mass;
+            }
+        }
+        else{
+            O->Mass += P[other].Mass;
+        }
+        MyFloat VelPred[3];
+        DM_VelPred(other, VelPred, BH_GET_PRIV(lv->tw)->kf);
+        /* Conserve momentum during accretion*/
+        int d;
+        for(d = 0; d < 3; d++)
+            O->AccretedMomentum[d] += (P[other].Mass * VelPred[d]);
+
+        if(BHP(other).SwallowTime < BH_GET_PRIV(lv->tw)->atime)
+            endrun(2, "Encountered BH %i swallowed at earlier time %g\n", other, BHP(other).SwallowTime);
+
+        int tid = omp_get_thread_num();
+        BH_GET_PRIV(lv->tw)->N_BH_swallowed[tid]++;
+
+    }
+}
+
+static int
+blackhole_real_merger_haswork(int n, TreeWalk * tw)
+{
+    /*Black hole not being swallowed*/
+    return (P[n].Type == 5) && (!P[n].Swallowed) && (BHP(n).SwallowID == (MyIDType) -1);
+}
+
+static void
+blackhole_real_merger_copy(int i, TreeWalkQueryBHRealMerger * I, TreeWalk * tw)
+{
+    I->Hsml = P[i].Hsml;
+    I->ID = P[i].ID;
+    I->Mtrack = BHP(i).Mtrack;
+}
+
+
+static void
+blackhole_real_merger_reduce(int place, TreeWalkResultBHRealMerger * remote, enum TreeWalkReduceMode mode, TreeWalk * tw)
+{
+    int k;
+    int PI = P[place].PI;
+
+    TREEWALK_REDUCE(BH_GET_PRIV(tw)->accreted->BH_accreted_Mass[PI], remote->Mass);
+    TREEWALK_REDUCE(BH_GET_PRIV(tw)->accreted->BH_accreted_BHMass[PI], remote->BH_Mass);
+    TREEWALK_REDUCE(BH_GET_PRIV(tw)->accreted->BH_accreted_Mtrack[PI], remote->acMtrack);
+    for(k = 0; k < 3; k++) {
+        TREEWALK_REDUCE(BH_GET_PRIV(tw)->accreted->BH_accreted_momentum[PI][k], remote->AccretedMomentum[k]);
+    }
+
+    TREEWALK_REDUCE(BHP(place).CountProgs, remote->BH_CountProgs);
+}
+
+static void
+bh_update_from_accreted(int n, AccretedVariables * accreted, const double SeedBHDynMass)
+{
+    const int PI = P[n].PI;
+    if(accreted->BH_accreted_BHMass[PI] > 0){
+       BHP(n).Mass += accreted->BH_accreted_BHMass[PI];
+    }
+    if(accreted->BH_accreted_Mass[PI] > 0)
+    {
+        /* velocity feedback due to accretion; momentum conservation.
+         * This does nothing with repositioning on.*/
+        const MyFloat accmass = accreted->BH_accreted_Mass[PI];
+        int k;
+        /* Need to add the momentum from Mtrack as well*/
+        for(k = 0; k < 3; k++)
+            P[n].Vel[k] = (P[n].Vel[k] * P[n].Mass + accreted->BH_accreted_momentum[PI][k]) /
+                    (P[n].Mass + accmass + accreted->BH_accreted_Mtrack[PI]);
+        P[n].Mass += accmass;
+    }
+
+    if(SeedBHDynMass > 0){
+        if(accreted->BH_accreted_Mtrack[PI] > 0){
+            BHP(n).Mtrack += accreted->BH_accreted_Mtrack[PI];
+        }
+        if(BHP(n).Mtrack > SeedBHDynMass){
+            BHP(n).Mtrack = SeedBHDynMass; /*cap Mtrack at SeedBHDynMass*/
+        }
+    }
+}
+
+static void
+blackhole_real_merger_postprocess(int n, TreeWalk * tw)
+{
+    bh_update_from_accreted(n, BH_GET_PRIV(tw)->accreted, BH_GET_PRIV(tw)->SeedBHDynMass);
+}
+
+int64_t
+blackhole_mergers(int * ActiveBlackHoles, const int64_t NumActiveBlackHoles, DomainDecomp * ddecomp, struct kick_factor_data *kf, const double atime, const double SeedBHDynMass, const int MergeGravBound, AccretedVariables * accrete)
+{
+    /* Small tree containing only BHs */
+    ForceTree tree[1] = {0};
+
+    struct BHMergerPriv priv[1] = {0};
+    priv->accreted = accrete;
+    bh_alloc_accreted(priv->accreted);
+
+    force_tree_rebuild_mask(tree, ddecomp, BHMASK, NULL);
+    /* Symmetric tree walk needs hmax values*/
+    force_tree_calc_moments(tree, ddecomp);
+    walltime_measure("/BH/BuildMerger");
+
+    priv->atime = atime;
+    priv->kf = kf;
+    priv->SeedBHDynMass = SeedBHDynMass;
+    priv->MergeGravBound = MergeGravBound;
+    /*************************************************************************/
+    TreeWalk tw_merger[1] = {{0}};
+
+    tw_merger->ev_label = "BH_MERGER";
+    tw_merger->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
+    tw_merger->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBase);
+    tw_merger->ngbiter = (TreeWalkNgbIterFunction) blackhole_merger_ngbiter;
+    tw_merger->haswork = NULL;
+    tw_merger->postprocess = NULL;
+    tw_merger->preprocess = NULL;
+    tw_merger->fill = (TreeWalkFillQueryFunction) blackhole_merger_copy;
+    tw_merger->reduce = (TreeWalkReduceResultFunction) blackhole_merger_reduce;
+    tw_merger->query_type_elsize = sizeof(TreeWalkQueryBHMerger);
+    tw_merger->result_type_elsize = sizeof(TreeWalkResultBHMerger);
+    tw_merger->tree = tree;
+    tw_merger->priv = priv;
+
+    treewalk_run(tw_merger, ActiveBlackHoles, NumActiveBlackHoles);
+
+    TreeWalk tw_real_merger[1] = {{0}};
+    tw_real_merger->ev_label = "BH_REAL_MERGER";
+    tw_real_merger->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
+    tw_real_merger->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBase);
+    tw_real_merger->ngbiter = (TreeWalkNgbIterFunction) blackhole_real_merger_ngbiter;
+    tw_real_merger->haswork = blackhole_real_merger_haswork;
+    tw_real_merger->fill = (TreeWalkFillQueryFunction) blackhole_real_merger_copy;
+    tw_real_merger->postprocess = blackhole_real_merger_postprocess;
+    tw_real_merger->reduce = (TreeWalkReduceResultFunction) blackhole_real_merger_reduce;
+    tw_real_merger->query_type_elsize = sizeof(TreeWalkQueryBHRealMerger);
+    tw_real_merger->result_type_elsize = sizeof(TreeWalkResultBHRealMerger);
+    tw_real_merger->tree = tree;
+    tw_real_merger->priv = priv;
+    tw_real_merger->repeatdisallowed = 1;
+
+    /* Ionization counters*/
+    priv[0].N_BH_swallowed = ta_malloc("n_BH_swallowed", int64_t, omp_get_max_threads());
+    memset(priv[0].N_BH_swallowed, 0, sizeof(int64_t) * omp_get_max_threads());
+
+    treewalk_run(tw_real_merger, ActiveBlackHoles, NumActiveBlackHoles);
+
+    int i;
+    int64_t Ntot_BH_swallowed;
+    int64_t N_BH_swallowed = 0;
+    for(i = 0; i < omp_get_max_threads(); i++) {
+        N_BH_swallowed += priv[0].N_BH_swallowed[i];
+    }
+    ta_free(priv[0].N_BH_swallowed);
+
+    force_tree_free(tree);
+    MPI_Reduce(&N_BH_swallowed, &Ntot_BH_swallowed, 1, MPI_INT64, MPI_SUM, 0, MPI_COMM_WORLD);
+    return Ntot_BH_swallowed;
+}
+
+
+void
+bh_alloc_accreted(AccretedVariables * accrete)
+{
+    accrete->BH_accreted_Mass = (MyFloat *) mymalloc("BH_accretedmass", SlotsManager->info[5].size * sizeof(MyFloat));
+    accrete->BH_accreted_BHMass = (MyFloat *) mymalloc("BH_accreted_BHMass", SlotsManager->info[5].size * sizeof(MyFloat));
+    accrete->BH_accreted_Mtrack = (MyFloat *) mymalloc("BH_accreted_Mtrack", SlotsManager->info[5].size * sizeof(MyFloat));
+    accrete->BH_accreted_momentum = (MyFloat (*) [3]) mymalloc("BH_accretemom", 3* SlotsManager->info[5].size * sizeof(accrete->BH_accreted_momentum[0]));
+}
+
+void
+bh_free_accreted(AccretedVariables * accrete)
+{
+    myfree(accrete->BH_accreted_momentum);
+    myfree(accrete->BH_accreted_Mtrack);
+    myfree(accrete->BH_accreted_BHMass);
+    myfree(accrete->BH_accreted_Mass);
+}

--- a/libgadget/bhmerger.c
+++ b/libgadget/bhmerger.c
@@ -126,7 +126,6 @@ blackhole_merger_ngbiter(TreeWalkQueryBHMerger * I,
     /* do the merge */
     if(flag == 1)
     {
-        O->encounter = 0;
         MyIDType readid, newswallowid;
 
         #pragma omp atomic read
@@ -159,10 +158,6 @@ blackhole_merger_reduce(int place, TreeWalkResultBHMerger * remote, enum TreeWal
     if (mode == 0 || BHP(place).encounter < remote->encounter) {
         BHP(place).encounter = remote->encounter;
     }
-    /* But set it to false if we are merging*/
-    if(BHP(place).SwallowID != (MyIDType) -1)
-        BHP(place).encounter = 0;
-
 }
 
 static void
@@ -233,6 +228,8 @@ blackhole_real_merger_ngbiter(TreeWalkQueryBHRealMerger * I,
          * in practice the new swallower should also take the marked black hole next timestep.
          */
         BHP(other).SwallowTime = BH_GET_PRIV(lv->tw)->atime;
+        /* Set encounter to zero when we merge*/
+        BHP(other).encounter = 0;
         P[other].Swallowed = 1;
         O->BH_CountProgs += BHP(other).CountProgs;
         O->BH_Mass += (BHP(other).Mass);

--- a/libgadget/bhmerger.h
+++ b/libgadget/bhmerger.h
@@ -1,0 +1,34 @@
+#ifndef BH_MERGER
+#define BH_MERGER
+
+#include "domain.h"
+
+typedef struct {
+    /* These are temporaries used when accreting particles to store masses
+     * for the BH Details file, and avoid roundoff.*/
+    MyFloat * BH_accreted_Mass;
+    MyFloat * BH_accreted_BHMass;
+    MyFloat * BH_accreted_Mtrack;
+    MyFloat (*BH_accreted_momentum)[3];
+} AccretedVariables;
+
+/* Allocate and free the accreted variables*/
+void
+bh_alloc_accreted(AccretedVariables * accrete);
+void
+bh_free_accreted(AccretedVariables * accrete);
+
+/* Merge two nearby black holes. Inactive BHs are merged into active ones. No inactive BHs increase their mass.
+ * Arguments: ActiveBlackHoles - candidates for accreting another black hole.
+              NumActiveBlackHoles - number of active black holes.
+              ddecomp - domain decomposition for building a BH tree.
+              kf - velocity prediction data.
+              atime - current time.
+              SeedBHDynMass - initial BH dynamic mass. Useful for keeping track of the mergers.
+              MergeGravBound - whether to check for the BH being gravitationally bound. Note this should be 0 if BH repositioning is on.
+    Returns: the number of BH mergers.*/
+int64_t
+blackhole_mergers(int * ActiveBlackHoles, const int64_t NumActiveBlackHoles, DomainDecomp * ddecomp, struct kick_factor_data *kf, const double atime, const double SeedBHDynMass, const int MergeGravBound, AccretedVariables * BHaccrete);
+
+
+#endif

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -215,15 +215,8 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
      * accretion uses: gas + black holes (to flag mergers).
      * feedback uses: gas + black holes (to flag mergers).
      */
-    if(tree->tree_allocated_flag && (tree->mask & GASMASK) != GASMASK)
-        force_tree_free(tree);
-    if(!tree->tree_allocated_flag)
-    {
-        message(0, "Building tree in blackhole\n");
-        int treemask = GASMASK;
-        force_tree_rebuild_mask(tree, ddecomp, treemask, NULL);
-        walltime_measure("/BH/Build");
-    }
+    if(!tree->tree_allocated_flag || !(tree->mask & GASMASK))
+        endrun(5, "blackhole called with bad tree allocated %d mask %d\n", tree->tree_allocated_flag, tree->mask);
 
     struct kick_factor_data kf;
     init_kick_factor_data(&kf, times, CP);

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -19,7 +19,6 @@ struct BHPriv {
 
     /* These are temporaries used in the feedback treewalk.*/
     MyFloat * BH_accreted_Mass;
-    MyFloat * BH_accreted_BHMass;
     MyFloat * BH_accreted_Mtrack;
 
     /* This is a temporary computed in the accretion treewalk and used

--- a/libgadget/cooling_qso_lightup.c
+++ b/libgadget/cooling_qso_lightup.c
@@ -523,7 +523,7 @@ ionize_all_part(int qso_ind, int * qso_cand, struct QSOPriv priv, ForceTree * tr
  * Keeps adding new quasars until need_more_quasars() returns 0.
  */
 static void
-turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
+turn_on_quasars(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
 {
     int ncand = 0;
     int * qso_cand = NULL;
@@ -573,8 +573,6 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
         return;
     }
     message(0, "HeII: Built quasar candidate list from %d quasars\n", ncand_tot);
-    ForceTree gasTree = {0};
-    force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, NULL);
     walltime_measure("/HeIII/Build");
     for(iteration = 0; curionfrac < desired_ion_frac; iteration++){
         /* Get a new quasar*/
@@ -588,7 +586,7 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
             break;
         }
 
-        int64_t n_ionized = ionize_all_part(new_qso, qso_cand, priv, &gasTree);
+        int64_t n_ionized = ionize_all_part(new_qso, qso_cand, priv, gasTree);
         int64_t tot_qso_ionized = 0;
         /* Check that the ionization fraction changed*/
         MPI_Allreduce(&n_ionized, &tot_qso_ionized, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
@@ -630,7 +628,6 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
             ncand--;
         }
     }
-    force_tree_free(&gasTree);
     if(qso_cand) {
         myfree(qso_cand);
     }
@@ -644,7 +641,7 @@ turn_on_quasars(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology
 
 /* Starts reionization by selecting the first halo and flagging all particles in the first HeIII bubble*/
 void
-do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
+do_heiii_reionization(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium)
 {
     if(!QSOLightupParams.QSOLightupOn)
         return;
@@ -655,9 +652,12 @@ do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cos
     if(atime > He_zz[Nreionhist-1])
         return;
 
+    if(!gasTree->tree_allocated_flag || !(gasTree->mask & GASMASK))
+        endrun(5, "helium_reion called with bad tree allocated %d mask %d\n", gasTree->tree_allocated_flag, gasTree->mask);
+
     walltime_measure("/Misc");
     //message(0, "HeII: Reionization initiated.\n");
-    turn_on_quasars(atime, fof, ddecomp, CP, uu_in_cgs, FdHelium);
+    turn_on_quasars(atime, fof, gasTree, CP, uu_in_cgs, FdHelium);
 }
 
 int

--- a/libgadget/cooling_qso_lightup.h
+++ b/libgadget/cooling_qso_lightup.h
@@ -11,7 +11,7 @@ void set_qso_lightup_params(ParameterSet * ps);
 void init_qso_lightup(char * reion_hist_file);
 
 /* Starts reionization by selecting the first halo and flagging all particles in the first HeIII bubble*/
-void do_heiii_reionization(double atime, FOFGroups * fof, DomainDecomp * ddecomp, Cosmology * CP, double uu_in_cgs, FILE * FdHelium);
+void do_heiii_reionization(double atime, FOFGroups * fof, ForceTree * gasTree, Cosmology * CP, double uu_in_cgs, FILE * FdHelium);
 
 /* Get the long mean free path photon heating that applies to not-yet-ionized particles*/
 double get_long_mean_free_path_heating(double redshift);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -922,9 +922,11 @@ add_particle_moment_to_node(struct NODE * pnode, const struct particle_data * co
     for(k=0; k<3; k++)
         pnode->mom.cofm[k] += (part->Mass * part->Pos[k]);
 
-    /* We do not add active particles to the hmax here because we are building the tree in density().
-     * The active particles will have hsml updated anyway, often to a smaller value*/
-    if(part->Type == 0 && !is_timebin_active(part->TimeBinHydro, part->Ti_drift))
+    /* We do not add active gas particles to the hmax here because we are building the tree in density().
+     * The active particles will have hsml updated anyway, often to a smaller value and will be included in force_update_hmax.
+     * Black holes include unconditionally.*/
+    if((part->Type == 0 && !is_timebin_active(part->TimeBinHydro, part->Ti_drift))
+        || part->Type == 5)
     {
         int j;
         /* Maximal distance any of the member particles peek out from the side of the node.

--- a/libgadget/metal_return.c
+++ b/libgadget/metal_return.c
@@ -517,7 +517,7 @@ metal_return_priv_free(struct MetalReturnPriv * priv)
 
 /*! This function is the driver routine for the calculation of metal return. */
 void
-metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmology * CP, const double atime, const double AvgGasMass)
+metal_return(const ActiveParticles * act, ForceTree * gasTree, Cosmology * CP, const double atime, const double AvgGasMass)
 {
     /* Do nothing if no stars yet*/
     int64_t totstar;
@@ -545,14 +545,10 @@ metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmolog
         return;
     }
 
-    ForceTree gasTree = {0};
-    /* Just gas, no moments*/
-    force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, NULL);
-    walltime_measure("/SPH/Metals/Build");
-
-
+    if(!gasTree->tree_allocated_flag || !(gasTree->mask & GASMASK))
+        endrun(5, "metal_return called with bad tree allocated %d mask %d\n", gasTree->tree_allocated_flag, gasTree->mask);
     /* Compute total number of weights around each star for actively returning stars*/
-    stellar_density(act, priv->StarVolumeSPH, priv->MassReturn, &gasTree);
+    stellar_density(act, priv->StarVolumeSPH, priv->MassReturn, gasTree);
 
     /* Do the metal return*/
     TreeWalk tw[1] = {{0}};
@@ -568,14 +564,13 @@ metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmolog
     tw->query_type_elsize = sizeof(TreeWalkQueryMetals);
     tw->result_type_elsize = sizeof(TreeWalkResultMetals);
     tw->repeatdisallowed = 1;
-    tw->tree = &gasTree;
+    tw->tree = gasTree;
     tw->priv = priv;
 
     priv->spin = init_spinlocks(SlotsManager->info[0].size);
     treewalk_run(tw, act->ActiveParticle, act->NumActiveParticle);
     free_spinlocks(priv->spin);
 
-    force_tree_free(&gasTree);
     metal_return_priv_free(priv);
 
     /* collect some timing information */

--- a/libgadget/metal_return.h
+++ b/libgadget/metal_return.h
@@ -39,7 +39,7 @@ struct MetalReturnPriv {
     struct SpinLocks * spin;
 };
 
-void metal_return(const ActiveParticles * act, DomainDecomp * const ddecomp, Cosmology * CP, const double atime, const double AvgGasMass);
+void metal_return(const ActiveParticles * act, ForceTree * gasTree, Cosmology * CP, const double atime, const double AvgGasMass);
 
 void set_metal_return_params(ParameterSet * ps);
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -586,10 +586,13 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
          */
         if(GasEnabled)
         {
+            if(!gasTree.tree_allocated_flag)
+                force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, NULL);
+
             /* Do this before sfr and bh so the gas hsml always contains DesNumNgb neighbours.*/
             if(All.MetalReturnOn) {
                 double AvgGasMass = All.CP.OmegaBaryon * 3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.CP.GravInternal) * pow(PartManager->BoxSize, 3) / header->NTotalInit[0];
-                metal_return(&Act, ddecomp, &All.CP, atime, AvgGasMass);
+                metal_return(&Act, &gasTree, &All.CP, atime, AvgGasMass);
             }
 
             /* this will find new black hole seed halos.
@@ -610,7 +613,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
 
                 if(during_helium_reionization(1/atime - 1)) {
                     /* Helium reionization by switching on quasar bubbles*/
-                    do_heiii_reionization(atime, &fof, ddecomp, &All.CP, units.UnitInternalEnergy_in_cgs, fds.FdHelium);
+                    do_heiii_reionization(atime, &fof, &gasTree, &All.CP, units.UnitInternalEnergy_in_cgs, fds.FdHelium);
                 }
 #ifdef EXCUR_REION
                 //excursion set reionisation

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -449,9 +449,8 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
         {
             /* Just gas. Note that the density() code computes hsml for black holes and gas.
              * However, hsml is the length that encloses NumNgb gas particles, so for density the tree needs only gas.
-             * We add BHs so we can re-use the tree for mergers.
              * No moments (yet). We do need hmax for hydro, but we need to compute hsml first.*/
-            force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK | BHMASK, All.OutputDir);
+            force_tree_rebuild_mask(&gasTree, ddecomp, GASMASK, All.OutputDir);
             walltime_measure("/SPH/Build");
 
             /*Predicted SPH data.*/


### PR DESCRIPTION
An addition to separate tree. Split the BH mergers into a separate file, using a separate treewalk.

Make a single tree containing only gas particles at the start of the timestep, and reuse it throughout the timestep. It no longer contains black holes. This lets the density and hydro code be a little faster again, and it avoids the need to rebuild the gas tree at all.

Splitting the BH mergers into a separate treewalk ensures that accretion is handled before mergers. This is mostly because to make the code faster. There are edge cases where the code behaviour depends on whether the gas or BH accretes first, but I have thought about it and believe that these only occur because we do not conserve momentum on accretion until bhbugfixes is merged.