### PR TITLE
Bhbugfixes

### DIFF
--- a/examples/dynfric/paramfile.gadget
+++ b/examples/dynfric/paramfile.gadget
@@ -1,0 +1,91 @@
+#  Relevant files
+InitCondFile = ICS/IC
+OutputDir = output
+TreeCoolFile = ../TREECOOL_fg_june11
+OutputList = 0.1,0.1111111, 0.125, 0.142857, 0.16666, 0.181818,0.2,0.222222, 0.25, 0.285714, 0.3333333,0.4
+#OutputList =  0.2, 0.222222, 0.25, 0.285714, 0.333333 
+#OutputList = 0.333333,0.4
+Nmesh = 1100
+# CPU time -limit
+	
+#TimeLimitCPU = 43000 #= 8 hours
+TimeLimitCPU = 230000
+
+# Code options
+#  Characteristics of run
+TimeMax = 0.5
+
+Omega0 = 0.2865      # Total matter density  (at z=0)
+OmegaLambda = 0.713413      # Cosmological constant (at z=0)
+OmegaBaryon = 0.04628     # Baryon density        (at z=0)
+HubbleParam = 0.6932      # Hubble paramater (may be used for power spec parameterization)
+
+CoolingOn = 1
+StarformationOn = 1
+BlackHoleOn = 1
+HydroOn = 1
+DensityIndependentSphOn = 1
+StarformationCriterion = density,h2
+RadiationOn = 1
+MassiveNuLinRespOn = 0
+WindOn = 1
+MetalCoolFile = ../cooling_metal_UVB
+
+# Accuracy of time integration
+MaxSizeTimestep = 0.1
+MinSizeTimestep = 0.00
+
+SnapshotWithFOF = 1
+FOFHaloLinkingLength = 0.2
+FOFHaloMinLength = 32
+
+#  Further parameters of SPH
+DensityKernelType = quintic
+
+DensityContrastLimit = 100   # max contrast for hydro force calculation
+DensityResolutionEta = 1.0  # for Cubic spline 1.0 = 33
+MaxNumNgbDeviation = 2
+ArtBulkViscConst = 0.75
+InitGasTemp = 580.0        # always ignored if set to 0 
+MinGasTemp = 5.0
+
+
+# Softening lengths
+
+MinGasHsmlFractional = 0.01
+
+#----------------------BH Stuff-------------------------
+BlackHoleFeedbackFactor = 0.05
+BlackHoleFeedbackRadius = 0.
+BlackHoleFeedbackRadiusMaxPhys = 0.
+BlackHoleFeedbackMethod = spline | mass
+SeedBlackHoleMass = 5.0e-5
+BlackHoleAccretionFactor = 100.0
+BlackHoleNgbFactor = 2.0
+BlackHoleEddingtonFactor = 3.0
+MetalReturnOn = 1
+MinFoFMassForNewSeed = 1
+TimeBetweenSeedingSearch = 1.03
+
+WriteBlackHoleDetails = 1
+BH_DynFrictionMethod = 2  # no DM/Star
+BH_DRAG = 1  # No drag
+BH_DFBoostFactor = 1
+SeedBHDynMass = 2e-3
+BH_DFbmax = 10.
+BlackHoleRepositionEnabled = 0 # No reposition
+MergeGravBound = 1 #  bound check
+#----------------------SFR Stuff-------------------------
+
+CritPhysDensity = 0       #  critical physical density for star formation in
+#  hydrogen number density in cm^(-3)
+CritOverDensity = 57.7   #  overdensity threshold value
+
+WindModel = ofjt10,decouple
+WindEfficiency = 2.0
+WindEnergyFraction = 1.0
+WindSigma0 = 353.0 #km/s
+WindSpeedFactor = 3.7
+
+WindFreeTravelLength = 20
+WindFreeTravelDensFac = 0.1

--- a/examples/dynfric/paramfile.genic
+++ b/examples/dynfric/paramfile.genic
@@ -1,0 +1,31 @@
+OutputDir =  ICS
+FileBase = IC              # Base-filename of output files
+
+Ngrid = 550 # Size of cubic grid on which to create particles.
+
+BoxSize = 25000   # Periodic box size of simulation
+
+Omega0 = 0.2865      # Total matter density  (at z=0)
+OmegaLambda = 0.713413      # Cosmological constant (at z=0)
+OmegaBaryon = 0.04628     # Baryon density        (at z=0)
+ProduceGas = 1         # 1 = Produce gas  0 = no gas, just DM.
+HubbleParam = 0.6932      # Hubble paramater (may be used for power spec parameterization)
+
+Redshift = 99        # Starting redshift
+
+DifferentTransferFunctions = 1
+#Tabulated output in Mpc/h units.
+FileWithInputSpectrum = ../class_pk_99.dat  # filename of tabulated input spectrum (if used)
+FileWithTransferFunction = ../class_tk_99.dat  # filename of transfer functions for different species
+
+                                    # Note: This can be chosen different from UnitLength_in_cm
+# Only used by the CLASS script.
+PrimordialAmp = 2.215e-9
+# May be used to tilt the primordial index. Only used if WhichSpectum != 2
+PrimordialIndex  = 0.96
+
+Seed = 738    #  seed for IC-generator
+
+UnitLength_in_cm = 3.085678e21   # defines length unit of output (in cm/h)
+UnitMass_in_g = 1.989e43      # defines mass unit of output (in g/cm)
+UnitVelocity_in_cm_per_s = 1e5 # defines velocity unit of output (in cm/sec)            

--- a/examples/dynfric/run.sh
+++ b/examples/dynfric/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export OMP_NUM_THREADS=8
+
+ROOT=../../
+mpirun -np 4 $ROOT/genic/MP-GenIC paramfile.genic || exit 1
+mpirun -np 4 $ROOT/gadget/MP-Gadget paramfile.gadget || exit 1

--- a/examples/hydro/paramfile.gadget
+++ b/examples/hydro/paramfile.gadget
@@ -6,7 +6,7 @@ TreeCoolFile = ../TREECOOL_fg_june11
 OutputList = 0.05,0.1,0.11, 0.15, 0.2,0.299,0.3,0.33333,0.4,0.5,0.66666,0.75,0.9
 
 # CPU time -limit
-	
+
 TimeLimitCPU = 43000 #= 8 hours
 SplitGravityTimestepsOn = 1
 
@@ -53,6 +53,7 @@ BlackHoleEddingtonFactor = 3.0
 
 MinFoFMassForNewSeed = 1
 TimeBetweenSeedingSearch 1.03
+WriteBlackHoleDetails = 1
 
 #----------------------SFR Stuff-------------------------
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -621,7 +621,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
                 if(readid != 0 && readid < I->ID ) {
                     /* Already marked, prefer to be swallowed by a bigger ID */
                     newswallowid = I->ID + 1;
-                } else if(readid == 0 && P[other].ID < I->ID) {
+                } else if(readid == 0 && (P[other].ID < I->ID || !is_timebin_active(P[other].TimeBinHydro, P[other].Ti_drift))) {
                     /* Unmarked, the BH with bigger ID swallows This avoids two BHs trying to swallow each other.
                      * (in which case neither would merge). If only one is active, only one can swallow.*/
                     newswallowid = I->ID + 1;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -711,7 +711,13 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
         }
     }
 
-    BHP(place).encounter = remote->encounter;
+    /* Set encounter to true if it is true on any remote*/
+    if (mode == 0 || BHP(place).encounter < remote->encounter) {
+        BHP(place).encounter = remote->encounter;
+    }
+    /* But set it to false if we are merging*/
+    if(BHP(place).SwallowID != (MyIDType) -1)
+        BHP(place).encounter = 0;
 
     if (mode == 0 || BHP(place).minTimeBin > remote->BH_minTimeBin) {
         BHP(place).minTimeBin = remote->BH_minTimeBin;

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -891,8 +891,9 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
             if(I->Mtrack < blackhole_params.SeedBHDynMass && BHP(other).Mtrack >= blackhole_params.SeedBHDynMass){
             /* I->Mass = SeedBHDynMass, P[other].Mass = gas_accreted,
                total_gas_accreted = I->track + P[other].Mass */
+                /* Add the 'true' other BH mass to the acMtrack. It will be turned into dynamical mass in post-processing,
+                 * when everything is summed.*/
                 O->acMtrack += BHP(other).Mtrack;
-                O->Mass += (P[other].Mass + I->Mtrack - blackhole_params.SeedBHDynMass);
             }
             if(I->Mtrack >= blackhole_params.SeedBHDynMass && BHP(other).Mtrack >= blackhole_params.SeedBHDynMass){
             /* trivial case, total_gas_accreted = I->Mass + P[other].Mass */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -905,8 +905,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
     /* perform thermal or kinetic feedback into non-swallowed particles. */
     if(P[other].Type == 0 && SPH_SwallowID[P[other].PI] == 0 &&
-        (r2 < iter->feedback_kernel.HH && P[other].Mass > 0) &&
-            (I->FeedbackWeightSum > 0))
+        (r2 < iter->feedback_kernel.HH))
     {
         double u = r * iter->feedback_kernel.Hinv;
         double wk = 1.0;
@@ -921,7 +920,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
             wk = density_kernel_wk(&iter->feedback_kernel, u);
 
         /* thermal feedback */
-        if(I->FeedbackEnergy > 0 && I->FdbkChannel == 0){
+        if(I->FeedbackWeightSum > 0 && I->FeedbackEnergy > 0 && I->FdbkChannel == 0 && P[other].Mass > 0){
             const double injected_BH = I->FeedbackEnergy * mass_j * wk / I->FeedbackWeightSum;
             /* Set a flag for star-forming particles:
                 * we want these to cool to the EEQOS via

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -529,7 +529,8 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         }
         iter->base.mask = GASMASK + STARMASK + BHMASK;
         iter->base.Hsml = I->Hsml;
-        iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
+        /* Symmetric for the BH mergers*/
+        iter->base.symmetric = NGB_TREEFIND_SYMMETRIC;
 
         density_kernel_init(&iter->accretion_kernel, I->Hsml, GetDensityKernelType());
         density_kernel_init(&iter->feedback_kernel, I->Hsml, GetDensityKernelType());

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -345,7 +345,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
 
     priv->BH_accreted_Mass = (MyFloat *) mymalloc("BH_accretedmass", SlotsManager->info[5].size * sizeof(MyFloat));
     priv->BH_accreted_BHMass = (MyFloat *) mymalloc("BH_accreted_BHMass", SlotsManager->info[5].size * sizeof(MyFloat));
-    priv->BH_accreted_Mtrack = (MyFloat *) mymalloc("BH_accreted_Mtrack", SlotsManager->info[5].size * sizeof(MyFloat));
     priv->BH_accreted_momentum = (MyFloat (*) [3]) mymalloc("BH_accretemom", 3* SlotsManager->info[5].size * sizeof(priv->BH_accreted_momentum[0]));
 
     /* Now do the swallowing of particles and dump feedback energy */
@@ -373,7 +372,6 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     }
 
     myfree(priv->BH_accreted_momentum);
-    myfree(priv->BH_accreted_Mtrack);
     myfree(priv->BH_accreted_BHMass);
     myfree(priv->BH_accreted_Mass);
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -294,6 +294,8 @@ blackhole(const ActiveParticles * act, double atime, Cosmology * CP, ForceTree *
     priv->SPH_SwallowID = (MyIDType *) mymalloc("SPH_SwallowID", SlotsManager->info[0].size * sizeof(MyIDType));
     memset(priv->SPH_SwallowID, 0, SlotsManager->info[0].size * sizeof(MyIDType));
 
+    /* We need hmax for the symmetric BH walk*/
+    force_tree_calc_moments(tree, ddecomp);
     /* Computed in accretion, used in feedback*/
     priv->BH_FeedbackWeightSum = (MyFloat *) mymalloc("BH_FeedbackWeightSum", SlotsManager->info[5].size * sizeof(MyFloat));
 
@@ -831,7 +833,8 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
         iter->base.mask = GASMASK + BHMASK;
         iter->base.Hsml = I->Hsml;
-        iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
+        /* Needs to be symmetric because the BH mergers should be symmetric*/
+        iter->base.symmetric = NGB_TREEFIND_SYMMETRIC;
         density_kernel_init(&iter->feedback_kernel, I->Hsml, GetDensityKernelType());
         return;
     }

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -883,8 +883,6 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
             if(I->Mtrack < blackhole_params.SeedBHDynMass && BHP(other).Mtrack < blackhole_params.SeedBHDynMass){
             /* I->Mass = SeedBHDynMass, total_gas_accreted = I->Mtrack + BHP(other).Mtrack */
                 O->acMtrack += BHP(other).Mtrack;
-                double delta_m = I->Mtrack + BHP(other).Mtrack - blackhole_params.SeedBHDynMass;
-                O->Mass += DMAX(0,delta_m);
             }
             if(I->Mtrack >= blackhole_params.SeedBHDynMass && BHP(other).Mtrack < blackhole_params.SeedBHDynMass){
             /* I->Mass = gas_accreted, total_gas_accreted = I->Mass + BHP(other).Mtrack */

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -892,7 +892,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
         /* Conserve momentum during accretion*/
         int d;
         for(d = 0; d < 3; d++)
-            O->AccretedMomentum[d] += (P[other].Mass * VelPred[d]);
+            O->AccretedMomentum[d] += (othermass * VelPred[d]);
 
         if(BHP(other).SwallowTime < BH_GET_PRIV(lv->tw)->atime)
             endrun(2, "Encountered BH %i swallowed at earlier time %g\n", other, BHP(other).SwallowTime);

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -985,14 +985,11 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
      * In that case we do not swallow this particle: all swallowing changes before this are temporary*/
     if(P[other].Type == 0 && SPH_SwallowID[P[other].PI] == I->ID+1)
     {
-        /* We do not know how to notify the tree of mass changes. so
-         * enforce a mass conservation. */
         if(blackhole_params.SeedBHDynMass > 0 && I->Mtrack < blackhole_params.SeedBHDynMass) {
             /* we just add gas mass to Mtrack instead of dynMass */
             O->acMtrack += P[other].Mass;
         } else
             O->Mass += P[other].Mass;
-        P[other].Mass = 0;
         MyFloat VelPred[3];
         SPH_VelPred(other, VelPred, BH_GET_PRIV(lv->tw)->kf);
         /* Conserve momentum during accretion*/

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -577,10 +577,9 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
                 message(0, "dx %g %g %g dv %g %g %g da %g %g %g\n",dx[0], dx[1], dx[2], dv[0], dv[1], dv[2], da[0], da[1], da[2]);*/
         }
 
-        /* do the merge */
+        /* Mark the BH via SwallowID.*/
         if(flag == 1)
         {
-            O->encounter = 0;
             MyIDType readid, newswallowid;
 
             #pragma omp atomic read
@@ -715,10 +714,6 @@ blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum T
     if (mode == 0 || BHP(place).encounter < remote->encounter) {
         BHP(place).encounter = remote->encounter;
     }
-    /* But set it to false if we are merging*/
-    if(BHP(place).SwallowID != (MyIDType) -1)
-        BHP(place).encounter = 0;
-
     if (mode == 0 || BHP(place).minTimeBin > remote->BH_minTimeBin) {
         BHP(place).minTimeBin = remote->BH_minTimeBin;
     }
@@ -852,6 +847,8 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
         BHP(other).SwallowTime = BH_GET_PRIV(lv->tw)->atime;
         P[other].Swallowed = 1;
+        /* Set encounter to zero when we merge*/
+        BHP(other).encounter = 0;
         O->BH_CountProgs += BHP(other).CountProgs;
         O->BH_Mass += (BHP(other).Mass);
 

--- a/libgadget/blackhole.c
+++ b/libgadget/blackhole.c
@@ -546,7 +546,9 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
     /* Accretion / merger doesn't do self interaction */
     if(P[other].ID == I->ID) return;
 
-    /* we have a black hole merger. Now we use 2 times GravitationalSoftening as merging criteria, previously we used the SPH smoothing length. */
+    /* we have a black hole merger. Now we use 2 times GravitationalSoftening as merging criteria.
+     * Note there is another condition: they must also be closer than the SPH smoothing length,
+     * as enforced by the tree search above. */
     if(P[other].Type == 5 && r < (2*FORCE_SOFTENING(0,1)/2.8))
     {
         O->encounter = 1; // mark the event when two BHs encounter each other

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -16,14 +16,11 @@ struct BHPriv {
     MyFloat * BH_Entropy;
     MyFloat (*BH_SurroundingGasVel)[3];
 
-    /*************************************************************************/
-
-    MyFloat (*BH_accreted_momentum)[3];
-
     /* These are temporaries used in the feedback treewalk.*/
     MyFloat * BH_accreted_Mass;
     MyFloat * BH_accreted_BHMass;
     MyFloat * BH_accreted_Mtrack;
+    MyFloat (*BH_accreted_momentum)[3];
 
     /* This is a temporary computed in the accretion treewalk and used
      * in the feedback treewalk*/

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -9,6 +9,8 @@ struct BHPriv {
     /* Temporary array to store the IDs of the swallowing black hole for gas.
      * We store ID + 1 so that SwallowID == 0 can correspond to the unswallowed case. */
     MyIDType * SPH_SwallowID;
+    /* Similar for IDs of BH mergers*/
+    MyIDType * BH_SwallowID;
     /* These are temporaries used in the accretion treewalk*/
     MyFloat * MinPot;
     MyFloat * BH_Entropy;

--- a/libgadget/blackhole.h
+++ b/libgadget/blackhole.h
@@ -19,7 +19,6 @@ struct BHPriv {
     /* These are temporaries used in the feedback treewalk.*/
     MyFloat * BH_accreted_Mass;
     MyFloat * BH_accreted_BHMass;
-    MyFloat * BH_accreted_Mtrack;
     MyFloat (*BH_accreted_momentum)[3];
 
     /* This is a temporary computed in the accretion treewalk and used

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1312,7 +1312,6 @@ void force_update_hmax(int * activeset, int size, ForceTree * tree, DomainDecomp
     /* Calculate moments to propagate everything upwards. */
     force_tree_calc_moments(tree, ddecomp);
 
-    tree->hmax_computed_flag = 1;
     walltime_measure("/SPH/HmaxUpdate");
     int64_t totnumparticles;
     MPI_Reduce(&tree->NumParticles, &totnumparticles, 1, MPI_INT64, MPI_SUM, 0, MPI_COMM_WORLD);

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -1368,5 +1368,7 @@ void force_tree_free(ForceTree * tree)
     myfree(tree->Nodes_base);
     if(tree->Father)
         myfree(tree->Father);
+    /* Zero everything, especially the allocation flag*/
+    memset(tree, 0, sizeof(ForceTree));
     tree->tree_allocated_flag = 0;
 }

--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -922,9 +922,11 @@ add_particle_moment_to_node(struct NODE * pnode, const struct particle_data * co
     for(k=0; k<3; k++)
         pnode->mom.cofm[k] += (part->Mass * part->Pos[k]);
 
-    /* We do not add active particles to the hmax here because we are building the tree in density().
-     * The active particles will have hsml updated anyway, often to a smaller value*/
-    if(part->Type == 0 && !is_timebin_active(part->TimeBinHydro, part->Ti_drift))
+    /* We do not add active gas particles to the hmax here because we are building the tree in density().
+     * The active particles will have hsml updated anyway, often to a smaller value and will be included in force_update_hmax.
+     * Black holes include unconditionally.*/
+    if((part->Type == 0 && !is_timebin_active(part->TimeBinHydro, part->Ti_drift))
+        || part->Type == 5)
     {
         int j;
         /* Maximal distance any of the member particles peek out from the side of the node.

--- a/libgadget/gravity.h
+++ b/libgadget/gravity.h
@@ -52,7 +52,7 @@ struct gravshort_tree_params get_gravshort_treepar(void);
  * Parameters: Cosmology, Time, UnitLength_in_cm and PowerOutputDir are used by the power spectrum output code.
  * TimeIC and FastParticleType are used by the massive neutrino code. FastParticleType denotes possibly inactive particles.
  * Note: tree is freed during this function*/
-void gravpm_force(PetaPM * pm, ForceTree * tree, Cosmology * CP, double Time, double UnitLength_in_cm, const char * PowerOutputDir, double TimeIC, int FastParticleType);
+void gravpm_force(PetaPM * pm, DomainDecomp * ddecomp, Cosmology * CP, double Time, double UnitLength_in_cm, const char * PowerOutputDir, double TimeIC, int FastParticleType);
 
 void grav_short_pair(const ActiveParticles * act, PetaPM * pm, ForceTree * tree, double Rcut, double rho0, int NeutrinoTracer, int FastParticleType);
 void grav_short_tree(const ActiveParticles * act, PetaPM * pm, ForceTree * tree, MyFloat (* AccelStore)[3], double rho0, int NeutrinoTracer, int FastParticleType, inttime_t Ti_Current);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -500,9 +500,7 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
         if(is_PM)
         {
             /* Tree freed in PM*/
-            ForceTree Tree = {0};
-            force_tree_full(&Tree, ddecomp, HybridNuTracer, All.OutputDir);
-            gravpm_force(&pm, &Tree, &All.CP, atime, units.UnitLength_in_cm, All.OutputDir, header->TimeIC, All.FastParticleType);
+            gravpm_force(&pm, ddecomp, &All.CP, atime, units.UnitLength_in_cm, All.OutputDir, header->TimeIC, All.FastParticleType);
 
             /* compute and output energy statistics if desired. */
             if(fds.FdEnergy)
@@ -814,9 +812,5 @@ runpower(const struct header_data * header)
     /* ... read in initial model */
     domain_decompose_full(ddecomp);	/* do initial domain decomposition (gives equal numbers of particles) */
     /*PM needs a tree*/
-    ForceTree Tree = {0};
-    int HybridNuGrav = hybrid_nu_tracer(&All.CP, header->TimeSnapshot);
-    force_tree_full(&Tree, ddecomp, HybridNuGrav, All.OutputDir);
-    gravpm_force(&pm, &Tree, &All.CP, header->TimeSnapshot, header->UnitLength_in_cm, All.OutputDir, header->TimeSnapshot, All.FastParticleType);
-    force_tree_free(&Tree);
+    gravpm_force(&pm, ddecomp, &All.CP, header->TimeSnapshot, header->UnitLength_in_cm, All.OutputDir, header->TimeSnapshot, All.FastParticleType);
 }

--- a/libgadget/runtests.c
+++ b/libgadget/runtests.c
@@ -91,9 +91,9 @@ run_gravity_test(int RestartSnapNum, Cosmology * CP, const double Asmth, const i
     ActiveParticles Act = init_empty_active_particles(0);
     build_active_particles(&Act, &times, 0, header->TimeSnapshot);
 
+    gravpm_force(pm, ddecomp, CP, header->TimeSnapshot, header->UnitLength_in_cm, OutputDir, header->TimeIC, FastParticleType);
+
     ForceTree Tree = {0};
-    force_tree_full(&Tree, ddecomp, 1, OutputDir);
-    gravpm_force(pm, &Tree, CP, header->TimeSnapshot, header->UnitLength_in_cm, OutputDir, header->TimeIC, FastParticleType);
     force_tree_full(&Tree, ddecomp, 1, OutputDir);
 
     struct gravshort_tree_params origtreeacc = get_gravshort_treepar();
@@ -163,8 +163,7 @@ run_gravity_test(int RestartSnapNum, Cosmology * CP, const double Asmth, const i
     petapm_destroy(pm);
 
     gravpm_init_periodic(pm, PartManager->BoxSize, Asmth, Nmesh/2., CP->GravInternal);
-    force_tree_full(&Tree, ddecomp, 1, OutputDir);
-    gravpm_force(pm, &Tree, CP, header->TimeSnapshot, header->UnitLength_in_cm, OutputDir, header->TimeIC, FastParticleType);
+    gravpm_force(pm, ddecomp, CP, header->TimeSnapshot, header->UnitLength_in_cm, OutputDir, header->TimeIC, FastParticleType);
     force_tree_full(&Tree, ddecomp, 1, OutputDir);
     set_gravshort_treepar(treeacc);
     grav_short_tree(&Act, pm, &Tree, NULL, rho0, 0, FastParticleType, times.Ti_Current);

--- a/libgadget/tests/test_forcetree.c
+++ b/libgadget/tests/test_forcetree.c
@@ -284,7 +284,7 @@ static void do_tree_mask_hmax_update_test(const int numpart, ForceTree * tb, Dom
         P[i].PI = 0;
         P[i].IsGarbage = 0;
         P[i].Type = 0;
-        P[i].Hsml = PartManager->BoxSize/cbrt(numpart);
+        P[i].Hsml = PartManager->BoxSize/cbrt(numpart) * get_random_number(P[i].Key);
     }
     qsort(P, numpart, sizeof(struct particle_data), order_by_type_and_key);
     PartManager->MaxPart = numpart;
@@ -459,6 +459,7 @@ static int setup_tree(void **state) {
     gsl_rng_set(data->r, 0);
     *state = (void *) data;
     walltime_init(&Clocks);
+    set_random_numbers(23);
     return 0;
 }
 

--- a/libgadget/tests/test_gravity.c
+++ b/libgadget/tests/test_gravity.c
@@ -179,8 +179,6 @@ static void do_force_test(int Nmesh, double Asmth, double ErrTolForceAcc, int di
 
     PetaPM pm = {0};
     gravpm_init_periodic(&pm, PartManager->BoxSize, Asmth, Nmesh, G);
-    ForceTree Tree = {0};
-    force_tree_full(&Tree, &ddecomp, 1, NULL);
     gravshort_fill_ntab(SHORTRANGE_FORCE_WINDOW_TYPE_EXACT, Asmth);
     /* Setup cosmology*/
     Cosmology CP ={0};
@@ -194,7 +192,8 @@ static void do_force_test(int Nmesh, double Asmth, double ErrTolForceAcc, int di
     struct UnitSystem units = get_unitsystem(3.085678e21, 1.989e43, 1e5);
     init_cosmology(&CP, 0.01, units);
 
-    gravpm_force(&pm, &Tree, &CP, 0.1, CM_PER_MPC/1000., ".", 0.01, 2);
+    gravpm_force(&pm, &ddecomp, &CP, 0.1, CM_PER_MPC/1000., ".", 0.01, 2);
+    ForceTree Tree = {0};
     force_tree_full(&Tree, &ddecomp, 1, NULL);
     const double rho0 = CP.Omega0 * 3 * CP.Hubble * CP.Hubble / (8 * M_PI * G);
 

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -964,11 +964,12 @@ int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
     /* Kick-start the iteration with other == -1 */
     iter->other = -1;
     lv->tw->ngbiter(I, O, iter, lv);
-#ifdef DEBUG
     /* Check whether the tree contains the particles we are looking for*/
     if((lv->tw->tree->mask & iter->mask) == 0)
         endrun(5, "Tried to run treewalk for particle mask %d but tree mask is %d.\n", iter->mask, lv->tw->tree->mask);
-#endif
+    /* If symmetric, make sure we did hmax first*/
+    if(iter->symmetric == NGB_TREEFIND_SYMMETRIC && !lv->tw->tree->hmax_computed_flag)
+        endrun(3, "%s tried to do a symmetric treewalk without computing hmax!\n", lv->tw->ev_label);
     const double BoxSize = lv->tw->tree->BoxSize;
 
     int64_t ninteractions = 0;


### PR DESCRIPTION
This fixes some clear (but small effect) bugs in the BH module.

To Black hole mergers:
- Make the BH treewalk symmetric again, so that we check if either BH is close to the other one. Only matters if the BH Hsml is < 2 * Force softening.
- Ensure that the SwallowID does not persist over timesteps. This ensures that black holes which are marked but not swallowed (because the swallowing BH is swallowed first) are not prevented from merging in future timesteps. This should be rare (as the comment said), but is worth fixing.
 - We avoid two BHs trying to swallow each other (ie, break the symmetry) by checking that a black hole only merges another with a larger ID. But only active black holes can swallow, so this can prevent an inactive black hole from being merged. This again is a rare case, as BHs take their timesteps from the shortest gas timestep surrounding them and close BHs likely have the same shortest gas timestep.

To gas accretion:
- Conserve momentum on gas accretion. Small effect because most gas accretion happens for massive black holes.
- Fix an edge case where mass conservation could be broken when a small BH swallows a gas particle and the mass is just enough to push it over the SeedBHDynMass. This is rare because most BHs grow by merger in this regime.