### PR TITLE
Reduced SF timescale 

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -283,6 +283,9 @@ create_gadget_parameter_set()
     param_declare_double(ps, "CritOverDensity", OPTIONAL, 57.7, "Threshold over-density (in units of the critical density) for gas to be star forming.");
     param_declare_double(ps, "CritPhysDensity", OPTIONAL, 0, "Threshold physical density (in protons/cm^3) for gas to be star forming. If zero this is worked out from CritOverDensity.");
 
+    param_declare_int(ps, "BoostSFDenseGas", OPTIONAL, 0, "Reduce sfr timescale for ultra-dense gas above BoostSFOverDenseFactor of the CritPhysDensity");
+    param_declare_double(ps, "BoostSFOverDenseFactor", OPTIONAL, 230, "Threshold overdensity with respect to the SF threshold, default is 230, the same as TNG50");
+
     param_declare_int(ps, "BHFeedbackUseTcool", OPTIONAL, 1, "Control how BH feedback interacts with the SFR. If 0, star-forming gas which is heated by a BH remains pressurized (and thus does not cool). If 1, it cools exponentially to the EEQOS using the cooling time rather than the relaxation time. If 2, gas more than 0.3 dex above the EOS temp just cools normally. If 3 all star forming gas cools normally. 1 and 2 give similar BH output, but 1 is 50% faster due to the smaller timebins populated by 2.");
     param_declare_double(ps, "FactorSN", OPTIONAL, 0.1, "Fraction of the gas energy which is locally returned as supernovae on star formation.");
     param_declare_double(ps, "FactorEVP", OPTIONAL, 1000, "Parameter of the SH03 model, controlling the energy of the hot gas.");

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -81,7 +81,9 @@ static struct SFRParams
     char J21CoeffFile[100];
     char MetalCoolFile[100];
     char UVFluctuationFile[100];
-
+    /* Boost SF for dense gas*/
+    int BoostSFDenseGas;
+    double BoostSFOverDenseFactor;
     /* File with the helium reionization table*/
     char ReionHistFile[100];
 } sfr_params;
@@ -149,6 +151,8 @@ void set_sfr_params(ParameterSet * ps)
         sfr_params.CritOverDensity = param_get_double(ps, "CritOverDensity");
         sfr_params.CritPhysDensity = param_get_double(ps, "CritPhysDensity");
         sfr_params.WindOn = param_get_int(ps, "WindOn");
+        sfr_params.BoostSFDenseGas = param_get_int(ps, "BoostSFDenseGas");
+        sfr_params.BoostSFOverDenseFactor = param_get_double(ps, "BoostSFOverDenseFactor");
 
         sfr_params.FactorSN = param_get_double(ps, "FactorSN");
         sfr_params.FactorEVP = param_get_double(ps, "FactorEVP");
@@ -786,6 +790,8 @@ struct sfr_eeqos_data get_sfr_eeqos(struct particle_data * part, struct sph_part
 
     data.ne = sph->Ne;
     data.tsfr = sqrt(sfr_params.PhysDensThresh / (sph->Density * a3inv)) * sfr_params.MaxSfrTimescale;
+    if(sfr_params.BoostSFDenseGas && ((sph->Density * a3inv) / sfr_params.PhysDensThresh > sfr_params.BoostSFOverDenseFactor))
+        data.tsfr = sfr_params.PhysDensThresh / (sph->Density * a3inv) * sfr_params.MaxSfrTimescale;
     /*
      * gadget-p doesn't have this cap.
      * without the cap sm can be bigger than cloudmass.


### PR DESCRIPTION
Add option to reduce SF timescale for ultra dense gas with density above certain factor of the SF threshold. TNG50 uses BoostSFOverDenseFactor=230