### PR TITLE
Splittimes

### DIFF
--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -144,6 +144,9 @@ all: libgadget.a libgadget-utils.a
 .objs/test_timebinmgr: tests/test_timebinmgr.c .objs/timebinmgr.o .objs/cosmology.o .objs/omega_nu_single.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
 
+.objs/test_timefac: tests/test_timefac.c .objs/timefac.o .objs/timebinmgr.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
+	$(MPICC) $(TCFLAGS) -I../tests/ $^ $(LIBS) -o $@
+
 .objs/test_neutrinos_lra: tests/test_neutrinos_lra.c .objs/neutrinos_lra.o .objs/cosmology.o .objs/omega_nu_single.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a
 
 .objs/test_cooling_rates: tests/test_cooling_rates.c .objs/cooling_rates.o .objs/cooling_uvfluc.o ../tests/stub.c ../tests/cmocka.c libgadget-utils.a

--- a/libgadget/density.c
+++ b/libgadget/density.c
@@ -72,7 +72,8 @@ SPH_EntVarPred(const int p_i, const DriftKickTimes * times)
 {
         const int bin = P[p_i].TimeBinHydro;
         const int PI = P[p_i].PI;
-        const double dloga = dloga_from_dti(times->Ti_Current - times->Ti_kick[bin], P[p_i].Ti_drift);
+        /* Start at the kick and evolve to current drift*/
+        const double dloga = dloga_from_dti(times->Ti_kick[bin], times->Ti_Current);
         double EntVarPred = SphP[PI].Entropy + SphP[PI].DtEntropy * dloga;
         /*Entropy limiter for the predicted entropy: makes sure entropy stays positive. */
         if(EntVarPred < 0.05*SphP[PI].Entropy)

--- a/libgadget/drift.c
+++ b/libgadget/drift.c
@@ -92,7 +92,7 @@ void drift_all_particles(inttime_t ti0, inttime_t ti1, Cosmology * CP, const dou
 {
     int i;
     walltime_measure("/Misc");
-    if(ti1 < ti0) {
+    if(compare_two_inttime(ti1, ti0) < 0) {
         endrun(12, "Trying to reverse time: ti0=%d ti1=%d\n", ti0, ti1);
     }
     const double ddrift = get_exact_drift_factor(CP, ti0, ti1);
@@ -100,7 +100,7 @@ void drift_all_particles(inttime_t ti0, inttime_t ti1, Cosmology * CP, const dou
 #pragma omp parallel for
     for(i = 0; i < PartManager->NumPart; i++) {
 #ifdef DEBUG
-        if(PartManager->Base[i].Ti_drift != ti0)
+        if(compare_two_inttime(PartManager->Base[i].Ti_drift, ti0) != 0)
             endrun(10, "Drift time mismatch: (ids = %ld %ld) %d != %d\n",PartManager->Base[0].ID, PartManager->Base[i].ID, ti0,  PartManager->Base[i].Ti_drift);
 #endif
         real_drift_particle(&PartManager->Base[i], SlotsManager, ddrift, PartManager->BoxSize, random_shift);

--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -72,9 +72,9 @@ void init_timeline(Cosmology * CP, int RestartSnapNum, double TimeMax, const str
         /* If TimeInit is not in a sensible place on the integer timeline
          * (can happen if the outputs changed since it was written)
          * start the integer timeline anew from TimeInit */
-        inttime_t ti_init = ti_from_loga(log(header->TimeSnapshot)) % TIMEBASE;
-        if(round_down_power_of_two(ti_init) != ti_init) {
-            message(0,"Resetting integer timeline (as %x != %x) to current snapshot\n",ti_init, round_down_power_of_two(ti_init));
+        inttime_t ti_init = ti_from_loga(log(header->TimeSnapshot));
+        if(round_down_power_of_two(ti_init.dti) != ti_init.dti) {
+            message(0,"Resetting integer timeline (as %x != %x) to current snapshot\n",ti_init.dti, round_down_power_of_two(ti_init.dti));
             setup_sync_points(CP, header->TimeSnapshot, TimeMax, header->TimeSnapshot, SnapshotWithFOF);
         }
     }

--- a/libgadget/sfr_eff.c
+++ b/libgadget/sfr_eff.c
@@ -464,7 +464,7 @@ cooling_direct(int i, const double redshift, const double a3inv, const double hu
     zreion = SPHP(i).zreion;
 #endif
     struct UVBG uvbg = get_local_UVBG(redshift, GlobalUVBG, P[i].Pos, PartManager->CurrentParticleOffset, localJ21, zreion);
-    double lasttime = exp(loga_from_ti(P[i].Ti_drift - dti_from_timebin(P[i].TimeBinHydro)));
+    double lasttime = exp(loga_from_ti(add_dti_and_inttime(P[i].Ti_drift, dti_from_timebin(P[i].TimeBinHydro))));
     double lastred = 1/lasttime - 1;
     double unew;
     /* The particle reionized this timestep, bump the temperature to the HI reionization temperature.

--- a/libgadget/tests/test_density.c
+++ b/libgadget/tests/test_density.c
@@ -62,7 +62,8 @@ static void do_density_test(void ** state, const int numpart, double expectedhsm
         P[i].Mass = 1;
         P[i].TimeBinHydro = 0;
         P[i].TimeBinGravity = 0;
-        P[i].Ti_drift = 0;
+        inttime_t ti = {0};
+        P[i].Ti_drift = ti;
         for(j=0; j<3; j++)
             P[i].Vel[j] = 1.5;
         if(P[i].Type == 0) {

--- a/libgadget/tests/test_gravity.c
+++ b/libgadget/tests/test_gravity.c
@@ -211,8 +211,9 @@ static void do_force_test(int Nmesh, double Asmth, double ErrTolForceAcc, int di
 
     /* Twice so the opening angle is consistent*/
     ActiveParticles act = init_empty_active_particles(PartManager->NumPart);
-    grav_short_tree(&act, &pm, &Tree, NULL, rho0, 0);
-    grav_short_tree(&act, &pm, &Tree, NULL, rho0, 0);
+    inttime_t ti = {0};
+    grav_short_tree(&act, &pm, &Tree, NULL, rho0, ti);
+    grav_short_tree(&act, &pm, &Tree, NULL, rho0, ti);
 
     force_tree_free(&Tree);
     petapm_destroy(&pm);

--- a/libgadget/timefac.c
+++ b/libgadget/timefac.c
@@ -46,7 +46,7 @@ static double hydrokick_integ(double a, void *param)
 static double get_exact_factor(Cosmology * CP, inttime_t t0, inttime_t t1, double (*factor) (double, void *))
 {
     double result, abserr;
-    if(t0 == t1)
+    if(compare_two_inttime(t0, t1) == 0)
         return 0;
     double a0 = exp(loga_from_ti(t0));
     double a1 = exp(loga_from_ti(t1));

--- a/libgadget/timestep.h
+++ b/libgadget/timestep.h
@@ -21,9 +21,10 @@ typedef struct
     /* Current drift time, which is universal.*/
     inttime_t Ti_Current;
     /* PM Timesteps*/
-    inttime_t PM_length; /*!< Duration of the current PM integer timestep*/
     inttime_t PM_start;           /* current start point of the PM step*/
+    inttime_t PM_end; /*!< End of the current PM integer timestep*/
     inttime_t PM_kick;  /* current inttime of PM Kick (velocity) */
+    dti_t PM_dti; /* Length of the current PM step.*/
 } DriftKickTimes;
 
 /* Structure to hold data about the currently active particles. Similar to the WorkQueue structure in treebuild.

--- a/libgadget/types.h
+++ b/libgadget/types.h
@@ -5,7 +5,13 @@
 
 /*Define some useful types*/
 
-typedef int32_t inttime_t;
+typedef int32_t dti_t;
+
+typedef struct inttime_t
+{
+    dti_t dti;
+    unsigned int lastsnap;
+} inttime_t;
 
 typedef uint64_t MyIDType;
 

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -62,7 +62,7 @@ double get_random_number(uint64_t id)
     return RndTable[(int)(id % RNDTABLE)];
 }
 
-void set_random_numbers(int seed)
+void set_random_numbers(uint64_t seed)
 {
     gsl_rng * random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
 

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -34,7 +34,7 @@ double get_physmem_bytes(void);
 /* Gets a random number in the range [0, 1). Only the low bits of the id are used,
  * and random deviates are drawn from a pre-seeded table so that they are independent of processor.*/
 double get_random_number(uint64_t id);
-void set_random_numbers(int seed);
+void set_random_numbers(uint64_t seed);
 void sumup_large_ints(int n, int *src, int64_t *res);
 void sumup_longs(int n, int64_t *src, int64_t *res);
 int64_t count_sum(int64_t countLocal);

--- a/libgadget/veldisp.c
+++ b/libgadget/veldisp.c
@@ -389,7 +389,7 @@ winds_find_vel_disp(const ActiveParticles * act, const double Time, const double
 
     priv[0].Time = Time;
     priv[0].hubble = hubble;
-    priv[0].ddrift = get_exact_drift_factor(CP, times->Ti_Current, times->Ti_Current + times->PM_length);
+    priv[0].ddrift = get_exact_drift_factor(CP, times->Ti_Current, times->PM_end);
     tw->priv = priv;
 
     /* Build the queue to check that we have something to do before we rebuild the tree.*/


### PR DESCRIPTION
Instead of making the integer timestep 64-bit, split it into two parts and make it a struct.