### PR TITLE
Fixasynctreefullbuffergravity

### DIFF
--- a/libgadget/forcetree.c
+++ b/libgadget/forcetree.c
@@ -126,6 +126,8 @@ force_tree_full(ForceTree * tree, DomainDecomp * ddecomp, const int HybridNuTrac
 
     /*No father array by default, only need it for hmax. We want moments.*/
     *tree = force_tree_build(mask, ddecomp, &act, 1, 1, EmergencyOutputDir);
+    /* This is all particles (even if there are neutrinos)*/
+    tree->full_particle_tree_flag = 1;
 }
 
 void
@@ -144,6 +146,9 @@ force_tree_active_moments(ForceTree * tree, DomainDecomp * ddecomp, const Active
 
     /*No father array by default, only need it for hmax. We want moments.*/
     *tree = force_tree_build(mask, ddecomp, act, 1, alloc_father, EmergencyOutputDir);
+    /* This is all particles if active particle is null (even if there are neutrinos)*/
+    if(!act->ActiveParticle)
+        tree->full_particle_tree_flag = 1;
 }
 
 void
@@ -159,6 +164,8 @@ force_tree_rebuild_mask(ForceTree * tree, DomainDecomp * ddecomp, int mask, cons
     ActiveParticles act = init_empty_active_particles(PartManager);
     /* No moments, but need father for hmax. The hybridnugrav only affects moments, so isn't needed.*/
     *tree = force_tree_build(mask, ddecomp, &act, 0, 1, EmergencyOutputDir);
+    if(mask == ALLMASK)
+        tree->full_particle_tree_flag = 1;
 }
 
 

--- a/libgadget/forcetree.h
+++ b/libgadget/forcetree.h
@@ -79,6 +79,8 @@ typedef struct ForceTree {
     int hmax_computed_flag;
     /* Flags that the tree has fully computed and exchanged mass moments*/
     int moments_computed_flag;
+    /* Flags that the tree contains all active particles*/
+    int full_particle_tree_flag;
     /*Index of first internal node. Difference between Nodes and Nodes_base. == MaxPart*/
     int firstnode;
     /*Index of first pseudo-particle node*/

--- a/libgadget/gravshort-pair.c
+++ b/libgadget/gravshort-pair.c
@@ -30,13 +30,7 @@ grav_short_pair(const ActiveParticles * act, PetaPM * pm, ForceTree * tree, doub
     priv.Rcut = Rcut * pm->Asmth * priv.cellsize;
     priv.G = pm->G;
     priv.cbrtrho0 = pow(rho0, 1.0 / 3);
-    /* We only want to calculate the potential
-     * if it is the true potential from all particles*/
-    if(tree->NumParticles == PartManager->NumPart)
-        priv.CalcPotential = 1;
-    else
-        priv.CalcPotential = 0;
-    priv.Accel = NULL;
+    priv.Accel = (MyFloat (*) [3]) mymalloc2("GravAccel", PartManager->NumPart * sizeof(priv.Accel[0]));
 
     message(0, "Starting pair-wise short range gravity...\n");
 
@@ -58,6 +52,7 @@ grav_short_pair(const ActiveParticles * act, PetaPM * pm, ForceTree * tree, doub
 
     treewalk_run(tw, act->ActiveParticle, act->NumActiveParticle);
 
+    myfree(priv.Accel);
     walltime_measure("/Tree/Pairwise");
 }
 

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -527,12 +527,9 @@ run(const int RestartSnapNum, const inttime_t ti_init, const struct header_data 
         /* Gravitational acceleration here*/
         if(totgravactive) {
             if(All.HierarchicalGravity) {
-                /* For steps where all particles are active we re-use FullTreeGravAccel and so do not allocate this.*/
-                if(!is_PM) {
-                    /* We need to store a GravAccel for new star particles as well, so we need extra memory.*/
-                    GravAccel.nstore = PartManager->NumPart + SlotsManager->info[0].size;
-                    GravAccel.GravAccel = (MyFloat (*) [3]) mymalloc2("GravAccel", GravAccel.nstore * sizeof(GravAccel.GravAccel[0]));
-                }
+                /* We need to store a GravAccel for new star particles as well, so we need extra memory.*/
+                GravAccel.nstore = PartManager->NumPart + SlotsManager->info[0].size;
+                GravAccel.GravAccel = (MyFloat (*) [3]) mymalloc2("GravAccel", GravAccel.nstore * sizeof(GravAccel.GravAccel[0]));
                 hierarchical_gravity_accelerations(&Act, &pm, ddecomp, GravAccel, &times, HybridNuTracer, &All.CP, All.OutputDir);
             }
             else if(All.TreeGravOn && totgravactive) {

--- a/libgadget/treewalk.h
+++ b/libgadget/treewalk.h
@@ -112,7 +112,8 @@ struct TreeWalk {
 
     TreeWalkVisitFunction visit;                /* Function to be called between a tree node and a particle */
     TreeWalkHasWorkFunction haswork; /* Is the particle part of this interaction? */
-    TreeWalkFillQueryFunction fill;       /* Copy the useful attributes of a particle to a query */
+    TreeWalkFillQueryFunction fill;       /* Copy the useful attributes of a particle to a query.
+                                            Note: This may be called multiple times including after a reduce and so MUST NOT copy attributes modified by reduce. */
     TreeWalkReduceResultFunction reduce;  /* Reduce a partial result to the local particle storage */
     TreeWalkNgbIterFunction ngbiter;     /* called for each pair of particles if visit is set to ngbiter */
     TreeWalkProcessFunction postprocess; /* postprocess finalizes quantities for each particle, e.g. divide the normalization */


### PR DESCRIPTION
This should fix the asynchronous treewalk gravity problem when the exchange buffer fills up. As a bonus fix the problem where the potential was not updated every PM step and a bug in the density test.