### PR TITLE
Remove NO_ISEND_IRECV_IN_DOMAIN 

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -13,9 +13,6 @@ OPTIMIZE =  -fopenmp -O3 -g -Wall -ffast-math
 #Disable openmp locking. This means no threading.
 #OPT += -DNO_OPENMP_SPINLOCK
 
-#-------------------------------------------- Things for special behaviour
-#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV
-
 #-----------
 #OPT += -DEXCUR_REION  # reionization with excursion set
 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,6 @@ Compile-time options may be set in Options.mk. The remaining compile time option
 
 - DEBUG which enables various internal code consistency checks for debugging.
 - VALGRIND which if set disables the internal memory allocator and allocates memory from the system. This is required for debugging memory allocation errors with valgrind of the address sanitizer.
-- NO_ISEND_IRECV_IN_DOMAIN disables the use of asynchronous send and receive in our custom MPI_Alltoallv implementation, for buggy MPI libraries.
 - NO_OPENMP_SPINLOCK uses the OpenMP default locking routines. These are often much slower than the default pthread spinlocks. However, they are necessary for Mac, which does not provide pthreads.
 - EXCUR_REION enables the excursion set reionization model.
 - USE_CFITSIO enables the output of lenstools compatible potential planes using cfitsio,

--- a/platform-options/Options.mk.BlueTides
+++ b/platform-options/Options.mk.BlueTides
@@ -12,6 +12,4 @@ OPTIMIZE =  -static -fopenmp -O3 -Ofast -g
 
 GSL_INCL = -I$(GSL_DIR)/include
 GSL_LIBS = -L$(GSL_DIR)/lib -lgsl -lgslcblas
-#
 #OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.cori
+++ b/platform-options/Options.mk.cori
@@ -8,4 +8,3 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #OPT += -DDEBUG
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.coriknl
+++ b/platform-options/Options.mk.coriknl
@@ -7,4 +7,3 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #OPT += -DDEBUG
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.edison
+++ b/platform-options/Options.mk.edison
@@ -8,4 +8,3 @@ GSL_LIBS = $(GSL) -lmvec -lmvec_nonshared
 
 #OPT += -DDEBUG
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.coma
+++ b/platform-options/Options.mk.example.coma
@@ -6,4 +6,3 @@ GSL_LIBS = -L/opt/gsl/impi/lib64 -lgsl -lgslcblas
 
 #OPT += -DDEBUG
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.example.icc
+++ b/platform-options/Options.mk.example.icc
@@ -7,5 +7,3 @@ OPTIMIZE =  -fopenmp -O3 -g -Wall -Zp16 -xHost -fp-model fast=1
 
 #OPT += -DDEBUG
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
-#Avoid ISEND IRECV which sometimes causes crashes with buggy MPI
-#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN

--- a/platform-options/Options.mk.frontera
+++ b/platform-options/Options.mk.frontera
@@ -10,4 +10,3 @@ OPTIMIZE =-fopenmp -O3 -g -Wall -xCORE-AVX512 -fp-model fast=1 -ipo -qopt-mem-la
 #--------------------------------------- Basic operation mode of code
 #OPT += -DVALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#OPT +=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.macos
+++ b/platform-options/Options.mk.macos
@@ -14,4 +14,3 @@ OPT += -DVALGRIND     # allow debugging with valgrind, disable the GADGET memory
 #OPT += -DDEBUG      # print a lot of debugging messages
 #Use alternative OpenMP locks, instead of the pthread spinlocks. Required on mac.
 OPT += -DNO_OPENMP_SPINLOCK
-#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.pfe
+++ b/platform-options/Options.mk.pfe
@@ -4,4 +4,3 @@ GSL_LIBS = $(HOME)/anaconda3/envs/3.5/lib/libgsl.a $(HOME)/anaconda3/envs/3.5/li
 
 #OPT += -DVALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
 #OPT += -DDEBUG      # print a lot of debugging messages
-#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/platform-options/Options.mk.scanbuild
+++ b/platform-options/Options.mk.scanbuild
@@ -9,5 +9,4 @@ OPTIMIZE =  -fopenmp -O0 -std=gnu99 -g -Wall -Wextra -Wno-unused-parameter -Wvla
 #OPT += -DNO_OPENMP_SPINLOCK
 OPT += -DVALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
 OPT += -DDEBUG      # print a lot of debugging messages
-#OPT += -DNO_ISEND_IRECV_IN_DOMAIN
 OPT += -DEXCUR_REION  # reionization with excursion set

--- a/platform-options/Options.mk.travis
+++ b/platform-options/Options.mk.travis
@@ -6,4 +6,3 @@ SHELL = /bin/bash
 
 # on travis we run with debug mode
 OPT += -DDEBUG
-#OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV


### PR DESCRIPTION
because if Isend/Irecv don't work we now have big problems! We use it exclusively in treewalk.