### PR TITLE
fix the memory issue of export/import 

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -195,7 +195,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "GravitySoftening", OPTIONAL, 1./30., "Gravitational Softening. Units of mean separation of DM. ForceSoftening is 2.8 times this.");
     param_declare_int(ps, "GravitySofteningGas", OPTIONAL, 1, "Unused. Previously was for adaptive softening.");
 
-    param_declare_int(ps, "ImportBufferBoost", OPTIONAL, 2, "Memory factor to allow for there being more particles imported during treewlk than exported. Increase this if code crashes during treewalk with out of memory.");
+    param_declare_double(ps, "ImportBufferBoost", OPTIONAL, 2., "Memory factor to allow for there being more particles imported during treewlk than exported. Increase this if code crashes during treewalk with out of memory.");
     param_declare_double(ps, "PartAllocFactor", OPTIONAL, 1.5, "Over-allocation factor of particles. The load can be imbalanced to allow for the work to be more balanced.");
     param_declare_double(ps, "TopNodeAllocFactor", OPTIONAL, 0.5, "Initial TopNode allocation as a fraction of maximum particle number.");
     param_declare_double(ps, "SlotsIncreaseFactor", OPTIONAL, 0.01, "Percentage factor to increase slot allocation by when requested.");

--- a/libgadget/domain.c
+++ b/libgadget/domain.c
@@ -89,6 +89,8 @@ void set_domain_params(ParameterSet * ps)
         /* Create one domain per thread. This helps the balance and makes the treebuild merge faster*/
         if(domain_params.DomainOverDecompositionFactor < 0)
             domain_params.DomainOverDecompositionFactor = omp_get_max_threads();
+        if(domain_params.DomainOverDecompositionFactor == 0)
+            domain_params.DomainOverDecompositionFactor = floor(omp_get_max_threads()/2);                
         if(domain_params.DomainOverDecompositionFactor < 4)
             domain_params.DomainOverDecompositionFactor = 4;
         domain_params.TopNodeAllocFactor = param_get_double(ps, "TopNodeAllocFactor");

--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -17,7 +17,7 @@
 #define FACT1 0.366025403785    /* FACT1 = 0.5 * (sqrt(3)-1) */
 
 /*!< Memory factor to leave for (N imported particles) > (N exported particles). */
-static int ImportBufferBoost;
+static double ImportBufferBoost;
 /* 7/9/24: The code segfaults if the send/recv buffer is larger than 4GB in size.
  * Likely a 32-bit variable is overflowing but it is hard to debug. Easier to enforce a maximum buffer size.*/
 static size_t MaxExportBufferBytes = 3584*1024*1024L;
@@ -28,8 +28,8 @@ void set_treewalk_params(ParameterSet * ps)
     int ThisTask;
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     if(ThisTask == 0)
-        ImportBufferBoost = param_get_int(ps, "ImportBufferBoost");
-    MPI_Bcast(&ImportBufferBoost, 1, MPI_INT, 0, MPI_COMM_WORLD);
+        ImportBufferBoost = param_get_double(ps, "ImportBufferBoost");
+    MPI_Bcast(&ImportBufferBoost, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 }
 
 /* This function is to allow a test which fills up the exchange buffer*/
@@ -113,7 +113,7 @@ ev_begin(TreeWalk * tw, int * active_set, const size_t size)
     /*This memory scales like the number of imports. In principle this could be much larger than Nexport
      * if the tree is very imbalanced and many processors all need to export to this one. In practice I have
      * not seen this happen, but provide a parameter to boost the memory for Nimport just in case.*/
-    bytesperbuffer += ImportBufferBoost * (tw->query_type_elsize + tw->result_type_elsize);
+    bytesperbuffer += ceil(ImportBufferBoost * (tw->query_type_elsize + tw->result_type_elsize));
     /*Use all free bytes for the tree buffer, as in exchange. Leave some free memory for array overhead.*/
     size_t freebytes = (size_t) mymalloc_freebytes();
     freebytes -= 4096 * 10 * bytesperbuffer;


### PR DESCRIPTION
1. change the ImportBufferBoost to be a float parameter 
2. make DomainOverDecompositionFactor half of the available threads, so there are fewer export particles