### PR TITLE
Replace the manual list of headers with an autogenerated dependency list

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -28,8 +28,8 @@ LIBS  = -lm $(GSL_LIBS) $(FITSIO_LIBS)
 LIBS += -L../depends/lib $(BUNDLEDLIBS)
 V ?= 0
 
-.objs/%.o: %.c $(INCL) Makefile $(CONFIG)
-	@cmd="$(MPICC) -c -o $@ $(CFLAGS) $<"; \
+.objs/%.o: %.c Makefile $(CONFIG)
+	@cmd="$(MPICC) -MMD -c -o $@ $(CFLAGS) $<"; \
 	if test "x$(V)" = "x1" ; then echo $$cmd; fi; \
 	mkdir -p `dirname $@`; \
 	echo Compiling $<; $$cmd

--- a/gadget/Makefile
+++ b/gadget/Makefile
@@ -3,8 +3,6 @@ CONFIG ?= ../Options.mk
 
 include $(CONFIG)
 
-INCL=../libgadget/config.h
-
 include ../Makefile.rules
 
 OBJS = main.o params.o
@@ -15,6 +13,9 @@ all: MP-Gadget
 
 MP-Gadget: $(OBJS) ../libgadget/libgadget.a ../libgadget/libgadget-utils.a
 	$(MPICC) $(OPTIMIZE) $^ $(LIBS) -o $@
+
+DEPS := $(OBJS:.o=.d)
+-include $(DEPS)
 
 clean:
 	rm -rf MP-Gadget .objs

--- a/genic/Makefile
+++ b/genic/Makefile
@@ -4,8 +4,6 @@ CONFIG ?= ../Options.mk
 
 include $(CONFIG)
 
-INCL=../libgadget/config.h
-
 include ../Makefile.rules
 
 OBJS = main.o params.o
@@ -16,6 +14,9 @@ all: MP-GenIC
 
 MP-GenIC: $(OBJS) ../libgenic/libgenic.a ../libgadget/libgadget.a ../libgadget/libgadget-utils.a
 	$(MPICC) $(OPTIMIZE) $^ $(LIBS) -o $@
+
+DEPS := $(OBJS:.o=.d)
+-include $(DEPS)
 
 clean:
 	rm -rf $(OBJS) MP-GenIC

--- a/libgadget/Makefile
+++ b/libgadget/Makefile
@@ -6,55 +6,6 @@ CONFIG ?= ../Options.mk
 
 include $(CONFIG)
 
-INCL = densitykernel.h \
-	forcetree.h \
-	hci.h \
-	petapm.h \
-	run.h \
-	timebinmgr.h \
-	treewalk.h \
-	partmanager.h \
-	cooling.h   \
-	cooling_rates.h cooling_qso_lightup.h \
-	domain.h   \
-	exchange.h \
-	slotsmanager.h     \
-	checkpoint.h \
-	physconst.h   \
-	sfr_eff.h \
-	stats.h \
-	metal_return.h \
-	winds.h \
-	timefac.h \
-	blackhole.h bhdynfric.h bhinfo.h \
-	gravity.h \
-	cosmology.h \
-	drift.h     \
-	fof.h  \
-	gravshort.h  \
-	petaio.h  \
-	powerspectrum.h  \
-	timestep.h  \
-	walltime.h \
-	neutrinos_lra.h \
-	omega_nu_single.h \
-	uvbg.h \
-	plane.h \
-	lenstools.h \
-utils/unitsystem.h \
-utils/peano.h \
-utils/interp.h \
-utils/paramset.h \
-utils/endrun.h \
-utils/memory.h \
-utils/mpsort.h \
-utils/mymalloc.h \
-utils/system.h \
-utils/event.h \
-utils/openmpsort.h \
-utils/spinlocks.h \
-utils/string.h
-
 UTILS_TESTED = memory openmpsort interp peano
 UTILS_MPI_TESTED = mpsort
 
@@ -131,7 +82,6 @@ utils/unitsystem.o \
 utils/string.o \
 utils/spinlocks.o
 
-
 GADGET_OBJS := $(GADGET_OBJS:%=.objs/%)
 GADGET_UTILS_OBJS := $(GADGET_UTILS_OBJS:%=.objs/%)
 
@@ -198,6 +148,12 @@ clean:
 config.c: $(CONFIG)
 	mkdir -p `dirname $@`
 	MPICC="$(MPICC)" CFLAGS="$(CFLAGS)" OPT="$(OPT)" OPTIMIZE="$(OPTIMIZE)" VERSION="$(VERSION)" bash makeconfig.sh $@
+
+GADGET_DEPS := $(GADGET_OBJS:.o=.d)
+GADGET_UTILS_DEPS := $(GADGET_UTILS_OBJS:.o=.d)
+-include $(GADGET_DEPS)
+-include $(GADGET_UTILS_DEPS)
+
 
 #This snippet works out the current git revision and the git revision in config.h.
 #It checks whether they are the same.

--- a/libgenic/Makefile
+++ b/libgenic/Makefile
@@ -4,9 +4,6 @@ CONFIG ?= ../Options.mk
 
 include $(CONFIG)
 
-INCL=../libgadget/config.h \
-    power.h allvars.h thermal.h proto.h pmesh.h
-
 TESTED = power thermal
 TESTBIN := $(TESTED:%=.objs/test_%) $(MPI_TESTED:%=.objs/test_%)
 SUITE?= $(TESTED:%=test_%)
@@ -38,6 +35,9 @@ test : build-tests
 
 libgenic.a: $(OBJS)
 	$(AR) r $@ $(OBJS)
+
+DEPS := $(OBJS:.o=.d)
+-include $(DEPS)
 
 clean:
 	rm -rf .objs libgenic.a


### PR DESCRIPTION
Uses -MMD to generate .d files and loads them into make.