### PR TITLE
Fix the OpenMP sort on ARM architectures.

### DIFF
--- a/libgadget/treewalk.c
+++ b/libgadget/treewalk.c
@@ -203,6 +203,14 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, const size_t size, int may
     }
 
     tw->work_set_stolen_from_active = 0;
+    /* Explicitly deal with the case where the queue is zero and there is nothing to do.
+     * Some OpenMP compilers (nvcc) seem to still execute the below loop in that case*/
+    if(size == 0) {
+        tw->WorkSet = mymalloc("ActiveQueue", sizeof(int));
+        tw->WorkSetSize = size;
+        return;
+    }
+
     /*We want a lockless algorithm which preserves the ordering of the particle list.*/
     gadget_thread_arrays gthread = gadget_setup_thread_arrays("ActiveQueue", 0, size);
     /* We enforce schedule static to ensure that each thread executes on contiguous particles.

--- a/libgadget/utils/system.c
+++ b/libgadget/utils/system.c
@@ -548,7 +548,7 @@ size_t gadget_compact_thread_arrays(int ** dest, gadget_thread_arrays * arrays)
     return asize;
 }
 
-gadget_thread_arrays gadget_setup_thread_arrays(const char * destname, int alloc_high, size_t total_size)
+gadget_thread_arrays gadget_setup_thread_arrays(const char * destname, const int alloc_high, const size_t total_size)
 {
     gadget_thread_arrays threadarray = {0};
     const int narrays = omp_get_max_threads();

--- a/libgadget/utils/system.h
+++ b/libgadget/utils/system.h
@@ -59,7 +59,7 @@ typedef struct _gadget_thread_arrays {
 size_t gadget_compact_thread_arrays(int ** dest, gadget_thread_arrays * arrays);
 
 /* Set up pointers to different parts of a single segmented array, evenly spaced and corresponding queue space for different threads.*/
-gadget_thread_arrays gadget_setup_thread_arrays(const char * destname, int alloc_high, size_t total_size);
+gadget_thread_arrays gadget_setup_thread_arrays(const char * destname, const int alloc_high, const size_t total_size);
 
 int MPI_Alltoallv_smart(void *sendbuf, int *sendcnts, int *sdispls,
         MPI_Datatype sendtype, void *recvbuf, int *recvcnts,


### PR DESCRIPTION
The standard does not guarantee that the merges are atomic, it seems. This new code seems to improve memory safety even on intel, so let's make it unconditional. It will make the sort a bit slower but we can live with that.