### PR TITLE
Improved handling if the power spectrum table is too short

### DIFF
--- a/genic/main.c
+++ b/genic/main.c
@@ -63,14 +63,14 @@ int main(int argc, char **argv)
   const double meanspacing = All2.BoxSize / DMAX(All2.Ngrid, All2.NgridGas);
   double shift_gas = -All2.ProduceGas * 0.5 * (CP.Omega0 - CP.OmegaBaryon) / CP.Omega0 * meanspacing;
   double shift_dm = All2.ProduceGas * 0.5 * CP.OmegaBaryon / CP.Omega0 * meanspacing;
-  
+
   double shift_nu = 0;
   if(!All2.ProduceGas && All2.NGridNu > 0) {
       double OmegaNu = get_omega_nu(&CP.ONu, 1);
       shift_nu = -0.5 * (CP.Omega0 - OmegaNu) / CP.Omega0 * meanspacing;
       shift_dm = 0.5 * OmegaNu / CP.Omega0 * meanspacing;
   }
-    
+
   if(All2.PrePosGridCenter){
       shift_dm += 0.5 * meanspacing;
       shift_gas += 0.5 * meanspacing;
@@ -246,13 +246,13 @@ int main(int argc, char **argv)
   message(0, "IC's generated.\n");
   message(0, "Initial scale factor = %g\n", All2.TimeIC);
 
-  print_spec(ThisTask, All2.Ngrid, All2, &CP);
+  print_spec(ThisTask, All2.Nmesh, All2, &CP);
 
   MPI_Finalize();		/* clean up & finalize MPI */
   return 0;
 }
 
-void print_spec(int ThisTask, const int Ngrid, struct genic_config All2, Cosmology * CP)
+void print_spec(int ThisTask, const int Nmesh, struct genic_config All2, Cosmology * CP)
 {
   if(ThisTask == 0)
     {
@@ -272,7 +272,7 @@ void print_spec(int ThisTask, const int Ngrid, struct genic_config All2, Cosmolo
       fprintf(fd, "# %12g %12g\n", 1/All2.TimeIC-1, DDD);
       /* print actual starting redshift and linear growth factor for this cosmology */
       kstart = 2 * M_PI / (2*All2.BoxSize * (CM_PER_MPC / All2.units.UnitLength_in_cm));	/* 2x box size Mpc/h */
-      kend = 2 * M_PI / (All2.BoxSize/(8*Ngrid) * (CM_PER_MPC / All2.units.UnitLength_in_cm));	/* 1/8 mean spacing Mpc/h */
+      kend = 2 * M_PI / (All2.BoxSize/(sqrt(3)*Nmesh) * (CM_PER_MPC / All2.units.UnitLength_in_cm));	/* smallest power mode in sim*/
 
       message(1,"kstart=%lg kend=%lg\n",kstart,kend);
 

--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -494,9 +494,13 @@ double TopHatSigma2(double R)
   F.function = &sigma2_int;
   F.params = &R;
 
-  /* note: 500/R is here chosen as integration boundary (infinity) */
-  gsl_integration_qags (&F, 0, 500. / R, 0, 1e-4,1000,w,&result, &abserr);
-/*   printf("gsl_integration_qng in TopHatSigma2. Result %g, error: %g, intervals: %lu\n",result, abserr,w->size); */
+  /* Integral is oscillatory but almost zero kr = (n +1/2) pi for odd n. With P(k) ~ n^-3 the integrand is close to zero kr = 20.5 pi */
+  double maxk = M_PI * (20 + 0.5) / R;
+  double maxtabk = pow(10, 0.24 + power_table.logk[power_table.Nentry - 1]);
+  if(maxk > maxtabk)
+      endrun(3, "Trying to do sigma8 integral for rescaling, but need k = %g and largest k in power table is %g\n", maxk, pow(10, power_table.logk[power_table.Nentry - 1]));
+  gsl_integration_qags (&F, 0, M_PI * (20 + 0.5) / R, 0, 1e-4,1000,w,&result, &abserr);
+  // printf("gsl_integration_qng in TopHatSigma2. Result %g, error: %g, intervals: %lu\n",result, abserr,w->size);
   gsl_integration_workspace_free (w);
   return result;
 }

--- a/libgenic/tests/test_power.c
+++ b/libgenic/tests/test_power.c
@@ -39,11 +39,8 @@ test_read_no_rescale(void ** state)
     int nentry = init_powerspectrum(0, 0.01, 3.085678e21, &CP, &PowerP);
     assert_int_equal(nentry, 347);
     /*Check that the tabulated power spectrum gives the right answer
-     * First check ranges: these should both be out of range.
      * Should be the same k as in the file (but /10^3 for Mpc -> kpc)
      * Note that our PowerSpec function is 2pi^3 larger than that in S-GenIC.*/
-    assert_true(DeltaSpec(9.8e-9, DELTA_TOT) < 2e-30);
-    assert_true(DeltaSpec(300, DELTA_TOT) < 2e-30);
     //Now check total power: k divided by 10^3,
     //Conversion for P(k) is 10^9/(2pi)^3
     assert_true(fabs(pow(DeltaSpec(1.124995061548053968e-02/1e3, DELTA_TOT),2) / 4.745074933325402533/1e9 - 1) < 1e-5);


### PR DESCRIPTION
Give an error message if the gap is too large. Assume the power spectrum is constant if a small distance past the table.