### PR TITLE
Fix a missing factor of aH / c in the baryon velocity transfer function

### DIFF
--- a/libgenic/power.c
+++ b/libgenic/power.c
@@ -349,6 +349,9 @@ init_transfer_table(int ThisTask, double InitTime, const struct power_params * c
     for(i=0; i< transfer_table.Nentry; i++) {
         /* Now row 4 is t_cdm*/
         transfer_table.logD[VEL_CDM][i] /= fac;
+        transfer_table.logD[VEL_BAR][i] /= fac;
+        transfer_table.logD[VEL_NU][i] /= fac;
+        /* Now change to t bar and tnu*/
         transfer_table.logD[VEL_BAR][i] += transfer_table.logD[VEL_CDM][i];
         transfer_table.logD[VEL_NU][i] += transfer_table.logD[VEL_CDM][i];
 

--- a/libgenic/tests/test_power.c
+++ b/libgenic/tests/test_power.c
@@ -94,8 +94,8 @@ test_growth_numerical(void ** state)
         //Growth of CDM should be lower, growth of baryons should be higher.
         assert_true(dlogGrowth(newk,DELTA_CDM) < F_Omega(&CP, 0.01) * DeltaSpec(newk, DELTA_CDM));
         assert_true(fabs(dlogGrowth(newk,DELTA_CDM) / DeltaSpec(newk, DELTA_CDM) - 0.9389) < 0.01);
-        assert_true(dlogGrowth(newk,DELTA_BAR) > 1.318 * DeltaSpec(newk, DELTA_BAR));
-        assert_true(dlogGrowth(newk,DELTA_BAR) < 1.35 * DeltaSpec(newk, DELTA_BAR));
+        assert_true(dlogGrowth(newk,DELTA_BAR) > 1.25 * DeltaSpec(newk, DELTA_BAR));
+        assert_true(dlogGrowth(newk,DELTA_BAR) < 1.3 * DeltaSpec(newk, DELTA_BAR));
     }
     //Test super-horizon scales
     lowk = 1e-3;


### PR DESCRIPTION
This means that MP-GenIC produces an initial baryon velocity similar to the CDM velocity, when it should be much smaller!

Reported-by: Matt McQuinn <mcquinn@uw.edu>