### PR TITLE
Some IC codes may wish to set different particle masses for different…

### DIFF
--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -317,6 +317,9 @@ petaio_read_snapshot(int num, const char * OutputDir, Cosmology * CP, struct hea
                 keep |= (0 == strcmp(IOTable->ent[i].name, "BlackholeMass"));
                 keep |= (0 == strcmp(IOTable->ent[i].name, "MinPotPos"));
             }
+            /* Some IC codes may set the gas particle mass directly, rather than in the header*/
+            if(ptype == 0 && header->MassTable[ptype] <= 0)
+                keep |= (0 == strcmp(IOTable->ent[i].name, "Mass"));
             if(!keep) continue;
         }
         if(IOTable->ent[i].setter == NULL) {


### PR DESCRIPTION
… gas particles. In this case they shall set the header field to zero. Check for this.