### PR TITLE
Fix the issue that AutoCheckPointTime is never triggered

### DIFF
--- a/libgadget/hci.c
+++ b/libgadget/hci.c
@@ -30,7 +30,7 @@ hci_init(HCIManager * manager, char * prefix, const double WallClockTimeLimit, c
 
     manager->WallClockTimeLimit = WallClockTimeLimit;
     manager->AutoCheckPointTime = AutoCheckPointTime;
-    manager->TimeLastCheckPoint = manager->timer_begin;
+    manager->TimeLastCheckPoint = 0;
     manager->FOFEnabled = FOFEnabled;
     manager->LongestTimeBetweenQueries = 0;
 }


### PR DESCRIPTION
hci.c initialized TimeLastCheckPoint with timer_begin, which is an absolute MPI_Wtime() value (>1e9), but hci_query_auto_checkpoint compare it againthci_get_elapsed_time(), which returns the time since the run started. As a result, AutoCheckPointTime is never triggered.